### PR TITLE
feat: Session 조회 및 출석 API 구현

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,3 @@
-import org.jetbrains.kotlin.builtins.StandardNames.FqNames.target
-
 plugins {
     kotlin("jvm") version "1.9.25"
     kotlin("plugin.spring") version "1.9.25"
@@ -54,6 +52,10 @@ dependencies {
     implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.8")
 
     implementation("io.github.oshai:kotlin-logging-jvm:7.0.7")
+
+    // kotlin-jdsl
+    val jdslVersion = "2.2.1.RELEASE"
+    implementation("com.linecorp.kotlin-jdsl:spring-data-kotlin-jdsl-starter-jakarta:$jdslVersion")
 
     developmentOnly("org.springframework.boot:spring-boot-devtools")
 

--- a/src/main/kotlin/com/server/dpmcore/attendance/application/AttendanceCommandService.kt
+++ b/src/main/kotlin/com/server/dpmcore/attendance/application/AttendanceCommandService.kt
@@ -1,0 +1,46 @@
+package com.server.dpmcore.attendance.application
+
+import com.server.dpmcore.attendance.domain.model.AttendanceStatus
+import com.server.dpmcore.attendance.domain.port.outbound.AttendancePersistencePort
+import com.server.dpmcore.attendance.presentation.dto.request.AttendanceCreateRequest
+import com.server.dpmcore.member.member.domain.model.MemberId
+import com.server.dpmcore.session.application.SessionQueryService
+import com.server.dpmcore.session.domain.exception.CheckedAttendanceException
+import com.server.dpmcore.session.domain.model.SessionId
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.time.Instant
+
+@Service
+@Transactional
+class AttendanceCommandService(
+    private val attendancePersistencePort: AttendancePersistencePort,
+    private val sessionQueryService: SessionQueryService,
+) {
+    fun attendSession(
+        sessionId: SessionId,
+        attendedAt: Instant,
+        request: AttendanceCreateRequest,
+    ): AttendanceStatus {
+        val memberId = MemberId(request.memberId)
+
+        val attendance =
+            attendancePersistencePort
+                .findAttendanceBy(sessionId, memberId)
+                .also {
+                    if (it.isAttended()) {
+                        throw CheckedAttendanceException()
+                    }
+                }
+
+        val status =
+            sessionQueryService
+                .getSessionById(sessionId)
+                .attend(attendedAt, request.attendanceCode)
+
+        attendance.markAttendance(status, attendedAt)
+        attendancePersistencePort.save(attendance)
+
+        return status
+    }
+}

--- a/src/main/kotlin/com/server/dpmcore/attendance/domain/model/Attendance.kt
+++ b/src/main/kotlin/com/server/dpmcore/attendance/domain/model/Attendance.kt
@@ -3,6 +3,7 @@ package com.server.dpmcore.attendance.domain.model
 import com.server.dpmcore.attendance.domain.port.inbound.command.AttendanceCreateCommand
 import com.server.dpmcore.member.member.domain.model.MemberId
 import com.server.dpmcore.session.domain.model.SessionId
+import java.time.Instant
 
 /**
  * 출석(Attendance) 도메인 모델
@@ -13,12 +14,22 @@ class Attendance internal constructor(
     val sessionId: SessionId,
     val memberId: MemberId,
     status: AttendanceStatus,
+    attendedAt: Instant? = null,
 ) {
     var status: AttendanceStatus = status
         private set
 
-    fun updateStatus(newStatus: AttendanceStatus) {
-        this.status = newStatus
+    var attendedAt: Instant? = attendedAt
+        private set
+
+    fun isAttended() = this.status != AttendanceStatus.PENDING
+
+    fun markAttendance(
+        status: AttendanceStatus,
+        attendedAt: Instant,
+    ) {
+        this.status = status
+        this.attendedAt = attendedAt
     }
 
     override fun equals(other: Any?): Boolean {

--- a/src/main/kotlin/com/server/dpmcore/attendance/domain/port/outbound/AttendancePersistencePort.kt
+++ b/src/main/kotlin/com/server/dpmcore/attendance/domain/port/outbound/AttendancePersistencePort.kt
@@ -1,3 +1,14 @@
 package com.server.dpmcore.attendance.domain.port.outbound
 
-interface AttendancePersistencePort
+import com.server.dpmcore.attendance.domain.model.Attendance
+import com.server.dpmcore.member.member.domain.model.MemberId
+import com.server.dpmcore.session.domain.model.SessionId
+
+interface AttendancePersistencePort {
+    fun findAttendanceBy(
+        sessionId: SessionId,
+        memberId: MemberId,
+    ): Attendance
+
+    fun save(attendance: Attendance)
+}

--- a/src/main/kotlin/com/server/dpmcore/attendance/infrastructure/entity/AttendanceEntity.kt
+++ b/src/main/kotlin/com/server/dpmcore/attendance/infrastructure/entity/AttendanceEntity.kt
@@ -11,6 +11,7 @@ import jakarta.persistence.GeneratedValue
 import jakarta.persistence.GenerationType
 import jakarta.persistence.Id
 import jakarta.persistence.Table
+import java.time.Instant
 
 @Entity
 @Table(name = "attendances")
@@ -24,6 +25,8 @@ class AttendanceEntity(
     val memberId: Long,
     @Column(nullable = false)
     val status: String,
+    @Column(nullable = true)
+    val attendedAt: Instant? = null,
 ) {
     fun toDomain(): Attendance =
         Attendance(
@@ -31,6 +34,7 @@ class AttendanceEntity(
             sessionId = SessionId(this.sessionId),
             memberId = MemberId(this.memberId),
             status = AttendanceStatus.valueOf(this.status),
+            attendedAt = this.attendedAt,
         )
 
     companion object {
@@ -40,6 +44,7 @@ class AttendanceEntity(
                 sessionId = domainModel.sessionId.value,
                 memberId = domainModel.memberId.value,
                 status = domainModel.status.name,
+                attendedAt = domainModel.attendedAt,
             )
     }
 }

--- a/src/main/kotlin/com/server/dpmcore/attendance/infrastructure/repository/AttendanceRepository.kt
+++ b/src/main/kotlin/com/server/dpmcore/attendance/infrastructure/repository/AttendanceRepository.kt
@@ -1,9 +1,35 @@
 package com.server.dpmcore.attendance.infrastructure.repository
 
+import com.linecorp.kotlinjdsl.querydsl.expression.col
+import com.linecorp.kotlinjdsl.spring.data.SpringDataQueryFactory
+import com.linecorp.kotlinjdsl.spring.data.singleQuery
+import com.server.dpmcore.attendance.domain.model.Attendance
 import com.server.dpmcore.attendance.domain.port.outbound.AttendancePersistencePort
+import com.server.dpmcore.attendance.infrastructure.entity.AttendanceEntity
+import com.server.dpmcore.member.member.domain.model.MemberId
+import com.server.dpmcore.session.domain.model.SessionId
 import org.springframework.stereotype.Repository
 
 @Repository
 class AttendanceRepository(
     private val attendanceJpaRepository: AttendanceJpaRepository,
-) : AttendancePersistencePort
+    private val queryFactory: SpringDataQueryFactory,
+) : AttendancePersistencePort {
+    override fun findAttendanceBy(
+        sessionId: SessionId,
+        memberId: MemberId,
+    ): Attendance =
+        queryFactory
+            .singleQuery<AttendanceEntity> {
+                select(entity(AttendanceEntity::class))
+                from(entity(AttendanceEntity::class))
+                whereAnd(
+                    col(AttendanceEntity::sessionId).equal(sessionId.value),
+                    col(AttendanceEntity::memberId).equal(memberId.value),
+                )
+            }.toDomain()
+
+    override fun save(attendance: Attendance) {
+        attendanceJpaRepository.save(AttendanceEntity.from(attendance))
+    }
+}

--- a/src/main/kotlin/com/server/dpmcore/attendance/presentation/AttendanceApi.kt
+++ b/src/main/kotlin/com/server/dpmcore/attendance/presentation/AttendanceApi.kt
@@ -1,0 +1,55 @@
+package com.server.dpmcore.attendance.presentation
+
+import com.server.dpmcore.attendance.presentation.dto.request.AttendanceCreateRequest
+import com.server.dpmcore.attendance.presentation.dto.response.AttendanceResponse
+import com.server.dpmcore.common.exception.CustomResponse
+import com.server.dpmcore.session.domain.model.SessionId
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.media.Content
+import io.swagger.v3.oas.annotations.media.ExampleObject
+import io.swagger.v3.oas.annotations.media.Schema
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.responses.ApiResponses
+import io.swagger.v3.oas.annotations.tags.Tag
+
+@Tag(name = "출석(Attendance)")
+interface AttendanceApi {
+    @Operation(
+        summary = "세션 출석",
+        description = "세션에 대한 출석을 합니다. 요청 시 현재 시간을 기준으로 미리 생성된 출석 기록의 상태를 변경합니다",
+    )
+    @ApiResponses(
+        value = [
+            ApiResponse(
+                responseCode = "200",
+                description = "출석 성공",
+                content = [
+                    Content(
+                        mediaType = "application/json",
+                        schema = Schema(implementation = CustomResponse::class),
+                        examples = [
+                            ExampleObject(
+                                name = "출석 성공 응답",
+                                value = """
+                                    {
+                                        "status": "OK",
+                                        "message": "요청에 성공했습니다",
+                                        "code": "G000",
+                                        "data": {
+                                            "attendanceStatus": "PRESENT",
+                                            "attendedAt": "2025-08-02T14:00:00"
+                                        }
+                                    }
+                                """,
+                            ),
+                        ],
+                    ),
+                ],
+            ),
+        ],
+    )
+    fun createAttendance(
+        sessionId: SessionId,
+        request: AttendanceCreateRequest,
+    ): CustomResponse<AttendanceResponse>
+}

--- a/src/main/kotlin/com/server/dpmcore/attendance/presentation/AttendanceController.kt
+++ b/src/main/kotlin/com/server/dpmcore/attendance/presentation/AttendanceController.kt
@@ -15,9 +15,9 @@ import java.time.Instant
 @RestController
 class AttendanceController(
     private val attendanceCommandService: AttendanceCommandService,
-) {
+) : AttendanceApi {
     @PostMapping("/v1/sessions/{sessionId}/attendances")
-    fun createAttendance(
+    override fun createAttendance(
         @PathVariable sessionId: SessionId,
         @RequestBody request: AttendanceCreateRequest,
     ): CustomResponse<AttendanceResponse> {

--- a/src/main/kotlin/com/server/dpmcore/attendance/presentation/AttendanceController.kt
+++ b/src/main/kotlin/com/server/dpmcore/attendance/presentation/AttendanceController.kt
@@ -1,0 +1,29 @@
+package com.server.dpmcore.attendance.presentation
+
+import com.server.dpmcore.attendance.application.AttendanceCommandService
+import com.server.dpmcore.attendance.presentation.dto.request.AttendanceCreateRequest
+import com.server.dpmcore.attendance.presentation.dto.response.AttendanceResponse
+import com.server.dpmcore.attendance.presentation.mapper.AttendanceMapper.toAttendanceResponse
+import com.server.dpmcore.common.exception.CustomResponse
+import com.server.dpmcore.session.domain.model.SessionId
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RestController
+import java.time.Instant
+
+@RestController
+class AttendanceController(
+    private val attendanceCommandService: AttendanceCommandService,
+) {
+    @PostMapping("/v1/sessions/{sessionId}/attendances")
+    fun createAttendance(
+        @PathVariable sessionId: SessionId,
+        @RequestBody request: AttendanceCreateRequest,
+    ): CustomResponse<AttendanceResponse> {
+        val attendedAt = Instant.now()
+        val attendanceStatus = attendanceCommandService.attendSession(sessionId, attendedAt, request)
+
+        return CustomResponse.ok(toAttendanceResponse(attendanceStatus, attendedAt))
+    }
+}

--- a/src/main/kotlin/com/server/dpmcore/attendance/presentation/dto/request/AttendanceCreateRequest.kt
+++ b/src/main/kotlin/com/server/dpmcore/attendance/presentation/dto/request/AttendanceCreateRequest.kt
@@ -1,0 +1,6 @@
+package com.server.dpmcore.attendance.presentation.dto.request
+
+data class AttendanceCreateRequest(
+    val memberId: Long,
+    val attendanceCode: String,
+)

--- a/src/main/kotlin/com/server/dpmcore/attendance/presentation/dto/response/AttendanceResponse.kt
+++ b/src/main/kotlin/com/server/dpmcore/attendance/presentation/dto/response/AttendanceResponse.kt
@@ -1,0 +1,8 @@
+package com.server.dpmcore.attendance.presentation.dto.response
+
+import java.time.LocalDateTime
+
+data class AttendanceResponse(
+    val attendanceStatus: String,
+    val attendedAt: LocalDateTime,
+)

--- a/src/main/kotlin/com/server/dpmcore/attendance/presentation/mapper/AttendanceMapper.kt
+++ b/src/main/kotlin/com/server/dpmcore/attendance/presentation/mapper/AttendanceMapper.kt
@@ -1,0 +1,17 @@
+package com.server.dpmcore.attendance.presentation.mapper
+
+import com.server.dpmcore.attendance.domain.model.AttendanceStatus
+import com.server.dpmcore.attendance.presentation.dto.response.AttendanceResponse
+import com.server.dpmcore.session.presentation.mapper.TimeMapper.instantToLocalDateTime
+import java.time.Instant
+
+object AttendanceMapper {
+    fun toAttendanceResponse(
+        attendanceStatus: AttendanceStatus,
+        attendedAt: Instant,
+    ): AttendanceResponse =
+        AttendanceResponse(
+            attendanceStatus = attendanceStatus.name,
+            attendedAt = instantToLocalDateTime(attendedAt),
+        )
+}

--- a/src/main/kotlin/com/server/dpmcore/common/jdsl/QueryFactoryExtensions.kt
+++ b/src/main/kotlin/com/server/dpmcore/common/jdsl/QueryFactoryExtensions.kt
@@ -1,0 +1,15 @@
+package com.server.dpmcore.common.jdsl
+
+import com.linecorp.kotlinjdsl.spring.data.SpringDataQueryFactory
+import com.linecorp.kotlinjdsl.spring.data.querydsl.SpringDataCriteriaQueryDsl
+import com.linecorp.kotlinjdsl.spring.data.singleQuery
+import jakarta.persistence.NoResultException
+
+inline fun <reified T : Any> SpringDataQueryFactory.singleQueryOrNull(
+    noinline dsl: SpringDataCriteriaQueryDsl<T>.() -> kotlin.Unit,
+): T? =
+    try {
+        this.singleQuery(dsl)
+    } catch (e: NoResultException) {
+        null
+    }

--- a/src/main/kotlin/com/server/dpmcore/common/jdsl/QueryFactoryExtensions.kt
+++ b/src/main/kotlin/com/server/dpmcore/common/jdsl/QueryFactoryExtensions.kt
@@ -6,7 +6,7 @@ import com.linecorp.kotlinjdsl.spring.data.singleQuery
 import jakarta.persistence.NoResultException
 
 inline fun <reified T : Any> SpringDataQueryFactory.singleQueryOrNull(
-    noinline dsl: SpringDataCriteriaQueryDsl<T>.() -> kotlin.Unit,
+    noinline dsl: SpringDataCriteriaQueryDsl<T>.() -> Unit,
 ): T? =
     try {
         this.singleQuery(dsl)

--- a/src/main/kotlin/com/server/dpmcore/session/application/SessionQueryService.kt
+++ b/src/main/kotlin/com/server/dpmcore/session/application/SessionQueryService.kt
@@ -11,7 +11,7 @@ import java.time.Instant
 
 @Service
 @Transactional(readOnly = true)
-class SessionReadService(
+class SessionQueryService(
     private val sessionPersistencePort: SessionPersistencePort,
 ) {
     fun getNextSession(): Session? {

--- a/src/main/kotlin/com/server/dpmcore/session/application/SessionReadService.kt
+++ b/src/main/kotlin/com/server/dpmcore/session/application/SessionReadService.kt
@@ -1,7 +1,9 @@
 package com.server.dpmcore.session.application
 
 import com.server.dpmcore.cohort.domain.model.CohortId
+import com.server.dpmcore.session.domain.exception.SessionNotFoundException
 import com.server.dpmcore.session.domain.model.Session
+import com.server.dpmcore.session.domain.model.SessionId
 import com.server.dpmcore.session.domain.port.outbound.SessionPersistencePort
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -19,4 +21,8 @@ class SessionReadService(
     }
 
     fun getAllSessions(cohortId: CohortId): List<Session> = sessionPersistencePort.findAllSessions(cohortId)
+
+    fun getSessionById(sessionId: SessionId): Session =
+        sessionPersistencePort.findSessionById(sessionId)
+            ?: throw SessionNotFoundException()
 }

--- a/src/main/kotlin/com/server/dpmcore/session/application/SessionReadService.kt
+++ b/src/main/kotlin/com/server/dpmcore/session/application/SessionReadService.kt
@@ -1,5 +1,6 @@
 package com.server.dpmcore.session.application
 
+import com.server.dpmcore.cohort.domain.model.CohortId
 import com.server.dpmcore.session.domain.model.Session
 import com.server.dpmcore.session.domain.port.outbound.SessionPersistencePort
 import org.springframework.stereotype.Service
@@ -16,4 +17,6 @@ class SessionReadService(
 
         return sessionPersistencePort.findNextSessionBy(currentTime)
     }
+
+    fun getAllSessions(cohortId: CohortId): List<Session> = sessionPersistencePort.findAllSessions(cohortId)
 }

--- a/src/main/kotlin/com/server/dpmcore/session/application/SessionReadService.kt
+++ b/src/main/kotlin/com/server/dpmcore/session/application/SessionReadService.kt
@@ -1,0 +1,19 @@
+package com.server.dpmcore.session.application
+
+import com.server.dpmcore.session.domain.model.Session
+import com.server.dpmcore.session.domain.port.outbound.SessionPersistencePort
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.time.Instant
+
+@Service
+@Transactional(readOnly = true)
+class SessionReadService(
+    private val sessionPersistencePort: SessionPersistencePort,
+) {
+    fun getNextSession(): Session? {
+        val currentTime = Instant.now()
+
+        return sessionPersistencePort.findNextSessionBy(currentTime)
+    }
+}

--- a/src/main/kotlin/com/server/dpmcore/session/application/config/SessionAttendanceProperties.kt
+++ b/src/main/kotlin/com/server/dpmcore/session/application/config/SessionAttendanceProperties.kt
@@ -1,0 +1,10 @@
+package com.server.dpmcore.session.application.config
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+@ConfigurationProperties(prefix = "session.attendance")
+class SessionAttendanceProperties {
+    var startHour: Long = 14
+}

--- a/src/main/kotlin/com/server/dpmcore/session/domain/exception/CheckedAttendanceException.kt
+++ b/src/main/kotlin/com/server/dpmcore/session/domain/exception/CheckedAttendanceException.kt
@@ -1,0 +1,8 @@
+package com.server.dpmcore.session.domain.exception
+
+import com.server.dpmcore.common.exception.BusinessException
+import com.server.dpmcore.common.exception.ExceptionCode
+
+class CheckedAttendanceException(
+    code: ExceptionCode = SessionExceptionCode.ALREADY_CHECKED_ATTENDANCE,
+) : BusinessException(code)

--- a/src/main/kotlin/com/server/dpmcore/session/domain/exception/InvalidAttendanceCodeException.kt
+++ b/src/main/kotlin/com/server/dpmcore/session/domain/exception/InvalidAttendanceCodeException.kt
@@ -1,0 +1,8 @@
+package com.server.dpmcore.session.domain.exception
+
+import com.server.dpmcore.common.exception.BusinessException
+import com.server.dpmcore.common.exception.ExceptionCode
+
+class InvalidAttendanceCodeException(
+    code: ExceptionCode = SessionExceptionCode.INVALID_ATTENDANCE_CODE,
+) : BusinessException(code)

--- a/src/main/kotlin/com/server/dpmcore/session/domain/exception/SessionExceptionCode.kt
+++ b/src/main/kotlin/com/server/dpmcore/session/domain/exception/SessionExceptionCode.kt
@@ -1,0 +1,21 @@
+package com.server.dpmcore.session.domain.exception
+
+import com.server.dpmcore.common.exception.ExceptionCode
+import org.springframework.http.HttpStatus
+
+enum class SessionExceptionCode(
+    @JvmField val status: HttpStatus,
+    @JvmField val code: String,
+    @JvmField val message: String,
+) : ExceptionCode {
+    SESSION_NOT_FOUND(HttpStatus.NOT_FOUND, "S404", "세션을 찾을 수 없습니다"),
+    SESSION_ALREADY_EXISTS(HttpStatus.CONFLICT, "S409", "이미 존재하는 세션입니다"),
+    INVALID_SESSION_STATE(HttpStatus.BAD_REQUEST, "S400", "유효하지 않은 세션 상태입니다"),
+    ;
+
+    override fun getStatus(): HttpStatus = status
+
+    override fun getCode(): String = code
+
+    override fun getMessage(): String = message
+}

--- a/src/main/kotlin/com/server/dpmcore/session/domain/exception/SessionExceptionCode.kt
+++ b/src/main/kotlin/com/server/dpmcore/session/domain/exception/SessionExceptionCode.kt
@@ -11,6 +11,9 @@ enum class SessionExceptionCode(
     SESSION_NOT_FOUND(HttpStatus.NOT_FOUND, "S404", "세션을 찾을 수 없습니다"),
     SESSION_ALREADY_EXISTS(HttpStatus.CONFLICT, "S409", "이미 존재하는 세션입니다"),
     INVALID_SESSION_STATE(HttpStatus.BAD_REQUEST, "S400", "유효하지 않은 세션 상태입니다"),
+    INVALID_ATTENDANCE_CODE(HttpStatus.BAD_REQUEST, "S400", "출석코드가 일치하지 않습니다"),
+    TOO_EARLY_ATTENDANCE(HttpStatus.BAD_REQUEST, "S400", "출석하기에는 너무 이른 시간입니다"),
+    ALREADY_CHECKED_ATTENDANCE(HttpStatus.BAD_REQUEST, "S400", "이미 출석을 체크했습니다"),
     ;
 
     override fun getStatus(): HttpStatus = status

--- a/src/main/kotlin/com/server/dpmcore/session/domain/exception/SessionNotFoundException.kt
+++ b/src/main/kotlin/com/server/dpmcore/session/domain/exception/SessionNotFoundException.kt
@@ -1,0 +1,14 @@
+package com.server.dpmcore.session.domain.exception
+
+import com.server.dpmcore.common.exception.BusinessException
+import com.server.dpmcore.common.exception.ExceptionCode
+
+class SessionNotFoundException(
+    code: ExceptionCode,
+) : BusinessException(code) {
+    constructor() : this(SessionExceptionCode.SESSION_NOT_FOUND)
+
+    companion object {
+        val SESSION_NOT_FOUND = SessionExceptionCode.SESSION_NOT_FOUND
+    }
+}

--- a/src/main/kotlin/com/server/dpmcore/session/domain/exception/TooEarlyAttendanceException.kt
+++ b/src/main/kotlin/com/server/dpmcore/session/domain/exception/TooEarlyAttendanceException.kt
@@ -1,0 +1,8 @@
+package com.server.dpmcore.session.domain.exception
+
+import com.server.dpmcore.common.exception.BusinessException
+import com.server.dpmcore.common.exception.ExceptionCode
+
+class TooEarlyAttendanceException(
+    code: ExceptionCode = SessionExceptionCode.TOO_EARLY_ATTENDANCE,
+) : BusinessException(code)

--- a/src/main/kotlin/com/server/dpmcore/session/domain/model/AttendancePolicy.kt
+++ b/src/main/kotlin/com/server/dpmcore/session/domain/model/AttendancePolicy.kt
@@ -4,9 +4,6 @@ import java.time.Instant
 
 class AttendancePolicy(
     val attendanceStart: Instant,
-    val attendanceEnd: Instant,
-    val latenessStart: Instant,
-    val latenessEnd: Instant,
     val attendanceCode: String,
 ) {
     override fun equals(other: Any?): Boolean {
@@ -14,17 +11,11 @@ class AttendancePolicy(
         if (other !is AttendancePolicy) return false
 
         return attendanceStart == other.attendanceStart &&
-            attendanceEnd == other.attendanceEnd &&
-            latenessStart == other.latenessStart &&
-            latenessEnd == other.latenessEnd &&
             attendanceCode == other.attendanceCode
     }
 
     override fun hashCode(): Int {
         var result = attendanceStart.hashCode()
-        result = 31 * result + attendanceEnd.hashCode()
-        result = 31 * result + latenessStart.hashCode()
-        result = 31 * result + latenessEnd.hashCode()
         result = 31 * result + attendanceCode.hashCode()
         return result
     }
@@ -32,9 +23,6 @@ class AttendancePolicy(
     override fun toString(): String =
         "AttendancePolicy(" +
             "attendanceStart=$attendanceStart, " +
-            "attendanceEnd=$attendanceEnd, " +
-            "latenessStart=$latenessStart, " +
-            "latenessEnd=$latenessEnd, " +
             "attendanceCode='$attendanceCode" +
             "')"
 }

--- a/src/main/kotlin/com/server/dpmcore/session/domain/model/Session.kt
+++ b/src/main/kotlin/com/server/dpmcore/session/domain/model/Session.kt
@@ -58,9 +58,6 @@ class Session internal constructor(
                 attendancePolicy =
                     AttendancePolicy(
                         attendanceStart = command.date.plus(14, ChronoUnit.HOURS),
-                        attendanceEnd = command.date.plus(14, ChronoUnit.HOURS).plus(15, ChronoUnit.MINUTES),
-                        latenessStart = command.date.plus(14, ChronoUnit.HOURS).plus(15, ChronoUnit.MINUTES),
-                        latenessEnd = command.date.plus(14, ChronoUnit.HOURS).plus(30, ChronoUnit.MINUTES),
                         attendanceCode = generateAttendanceCode(),
                     ),
             )

--- a/src/main/kotlin/com/server/dpmcore/session/domain/model/Session.kt
+++ b/src/main/kotlin/com/server/dpmcore/session/domain/model/Session.kt
@@ -57,7 +57,7 @@ class Session internal constructor(
                 isOnline = command.isOnline ?: true,
                 attendancePolicy =
                     AttendancePolicy(
-                        attendanceStart = command.date.plus(14, ChronoUnit.HOURS),
+                        attendanceStart = command.date.plus(command.startHour, ChronoUnit.HOURS),
                         attendanceCode = generateAttendanceCode(),
                     ),
             )

--- a/src/main/kotlin/com/server/dpmcore/session/domain/model/Session.kt
+++ b/src/main/kotlin/com/server/dpmcore/session/domain/model/Session.kt
@@ -18,13 +18,13 @@ class Session internal constructor(
     val week: Int,
     val attendancePolicy: AttendancePolicy,
     private val attachments: MutableList<SessionAttachment> = mutableListOf(),
-    place: String?,
-    eventName: String?,
+    place: String,
+    eventName: String,
     isOnline: Boolean = false,
 ) {
-    var place: String? = place
+    var place: String = place
         private set
-    var eventName: String? = eventName
+    var eventName: String = eventName
         private set
     var isOnline: Boolean = isOnline
         private set

--- a/src/main/kotlin/com/server/dpmcore/session/domain/model/Session.kt
+++ b/src/main/kotlin/com/server/dpmcore/session/domain/model/Session.kt
@@ -1,6 +1,9 @@
 package com.server.dpmcore.session.domain.model
 
+import com.server.dpmcore.attendance.domain.model.AttendanceStatus
 import com.server.dpmcore.cohort.domain.model.CohortId
+import com.server.dpmcore.session.domain.exception.InvalidAttendanceCodeException
+import com.server.dpmcore.session.domain.exception.TooEarlyAttendanceException
 import com.server.dpmcore.session.domain.port.inbound.command.SessionCreateCommand
 import java.time.Instant
 import java.time.temporal.ChronoUnit
@@ -30,6 +33,25 @@ class Session internal constructor(
         private set
 
     fun getAttachments(): List<SessionAttachment> = attachments.toList()
+
+    fun attend(
+        attendedAt: Instant,
+        inputCode: String,
+    ): AttendanceStatus {
+        if (inputCode != attendancePolicy.attendanceCode) {
+            throw InvalidAttendanceCodeException()
+        }
+
+        return determineAttendanceStatus(attendedAt)
+    }
+
+    private fun determineAttendanceStatus(now: Instant): AttendanceStatus =
+        when {
+            now.isBefore(attendancePolicy.attendanceStart) -> throw TooEarlyAttendanceException()
+            now.isBefore(attendancePolicy.attendanceStart.plus(5, ChronoUnit.MINUTES)) -> AttendanceStatus.PRESENT
+            now.isBefore(attendancePolicy.attendanceStart.plus(30, ChronoUnit.MINUTES)) -> AttendanceStatus.LATE
+            else -> AttendanceStatus.ABSENT
+        }
 
     override fun equals(other: Any?): Boolean {
         if (this === other) return true

--- a/src/main/kotlin/com/server/dpmcore/session/domain/port/inbound/command/SessionCreateCommand.kt
+++ b/src/main/kotlin/com/server/dpmcore/session/domain/port/inbound/command/SessionCreateCommand.kt
@@ -6,6 +6,7 @@ data class SessionCreateCommand(
     val cohortId: Long,
     val date: Instant,
     val week: Int,
+    val startHour: Long,
     val place: String?,
     val eventName: String?,
     val isOnline: Boolean?,

--- a/src/main/kotlin/com/server/dpmcore/session/domain/port/outbound/SessionPersistencePort.kt
+++ b/src/main/kotlin/com/server/dpmcore/session/domain/port/outbound/SessionPersistencePort.kt
@@ -2,10 +2,13 @@ package com.server.dpmcore.session.domain.port.outbound
 
 import com.server.dpmcore.cohort.domain.model.CohortId
 import com.server.dpmcore.session.domain.model.Session
+import com.server.dpmcore.session.domain.model.SessionId
 import java.time.Instant
 
 interface SessionPersistencePort {
     fun findNextSessionBy(currentTime: Instant): Session?
 
     fun findAllSessions(cohortId: CohortId): List<Session>
+
+    fun findSessionById(sessionId: SessionId): Session?
 }

--- a/src/main/kotlin/com/server/dpmcore/session/domain/port/outbound/SessionPersistencePort.kt
+++ b/src/main/kotlin/com/server/dpmcore/session/domain/port/outbound/SessionPersistencePort.kt
@@ -1,8 +1,11 @@
 package com.server.dpmcore.session.domain.port.outbound
 
+import com.server.dpmcore.cohort.domain.model.CohortId
 import com.server.dpmcore.session.domain.model.Session
 import java.time.Instant
 
 interface SessionPersistencePort {
     fun findNextSessionBy(currentTime: Instant): Session?
+
+    fun findAllSessions(cohortId: CohortId): List<Session>
 }

--- a/src/main/kotlin/com/server/dpmcore/session/domain/port/outbound/SessionPersistencePort.kt
+++ b/src/main/kotlin/com/server/dpmcore/session/domain/port/outbound/SessionPersistencePort.kt
@@ -1,3 +1,8 @@
 package com.server.dpmcore.session.domain.port.outbound
 
-interface SessionPersistencePort
+import com.server.dpmcore.session.domain.model.Session
+import java.time.Instant
+
+interface SessionPersistencePort {
+    fun findNextSessionBy(currentTime: Instant): Session?
+}

--- a/src/main/kotlin/com/server/dpmcore/session/infrastructure/entity/EmbeddedAttendancePolicy.kt
+++ b/src/main/kotlin/com/server/dpmcore/session/infrastructure/entity/EmbeddedAttendancePolicy.kt
@@ -10,20 +10,11 @@ class EmbeddedAttendancePolicy(
     @Column(nullable = false)
     val attendanceStart: Instant,
     @Column(nullable = false)
-    val attendanceEnd: Instant,
-    @Column(nullable = false)
-    val latenessStart: Instant,
-    @Column(nullable = false)
-    val latenessEnd: Instant,
-    @Column(nullable = false)
     val attendanceCode: String,
 ) {
     fun toDomain(): AttendancePolicy =
         AttendancePolicy(
             attendanceStart = this.attendanceStart,
-            attendanceEnd = this.attendanceEnd,
-            latenessStart = this.latenessStart,
-            latenessEnd = this.latenessEnd,
             attendanceCode = this.attendanceCode,
         )
 
@@ -31,9 +22,6 @@ class EmbeddedAttendancePolicy(
         fun from(domainModel: AttendancePolicy): EmbeddedAttendancePolicy =
             EmbeddedAttendancePolicy(
                 attendanceStart = domainModel.attendanceStart,
-                attendanceEnd = domainModel.attendanceEnd,
-                latenessStart = domainModel.latenessStart,
-                latenessEnd = domainModel.latenessEnd,
                 attendanceCode = domainModel.attendanceCode,
             )
     }

--- a/src/main/kotlin/com/server/dpmcore/session/infrastructure/entity/SessionEntity.kt
+++ b/src/main/kotlin/com/server/dpmcore/session/infrastructure/entity/SessionEntity.kt
@@ -32,8 +32,8 @@ class SessionEntity(
     val attendancePolicy: EmbeddedAttendancePolicy,
     @Column(nullable = false)
     val isOnline: Boolean,
-    val place: String?,
-    val eventName: String?,
+    val place: String,
+    val eventName: String,
     @OneToMany(mappedBy = "session", fetch = FetchType.LAZY, cascade = [CascadeType.ALL], orphanRemoval = true)
     val attachments: MutableList<SessionAttachmentEntity> = mutableListOf(),
 ) {

--- a/src/main/kotlin/com/server/dpmcore/session/infrastructure/repository/SessionRepository.kt
+++ b/src/main/kotlin/com/server/dpmcore/session/infrastructure/repository/SessionRepository.kt
@@ -2,6 +2,8 @@ package com.server.dpmcore.session.infrastructure.repository
 
 import com.linecorp.kotlinjdsl.querydsl.expression.col
 import com.linecorp.kotlinjdsl.spring.data.SpringDataQueryFactory
+import com.linecorp.kotlinjdsl.spring.data.listQuery
+import com.server.dpmcore.cohort.domain.model.CohortId
 import com.server.dpmcore.common.jdsl.singleQueryOrNull
 import com.server.dpmcore.session.domain.model.Session
 import com.server.dpmcore.session.domain.port.outbound.SessionPersistencePort
@@ -24,4 +26,13 @@ class SessionRepository(
                 )
                 orderBy(col(SessionEntity::date).asc())
             }?.toDomain()
+
+    override fun findAllSessions(cohortId: CohortId): List<Session> =
+        queryFactory
+            .listQuery<SessionEntity> {
+                select(entity(SessionEntity::class))
+                from(entity(SessionEntity::class))
+                where(col(SessionEntity::cohortId).equal(cohortId.value))
+                orderBy(col(SessionEntity::id).asc())
+            }.map { it.toDomain() }
 }

--- a/src/main/kotlin/com/server/dpmcore/session/infrastructure/repository/SessionRepository.kt
+++ b/src/main/kotlin/com/server/dpmcore/session/infrastructure/repository/SessionRepository.kt
@@ -1,9 +1,27 @@
 package com.server.dpmcore.session.infrastructure.repository
 
+import com.linecorp.kotlinjdsl.querydsl.expression.col
+import com.linecorp.kotlinjdsl.spring.data.SpringDataQueryFactory
+import com.server.dpmcore.common.jdsl.singleQueryOrNull
+import com.server.dpmcore.session.domain.model.Session
 import com.server.dpmcore.session.domain.port.outbound.SessionPersistencePort
+import com.server.dpmcore.session.infrastructure.entity.SessionEntity
 import org.springframework.stereotype.Repository
+import java.time.Instant
 
 @Repository
 class SessionRepository(
     private val sessionJpaRepository: SessionJpaRepository,
-) : SessionPersistencePort
+    private val queryFactory: SpringDataQueryFactory,
+) : SessionPersistencePort {
+    override fun findNextSessionBy(currentTime: Instant): Session? =
+        queryFactory
+            .singleQueryOrNull<SessionEntity> {
+                select(entity(SessionEntity::class))
+                from(entity(SessionEntity::class))
+                where(
+                    col(SessionEntity::date).greaterThan(currentTime),
+                )
+                orderBy(col(SessionEntity::date).asc())
+            }?.toDomain()
+}

--- a/src/main/kotlin/com/server/dpmcore/session/infrastructure/repository/SessionRepository.kt
+++ b/src/main/kotlin/com/server/dpmcore/session/infrastructure/repository/SessionRepository.kt
@@ -6,6 +6,7 @@ import com.linecorp.kotlinjdsl.spring.data.listQuery
 import com.server.dpmcore.cohort.domain.model.CohortId
 import com.server.dpmcore.common.jdsl.singleQueryOrNull
 import com.server.dpmcore.session.domain.model.Session
+import com.server.dpmcore.session.domain.model.SessionId
 import com.server.dpmcore.session.domain.port.outbound.SessionPersistencePort
 import com.server.dpmcore.session.infrastructure.entity.SessionEntity
 import org.springframework.stereotype.Repository
@@ -35,4 +36,12 @@ class SessionRepository(
                 where(col(SessionEntity::cohortId).equal(cohortId.value))
                 orderBy(col(SessionEntity::id).asc())
             }.map { it.toDomain() }
+
+    override fun findSessionById(sessionId: SessionId): Session? =
+        queryFactory
+            .singleQueryOrNull<SessionEntity> {
+                select(entity(SessionEntity::class))
+                from(entity(SessionEntity::class))
+                where(col(SessionEntity::id).equal(sessionId.value))
+            }?.toDomain()
 }

--- a/src/main/kotlin/com/server/dpmcore/session/presentation/controller/SessionApi.kt
+++ b/src/main/kotlin/com/server/dpmcore/session/presentation/controller/SessionApi.kt
@@ -13,7 +13,6 @@ import io.swagger.v3.oas.annotations.media.Schema
 import io.swagger.v3.oas.annotations.responses.ApiResponse
 import io.swagger.v3.oas.annotations.responses.ApiResponses
 import io.swagger.v3.oas.annotations.tags.Tag
-import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RequestParam
 
 @Tag(name = "세션(Session)")
@@ -147,7 +146,5 @@ interface SessionApi {
             ),
         ],
     )
-    fun getSessionById(
-        @PathVariable(name = "sessionId") sessionId: SessionId,
-    ): CustomResponse<SessionDetailResponse>
+    fun getSessionById(sessionId: SessionId): CustomResponse<SessionDetailResponse>
 }

--- a/src/main/kotlin/com/server/dpmcore/session/presentation/controller/SessionApi.kt
+++ b/src/main/kotlin/com/server/dpmcore/session/presentation/controller/SessionApi.kt
@@ -1,0 +1,153 @@
+package com.server.dpmcore.session.presentation.controller
+
+import com.server.dpmcore.cohort.domain.model.CohortId
+import com.server.dpmcore.common.exception.CustomResponse
+import com.server.dpmcore.session.domain.model.SessionId
+import com.server.dpmcore.session.presentation.dto.response.NextSessionResponse
+import com.server.dpmcore.session.presentation.dto.response.SessionDetailResponse
+import com.server.dpmcore.session.presentation.dto.response.SessionListResponse
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.media.Content
+import io.swagger.v3.oas.annotations.media.ExampleObject
+import io.swagger.v3.oas.annotations.media.Schema
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.responses.ApiResponses
+import io.swagger.v3.oas.annotations.tags.Tag
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestParam
+
+@Tag(name = "세션(Session)")
+interface SessionApi {
+    @Operation(
+        summary = "다음 세션 조회",
+        description = "현재 시간 이후의 가장 가까운 세션을 조회합니다. 만약 현재 시간이 세션이 없는 경우, data를 반환하지 않습니다.",
+    )
+    @ApiResponses(
+        value = [
+            ApiResponse(
+                responseCode = "200",
+                description = "다음 세션 조회 성공",
+                content = [
+                    Content(
+                        mediaType = "application/json",
+                        schema = Schema(implementation = CustomResponse::class),
+                        examples = [
+                            ExampleObject(
+                                name = "다음 세션 조회 성공 응답",
+                                value = """
+                                    {
+                                        "status": "OK",
+                                        "message": "요청에 성공했습니다",
+                                        "code": "G000",
+                                        "data": {
+                                            "sessionId": "1",
+                                            "week": 1,
+                                            "eventName": "디프만 17기 OT",
+                                            "place": "공덕 프론트원",
+                                            "isOnline": false,
+                                            "date": "2025-08-02T14:00:00"
+                                        }
+                                    }
+                                """,
+                            ),
+                        ],
+                    ),
+                ],
+            ),
+        ],
+    )
+    fun getNextSession(): CustomResponse<NextSessionResponse>
+
+    @Operation(
+        summary = "기수 모든 세션 조회",
+        description = "기수에 속한 모든 세션을 조회합니다.",
+    )
+    @ApiResponses(
+        value = [
+            ApiResponse(
+                responseCode = "200",
+                description = "세션 목록 조회 성공",
+                content = [
+                    Content(
+                        mediaType = "application/json",
+                        schema = Schema(implementation = CustomResponse::class),
+                        examples = [
+                            ExampleObject(
+                                name = "세션 목록 조회 성공 응답",
+                                value = """
+                                    {
+                                        "status": "OK",
+                                        "message": "요청에 성공했습니다",
+                                        "code": "G000",
+                                        "data": {
+                                            "sessions": [
+                                                {
+                                                    "id": 1,
+                                                    "week": 1,
+                                                    "eventName": "디프만 17기 OT",
+                                                    "date": "2025-08-02T14:00:00"
+                                                },
+                                                {
+                                                    "id": 2,
+                                                    "week": 2,
+                                                    "eventName": "미니 디프콘",
+                                                    "date": "2025-08-09T14:00:00"
+                                                }
+                                            ]
+                                        }
+                                    }
+                                """,
+                            ),
+                        ],
+                    ),
+                ],
+            ),
+        ],
+    )
+    fun getAllSessions(
+        @RequestParam(name = "cohortId") cohortId: CohortId,
+    ): CustomResponse<SessionListResponse>
+
+    @Operation(
+        summary = "세션 상세 조회",
+        description = "세션 ID를 통해 세션의 상세 정보를 조회합니다.",
+    )
+    @ApiResponses(
+        value = [
+            ApiResponse(
+                responseCode = "200",
+                description = "세션 상세 조회 성공",
+                content = [
+                    Content(
+                        mediaType = "application/json",
+                        schema = Schema(implementation = CustomResponse::class),
+                        examples = [
+                            ExampleObject(
+                                name = "세션 상세 조회 성공 응답",
+                                value = """
+                                    {
+                                        "status": "OK",
+                                        "message": "요청에 성공했습니다",
+                                        "code": "G000",
+                                        "data": {
+                                            "sessionId": 1,
+                                            "week": 1,
+                                            "eventName": "디프만 17기 OT",
+                                            "place": "공덕 프론트원",
+                                            "isOnline": false,
+                                            "date": "2025-08-02T14:00:00",
+                                            "attendanceStartTime": "2025-08-02T14:00:00"
+                                        }
+                                    }
+                                """,
+                            ),
+                        ],
+                    ),
+                ],
+            ),
+        ],
+    )
+    fun getSessionById(
+        @PathVariable(name = "sessionId") sessionId: SessionId,
+    ): CustomResponse<SessionDetailResponse>
+}

--- a/src/main/kotlin/com/server/dpmcore/session/presentation/controller/SessionController.kt
+++ b/src/main/kotlin/com/server/dpmcore/session/presentation/controller/SessionController.kt
@@ -1,11 +1,14 @@
 package com.server.dpmcore.session.presentation.controller
 
+import com.server.dpmcore.cohort.domain.model.CohortId
 import com.server.dpmcore.common.exception.CustomResponse
 import com.server.dpmcore.session.application.SessionReadService
 import com.server.dpmcore.session.presentation.dto.response.NextSessionResponse
+import com.server.dpmcore.session.presentation.dto.response.SessionListResponse
 import com.server.dpmcore.session.presentation.mapper.SessionMapper
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
 
 @RestController
@@ -18,5 +21,14 @@ class SessionController(
         val nextSession = sessionReadService.getNextSession()
 
         return CustomResponse.ok(nextSession?.let { SessionMapper.toNextSessionResponse(it) })
+    }
+
+    @GetMapping
+    fun getAllSessions(
+        @RequestParam(name = "cohortId") cohortId: CohortId,
+    ): CustomResponse<SessionListResponse> {
+        val sessions = sessionReadService.getAllSessions(cohortId)
+
+        return CustomResponse.ok(SessionMapper.toSessionListResponse(sessions))
     }
 }

--- a/src/main/kotlin/com/server/dpmcore/session/presentation/controller/SessionController.kt
+++ b/src/main/kotlin/com/server/dpmcore/session/presentation/controller/SessionController.kt
@@ -18,16 +18,16 @@ import org.springframework.web.bind.annotation.RestController
 @RequestMapping("/v1/sessions")
 class SessionController(
     private val sessionReadService: SessionReadService,
-) {
+) : SessionApi {
     @GetMapping("/next")
-    fun getNextSession(): CustomResponse<NextSessionResponse> {
+    override fun getNextSession(): CustomResponse<NextSessionResponse> {
         val nextSession = sessionReadService.getNextSession()
 
         return CustomResponse.ok(nextSession?.let { SessionMapper.toNextSessionResponse(it) })
     }
 
     @GetMapping
-    fun getAllSessions(
+    override fun getAllSessions(
         @RequestParam(name = "cohortId") cohortId: CohortId,
     ): CustomResponse<SessionListResponse> {
         val sessions = sessionReadService.getAllSessions(cohortId)
@@ -36,7 +36,7 @@ class SessionController(
     }
 
     @GetMapping("/{sessionId}")
-    fun getSessionById(
+    override fun getSessionById(
         @PathVariable(name = "sessionId") sessionId: SessionId,
     ): CustomResponse<SessionDetailResponse> {
         val session = sessionReadService.getSessionById(sessionId)

--- a/src/main/kotlin/com/server/dpmcore/session/presentation/controller/SessionController.kt
+++ b/src/main/kotlin/com/server/dpmcore/session/presentation/controller/SessionController.kt
@@ -3,10 +3,13 @@ package com.server.dpmcore.session.presentation.controller
 import com.server.dpmcore.cohort.domain.model.CohortId
 import com.server.dpmcore.common.exception.CustomResponse
 import com.server.dpmcore.session.application.SessionReadService
+import com.server.dpmcore.session.domain.model.SessionId
 import com.server.dpmcore.session.presentation.dto.response.NextSessionResponse
+import com.server.dpmcore.session.presentation.dto.response.SessionDetailResponse
 import com.server.dpmcore.session.presentation.dto.response.SessionListResponse
 import com.server.dpmcore.session.presentation.mapper.SessionMapper
 import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
@@ -30,5 +33,14 @@ class SessionController(
         val sessions = sessionReadService.getAllSessions(cohortId)
 
         return CustomResponse.ok(SessionMapper.toSessionListResponse(sessions))
+    }
+
+    @GetMapping("/{sessionId}")
+    fun getSessionById(
+        @PathVariable(name = "sessionId") sessionId: SessionId,
+    ): CustomResponse<SessionDetailResponse> {
+        val session = sessionReadService.getSessionById(sessionId)
+
+        return CustomResponse.ok(session.let { SessionMapper.toSessionDetailResponse(it) })
     }
 }

--- a/src/main/kotlin/com/server/dpmcore/session/presentation/controller/SessionController.kt
+++ b/src/main/kotlin/com/server/dpmcore/session/presentation/controller/SessionController.kt
@@ -1,0 +1,22 @@
+package com.server.dpmcore.session.presentation.controller
+
+import com.server.dpmcore.common.exception.CustomResponse
+import com.server.dpmcore.session.application.SessionReadService
+import com.server.dpmcore.session.presentation.dto.response.NextSessionResponse
+import com.server.dpmcore.session.presentation.mapper.SessionMapper
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/v1/sessions")
+class SessionController(
+    private val sessionReadService: SessionReadService,
+) {
+    @GetMapping("/next")
+    fun getNextSession(): CustomResponse<NextSessionResponse> {
+        val nextSession = sessionReadService.getNextSession()
+
+        return CustomResponse.ok(nextSession?.let { SessionMapper.toNextSessionResponse(it) })
+    }
+}

--- a/src/main/kotlin/com/server/dpmcore/session/presentation/controller/SessionController.kt
+++ b/src/main/kotlin/com/server/dpmcore/session/presentation/controller/SessionController.kt
@@ -2,7 +2,7 @@ package com.server.dpmcore.session.presentation.controller
 
 import com.server.dpmcore.cohort.domain.model.CohortId
 import com.server.dpmcore.common.exception.CustomResponse
-import com.server.dpmcore.session.application.SessionReadService
+import com.server.dpmcore.session.application.SessionQueryService
 import com.server.dpmcore.session.domain.model.SessionId
 import com.server.dpmcore.session.presentation.dto.response.NextSessionResponse
 import com.server.dpmcore.session.presentation.dto.response.SessionDetailResponse
@@ -17,11 +17,11 @@ import org.springframework.web.bind.annotation.RestController
 @RestController
 @RequestMapping("/v1/sessions")
 class SessionController(
-    private val sessionReadService: SessionReadService,
+    private val sessionQueryService: SessionQueryService,
 ) : SessionApi {
     @GetMapping("/next")
     override fun getNextSession(): CustomResponse<NextSessionResponse> {
-        val nextSession = sessionReadService.getNextSession()
+        val nextSession = sessionQueryService.getNextSession()
 
         return CustomResponse.ok(nextSession?.let { SessionMapper.toNextSessionResponse(it) })
     }
@@ -30,7 +30,7 @@ class SessionController(
     override fun getAllSessions(
         @RequestParam(name = "cohortId") cohortId: CohortId,
     ): CustomResponse<SessionListResponse> {
-        val sessions = sessionReadService.getAllSessions(cohortId)
+        val sessions = sessionQueryService.getAllSessions(cohortId)
 
         return CustomResponse.ok(SessionMapper.toSessionListResponse(sessions))
     }
@@ -39,7 +39,7 @@ class SessionController(
     override fun getSessionById(
         @PathVariable(name = "sessionId") sessionId: SessionId,
     ): CustomResponse<SessionDetailResponse> {
-        val session = sessionReadService.getSessionById(sessionId)
+        val session = sessionQueryService.getSessionById(sessionId)
 
         return CustomResponse.ok(session.let { SessionMapper.toSessionDetailResponse(it) })
     }

--- a/src/main/kotlin/com/server/dpmcore/session/presentation/dto/response/NextSessionResponse.kt
+++ b/src/main/kotlin/com/server/dpmcore/session/presentation/dto/response/NextSessionResponse.kt
@@ -1,0 +1,12 @@
+package com.server.dpmcore.session.presentation.dto.response
+
+import java.time.LocalDateTime
+
+data class NextSessionResponse(
+    val sessionId: Long,
+    val week: Int,
+    val eventName: String,
+    val place: String,
+    val isOnline: Boolean,
+    val date: LocalDateTime,
+)

--- a/src/main/kotlin/com/server/dpmcore/session/presentation/dto/response/SessionDetailResponse.kt
+++ b/src/main/kotlin/com/server/dpmcore/session/presentation/dto/response/SessionDetailResponse.kt
@@ -1,0 +1,13 @@
+package com.server.dpmcore.session.presentation.dto.response
+
+import java.time.LocalDateTime
+
+data class SessionDetailResponse(
+    val sessionId: Long,
+    val week: Int,
+    val eventName: String,
+    val place: String,
+    val isOnline: Boolean,
+    val date: LocalDateTime,
+    val attendanceStartTime: LocalDateTime,
+)

--- a/src/main/kotlin/com/server/dpmcore/session/presentation/dto/response/SessionListDetailResponse.kt
+++ b/src/main/kotlin/com/server/dpmcore/session/presentation/dto/response/SessionListDetailResponse.kt
@@ -1,0 +1,10 @@
+package com.server.dpmcore.session.presentation.dto.response
+
+import java.time.LocalDateTime
+
+data class SessionListDetailResponse(
+    val id: Long,
+    val week: Int,
+    val eventName: String,
+    val date: LocalDateTime,
+)

--- a/src/main/kotlin/com/server/dpmcore/session/presentation/dto/response/SessionListResponse.kt
+++ b/src/main/kotlin/com/server/dpmcore/session/presentation/dto/response/SessionListResponse.kt
@@ -1,0 +1,5 @@
+package com.server.dpmcore.session.presentation.dto.response
+
+data class SessionListResponse(
+    val sessions: List<SessionListDetailResponse>,
+)

--- a/src/main/kotlin/com/server/dpmcore/session/presentation/mapper/SessionMapper.kt
+++ b/src/main/kotlin/com/server/dpmcore/session/presentation/mapper/SessionMapper.kt
@@ -13,7 +13,7 @@ object SessionMapper {
     fun toNextSessionResponse(session: Session): NextSessionResponse =
         with(session) {
             NextSessionResponse(
-                sessionId = id!!.value,
+                sessionId = id?.value ?: throw IllegalStateException("Session ID cannot be null"),
                 week = week,
                 eventName = eventName,
                 place = place,
@@ -40,7 +40,7 @@ object SessionMapper {
         }
 
     private fun instantToLocalDateTime(instant: Instant): LocalDateTime =
-        LocalDateTime.ofInstant(instant, ZoneId.systemDefault())
+        LocalDateTime.ofInstant(instant, ZoneId.of("Asia/Seoul"))
 
     fun toSessionDetailResponse(session: Session): SessionDetailResponse =
         with(session) {

--- a/src/main/kotlin/com/server/dpmcore/session/presentation/mapper/SessionMapper.kt
+++ b/src/main/kotlin/com/server/dpmcore/session/presentation/mapper/SessionMapper.kt
@@ -2,20 +2,41 @@ package com.server.dpmcore.session.presentation.mapper
 
 import com.server.dpmcore.session.domain.model.Session
 import com.server.dpmcore.session.presentation.dto.response.NextSessionResponse
+import com.server.dpmcore.session.presentation.dto.response.SessionListDetailResponse
+import com.server.dpmcore.session.presentation.dto.response.SessionListResponse
 import java.time.Instant
 import java.time.LocalDateTime
 import java.time.ZoneId
 
 object SessionMapper {
     fun toNextSessionResponse(session: Session): NextSessionResponse =
-        NextSessionResponse(
-            sessionId = session.id!!.value,
-            week = session.week,
-            eventName = session.eventName,
-            place = session.place,
-            isOnline = session.isOnline,
-            date = instantToLocalDateTime(session.date),
-        )
+        with(session) {
+            NextSessionResponse(
+                sessionId = id!!.value,
+                week = week,
+                eventName = eventName,
+                place = place,
+                isOnline = isOnline,
+                date = instantToLocalDateTime(date),
+            )
+        }
+
+    fun toSessionListResponse(sessions: List<Session>): SessionListResponse =
+        sessions.run {
+            if (isEmpty()) return SessionListResponse(sessions = emptyList())
+
+            SessionListResponse(
+                sessions =
+                    map {
+                        SessionListDetailResponse(
+                            id = it.id!!.value,
+                            week = it.week,
+                            eventName = it.eventName,
+                            date = instantToLocalDateTime(it.date),
+                        )
+                    },
+            )
+        }
 
     private fun instantToLocalDateTime(instant: Instant): LocalDateTime =
         LocalDateTime.ofInstant(instant, ZoneId.systemDefault())

--- a/src/main/kotlin/com/server/dpmcore/session/presentation/mapper/SessionMapper.kt
+++ b/src/main/kotlin/com/server/dpmcore/session/presentation/mapper/SessionMapper.kt
@@ -1,0 +1,22 @@
+package com.server.dpmcore.session.presentation.mapper
+
+import com.server.dpmcore.session.domain.model.Session
+import com.server.dpmcore.session.presentation.dto.response.NextSessionResponse
+import java.time.Instant
+import java.time.LocalDateTime
+import java.time.ZoneId
+
+object SessionMapper {
+    fun toNextSessionResponse(session: Session): NextSessionResponse =
+        NextSessionResponse(
+            sessionId = session.id!!.value,
+            week = session.week,
+            eventName = session.eventName,
+            place = session.place,
+            isOnline = session.isOnline,
+            date = instantToLocalDateTime(session.date),
+        )
+
+    private fun instantToLocalDateTime(instant: Instant): LocalDateTime =
+        LocalDateTime.ofInstant(instant, ZoneId.systemDefault())
+}

--- a/src/main/kotlin/com/server/dpmcore/session/presentation/mapper/SessionMapper.kt
+++ b/src/main/kotlin/com/server/dpmcore/session/presentation/mapper/SessionMapper.kt
@@ -2,6 +2,7 @@ package com.server.dpmcore.session.presentation.mapper
 
 import com.server.dpmcore.session.domain.model.Session
 import com.server.dpmcore.session.presentation.dto.response.NextSessionResponse
+import com.server.dpmcore.session.presentation.dto.response.SessionDetailResponse
 import com.server.dpmcore.session.presentation.dto.response.SessionListDetailResponse
 import com.server.dpmcore.session.presentation.dto.response.SessionListResponse
 import java.time.Instant
@@ -40,4 +41,17 @@ object SessionMapper {
 
     private fun instantToLocalDateTime(instant: Instant): LocalDateTime =
         LocalDateTime.ofInstant(instant, ZoneId.systemDefault())
+
+    fun toSessionDetailResponse(session: Session): SessionDetailResponse =
+        with(session) {
+            SessionDetailResponse(
+                sessionId = id!!.value,
+                week = week,
+                eventName = eventName,
+                place = place,
+                isOnline = isOnline,
+                date = instantToLocalDateTime(date),
+                attendanceStartTime = session.attendancePolicy.attendanceStart.let { instantToLocalDateTime(it) },
+            )
+        }
 }

--- a/src/main/kotlin/com/server/dpmcore/session/presentation/mapper/SessionMapper.kt
+++ b/src/main/kotlin/com/server/dpmcore/session/presentation/mapper/SessionMapper.kt
@@ -5,9 +5,7 @@ import com.server.dpmcore.session.presentation.dto.response.NextSessionResponse
 import com.server.dpmcore.session.presentation.dto.response.SessionDetailResponse
 import com.server.dpmcore.session.presentation.dto.response.SessionListDetailResponse
 import com.server.dpmcore.session.presentation.dto.response.SessionListResponse
-import java.time.Instant
-import java.time.LocalDateTime
-import java.time.ZoneId
+import com.server.dpmcore.session.presentation.mapper.TimeMapper.instantToLocalDateTime
 
 object SessionMapper {
     fun toNextSessionResponse(session: Session): NextSessionResponse =
@@ -38,9 +36,6 @@ object SessionMapper {
                     },
             )
         }
-
-    private fun instantToLocalDateTime(instant: Instant): LocalDateTime =
-        LocalDateTime.ofInstant(instant, ZoneId.of("Asia/Seoul"))
 
     fun toSessionDetailResponse(session: Session): SessionDetailResponse =
         with(session) {

--- a/src/main/kotlin/com/server/dpmcore/session/presentation/mapper/TimeMapper.kt
+++ b/src/main/kotlin/com/server/dpmcore/session/presentation/mapper/TimeMapper.kt
@@ -1,0 +1,13 @@
+package com.server.dpmcore.session.presentation.mapper
+
+import java.time.Instant
+import java.time.LocalDateTime
+import java.time.ZoneId
+
+object TimeMapper {
+    fun instantToLocalDateTime(instant: Instant): LocalDateTime =
+        LocalDateTime.ofInstant(instant, ZoneId.of("Asia/Seoul"))
+
+    fun localDateTimeToInstant(localDateTime: LocalDateTime): Instant =
+        localDateTime.atZone(ZoneId.of("Asia/Seoul")).toInstant()
+}

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -8,3 +8,7 @@ spring:
   jpa:
     hibernate:
       ddl-auto: update
+
+session:
+  attendance:
+    start-hour: 14


### PR DESCRIPTION
## Summary

>- #28 

<!-- 해당 PR에 대한 요약을 작성해주세요. -->

## Tasks

- 세션 조회에 관련된 3가지의 API를 구현하였습니다.
1. 금주 세션 정보 조회 API
2. 세션 리스트 조회 API
3. 세션 상세 조회 API

- kotlin-jdsl gradle 의존성 설정을 수행하였습니다.
- kotlin-jdsl singleQuery시에 데이터가 존재하지 않을 경우 Exception이 발생하는데, nullable하게 핸들링하기 위한 확장함수(singleQueryOrNull)를 구현하였습니다.

- 출석 정책이 변경되어 도메인 모델을 수정하였습니다.
1. 출석 시간은 출석 시작 시간 + 5분까지이다.
2. 지각 시간은 출석 시작 시간+5분 ~ 출석 시작 시간+30분까지이다.
3. 그 외에는 결석이다.

## ETC

<!-- 추가적인 정보나 참고 사항을 작성해주세요. -->

**[Session 리스트 조회]**
<img src="https://github.com/user-attachments/assets/4c5b51b3-f689-45ad-8ffe-1a84afb01e1e" width="400" height="300"  alt="Session 리스트 조회" />

**[금주 Session 조회]**
<img src="https://github.com/user-attachments/assets/d5261a4f-148f-4aea-8f69-cfffd2b82f12" width="400" height="300" alt="금주 Session 조회" />

**[Session 상세 조회]**
<img src="https://github.com/user-attachments/assets/4d3d5a96-9449-4fa3-ab75-e39d14e93899" width="400" height="300"  alt="Session 상세 조회" />

**[Session 상세 조회 실패 - 없는 ID일때]**
<img src="https://github.com/user-attachments/assets/0a4a35dc-3cc9-43cb-99e0-af885634e129" width="400" height="300"  alt="Session 상세 조회 실패 - 없는 ID일때" />




## Screenshot

<!-- (없을 경우 삭제) 작업한 내용에 대한 스크린샷을 첨부해주세요._ -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 세션 관련 REST API 엔드포인트(다음 세션 조회, 전체 세션 목록, 세션 상세 조회) 추가
  * 출석 생성 및 출석 상태 반환 API 추가
  * 세션 출석 정책 및 출석 상태 로직 도입
  * 세션 및 출석 관련 상세 응답 DTO 및 매퍼 추가
  * 출석 시각 기록 및 출석 상태 관리 기능 추가
  * 세션 출석 시작 시간 외부 설정값 도입 및 관련 프로퍼티 추가

* **버그 수정**
  * 세션 및 출석 엔티티의 일부 필드(장소, 이벤트명 등)에서 널 허용 제거

* **예외 처리**
  * 세션 및 출석 관련 다양한 예외 및 예외 코드 추가(존재하지 않는 세션, 중복 출석, 잘못된 출석코드, 너무 이른 출석 등)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->