### PR TITLE
refactor: CI/CD 실패 시 알림 채널 Slack에서 Discord로 변경

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,8 +27,8 @@ jobs:
         run: ./gradlew compileKotlin --configuration-cache --build-cache
 
       - name: "Discord로 빌드 실패를 알린다"
-        # if: failure()
-        uses: Ilshidur/action-discord@master
+        if: failure()
+        uses: Ilshidur/action-discord@0.3.2
         env:
           DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,13 +27,13 @@ jobs:
         run: ./gradlew compileKotlin --configuration-cache --build-cache
 
       - name: "Discord로 빌드 실패를 알린다."
-        # if: failure()
+        if: failure()
         uses: Ilshidur/action-discord@0.3.2
         env:
           DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
         with:
           args: |
-            ❌ **CI 도중 문제가 발생했습니다.(테스트)**
+            ❌ **CI 도중 문제가 발생했습니다.**
             actor : `@${{ github.actor }}`
             branch : `${{ github.head_ref }}`
             pull-request : `${{ github.event.pull_request.title }}`

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,26 +21,19 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: '21'
-
-      - name: "Gradle 캐시로 CI 속도를 향상시킨다."
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.gradle/caches
-            ~/.gradle/wrapper
-          key: gradle-${{ runner.os }}-caches-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
-          restore-keys: |
-            gradle-${{ runner.os }}-caches-
+          cache: 'gradle'
 
       - name: "Kotlin 소스를 컴파일한다."
         run: ./gradlew compileKotlin --configuration-cache --build-cache
 
-      - name: "Slack으로 빌드 실패를 알린다."
-        if: failure()
-        uses: 8398a7/action-slack@v3
-        with:
-          status: ${{ job.status }}
-          author_name: 'GitHub Actions'
-          fields: repo,message,commit,author
+      - name: "Discord로 빌드 실패를 알린다"
+        # if: failure()
+        uses: Ilshidur/action-discord@master
         env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }} # 추후 웹훅 추가
+          DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
+        with:
+          args: |
+            ❌ **CI 도중 문제가 발생했습니다.(테스트)**
+            브랜치: `${{ github.head_ref }}`
+            커밋 메시지: `${{ github.event.head_commit.message }}`
+            [🔗 작업 요약 보기](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
       - name: "Kotlin 소스를 컴파일한다."
         run: ./gradlew compileKotlin --configuration-cache --build-cache
 
-      - name: "Discord로 빌드 실패를 알린다"
+      - name: "Discord로 빌드 실패를 알린다."
         if: failure()
         uses: Ilshidur/action-discord@0.3.2
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,8 @@ jobs:
           DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
         with:
           args: |
-            ❌ **CI 도중 문제가 발생했습니다.**
+            ❌ **CI 도중 문제가 발생했습니다.(테스트)**
+            actor : `@${{ github.actor }}`
             branch : `${{ github.head_ref }}`
             pull-request : `${{ github.event.pull_request.title }}`
             [🔗 작업 요약 보기](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
         run: ./gradlew compileKotlin --configuration-cache --build-cache
 
       - name: "Discord로 빌드 실패를 알린다."
-        if: failure()
+        # if: failure()
         uses: Ilshidur/action-discord@0.3.2
         env:
           DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,6 @@ jobs:
         with:
           args: |
             ❌ **CI 도중 문제가 발생했습니다.(테스트)**
-            브랜치: `${{ github.head_ref }}`
-            커밋 메시지: `${{ github.event.head_commit.message }}`
+            branch : `${{ github.head_ref }}`
+            pull-request : `${{ github.event.pull_request.title }}`
             [🔗 작업 요약 보기](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
           DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
         with:
           args: |
-            ❌ **CI 도중 문제가 발생했습니다.(테스트)**
+            ❌ **CI 도중 문제가 발생했습니다.**
             branch : `${{ github.head_ref }}`
             pull-request : `${{ github.event.pull_request.title }}`
             [🔗 작업 요약 보기](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})

--- a/.github/workflows/dev-cd.yml
+++ b/.github/workflows/dev-cd.yml
@@ -35,6 +35,7 @@ jobs:
         with:
           args: |
             ❌ **컴파일 도중 문제가 발생했습니다.**
+            actor : `@${{ github.actor }}`
             branch : `${{ github.head_ref }}`
             pull-request : `${{ github.event.pull_request.title }}`
             [🔗 작업 요약 보기](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})
@@ -102,6 +103,7 @@ jobs:
         with:
           args: |
             ❌ **`Development` 배포 도중 문제가 발생했습니다.**
+            actor : `@${{ github.actor }}`
             branch : `${{ github.head_ref }}`
             pull-request : `${{ github.event.pull_request.title }}`
             [🔗 작업 요약 보기](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})

--- a/.github/workflows/dev-cd.yml
+++ b/.github/workflows/dev-cd.yml
@@ -27,7 +27,7 @@ jobs:
       - name: "Kotlin 소스를 컴파일한다."
         run: ./gradlew compileKotlin --configuration-cache --build-cache
 
-      - name: "Discord로 빌드 실패를 알린다"
+      - name: "Discord로 빌드 실패를 알린다."
         if: failure()
         uses: Ilshidur/action-discord@0.3.2
         env:
@@ -94,7 +94,7 @@ jobs:
             chmod +x deploy.sh
             ./deploy.sh ${{ env.IMAGE_TAG }}
 
-      - name: "Discord로 Development 배포 실패를 알린다"
+      - name: "Discord로 Development 배포 실패를 알린다."
         if: failure()
         uses: Ilshidur/action-discord@0.3.2
         env:

--- a/.github/workflows/dev-cd.yml
+++ b/.github/workflows/dev-cd.yml
@@ -22,29 +22,22 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: '21'
-
-      - name: "Gradle 캐시로 CI 속도를 향상시킨다."
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.gradle/caches
-            ~/.gradle/wrapper
-          key: gradle-${{ runner.os }}-caches-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
-          restore-keys: |
-            gradle-${{ runner.os }}-caches-
+          cache: 'gradle'
 
       - name: "Kotlin 소스를 컴파일한다."
         run: ./gradlew compileKotlin --configuration-cache --build-cache
 
-      - name: "Slack으로 빌드 실패를 알린다."
+      - name: "Discord로 빌드 실패를 알린다"
         if: failure()
-        uses: 8398a7/action-slack@v3
-        with:
-          status: ${{ job.status }}
-          author_name: 'GitHub Actions'
-          fields: repo,message,commit,author
+        uses: Ilshidur/action-discord@0.3.2
         env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }} # 추후 웹훅 추가
+          DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
+        with:
+          args: |
+            ❌ **컴파일 도중 문제가 발생했습니다.**
+            branch : `${{ github.head_ref }}`
+            pull-request : `${{ github.event.pull_request.title }}`
+            [🔗 작업 요약 보기](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})
 
   deploy:
     needs:
@@ -100,3 +93,15 @@ jobs:
             cd ~
             chmod +x deploy.sh
             ./deploy.sh ${{ env.IMAGE_TAG }}
+
+      - name: "Discord로 배포 실패를 알린다"
+        if: failure()
+        uses: Ilshidur/action-discord@0.3.2
+        env:
+          DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
+        with:
+          args: |
+            ❌ **배포 도중 문제가 발생했습니다.**
+            branch : `${{ github.head_ref }}`
+            pull-request : `${{ github.event.pull_request.title }}`
+            [🔗 작업 요약 보기](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})

--- a/.github/workflows/dev-cd.yml
+++ b/.github/workflows/dev-cd.yml
@@ -94,14 +94,14 @@ jobs:
             chmod +x deploy.sh
             ./deploy.sh ${{ env.IMAGE_TAG }}
 
-      - name: "Discord로 배포 실패를 알린다"
+      - name: "Discord로 Development 배포 실패를 알린다"
         if: failure()
         uses: Ilshidur/action-discord@0.3.2
         env:
           DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
         with:
           args: |
-            ❌ **배포 도중 문제가 발생했습니다.**
+            ❌ **`Development` 배포 도중 문제가 발생했습니다.**
             branch : `${{ github.head_ref }}`
             pull-request : `${{ github.event.pull_request.title }}`
             [🔗 작업 요약 보기](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})

--- a/.github/workflows/prod-cd.yml
+++ b/.github/workflows/prod-cd.yml
@@ -27,7 +27,7 @@ jobs:
       - name: "Kotlin 소스를 컴파일한다."
         run: ./gradlew compileKotlin --configuration-cache --build-cache
 
-      - name: "Discord로 빌드 실패를 알린다"
+      - name: "Discord로 빌드 실패를 알린다."
         if: failure()
         uses: Ilshidur/action-discord@0.3.2
         env:
@@ -105,7 +105,7 @@ jobs:
               --update-monitor 30s \
               core-service
 
-      - name: "Discord로 Production 배포 실패를 알린다"
+      - name: "Discord로 Production 배포 실패를 알린다."
         if: failure()
         uses: Ilshidur/action-discord@0.3.2
         env:

--- a/.github/workflows/prod-cd.yml
+++ b/.github/workflows/prod-cd.yml
@@ -22,29 +22,22 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: '21'
-
-      - name: "Gradle 캐시로 CI 속도를 향상시킨다."
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.gradle/caches
-            ~/.gradle/wrapper
-          key: gradle-${{ runner.os }}-caches-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
-          restore-keys: |
-            gradle-${{ runner.os }}-caches-
+        cache: 'gradle'
 
       - name: "Kotlin 소스를 컴파일한다."
         run: ./gradlew compileKotlin --configuration-cache --build-cache
 
-      - name: "Slack으로 빌드 실패를 알린다."
+      - name: "Discord로 빌드 실패를 알린다"
         if: failure()
-        uses: 8398a7/action-slack@v3
-        with:
-          status: ${{ job.status }}
-          author_name: 'GitHub Actions'
-          fields: repo,message,commit,author
+        uses: Ilshidur/action-discord@0.3.2
         env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }} # 추후 웹훅 추가
+          DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
+        with:
+          args: |
+            ❌ **컴파일 도중 문제가 발생했습니다.**
+            branch : `${{ github.head_ref }}`
+            pull-request : `${{ github.event.pull_request.title }}`
+            [🔗 작업 요약 보기](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})
 
   deploy:
     needs:
@@ -111,3 +104,15 @@ jobs:
               --update-failure-action pause \
               --update-monitor 30s \
               core-service
+
+      - name: "Discord로 Production 배포 실패를 알린다"
+        if: failure()
+        uses: Ilshidur/action-discord@0.3.2
+        env:
+          DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
+        with:
+          args: |
+            ❌ **`Production` 배포 도중 문제가 발생했습니다.**
+            branch : `${{ github.head_ref }}`
+            pull-request : `${{ github.event.pull_request.title }}`
+            [🔗 작업 요약 보기](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})

--- a/.github/workflows/prod-cd.yml
+++ b/.github/workflows/prod-cd.yml
@@ -22,7 +22,7 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: '21'
-        cache: 'gradle'
+          cache: 'gradle'
 
       - name: "Kotlin 소스를 컴파일한다."
         run: ./gradlew compileKotlin --configuration-cache --build-cache

--- a/.github/workflows/prod-cd.yml
+++ b/.github/workflows/prod-cd.yml
@@ -35,6 +35,7 @@ jobs:
         with:
           args: |
             ❌ **컴파일 도중 문제가 발생했습니다.**
+            actor : `@${{ github.actor }}`
             branch : `${{ github.head_ref }}`
             pull-request : `${{ github.event.pull_request.title }}`
             [🔗 작업 요약 보기](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})
@@ -113,6 +114,7 @@ jobs:
         with:
           args: |
             ❌ **`Production` 배포 도중 문제가 발생했습니다.**
+            actor : `@${{ github.actor }}`
             branch : `${{ github.head_ref }}`
             pull-request : `${{ github.event.pull_request.title }}`
             [🔗 작업 요약 보기](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})


### PR DESCRIPTION
## Summary

>- #42 

CI/CD 실패시 알림 채널을 Slack에서 Discord로 변경하고 cache 전략을 일부 변경하였습니다

<!-- 해당 PR에 대한 요약을 작성해주세요. -->

## Tasks

- 알림 채널 Discord로 변경
- cache 전략 수정

## ETC

**`setup-java`의 `cache: gradle` 적용**
자동으로 Gradle 관련 경로 적용하여 불필요한 캐시 키 전략을 삭제합니다

<!-- 추가적인 정보나 참고 사항을 작성해주세요. -->

## Screenshot
<img width="1008" height="497" alt="스크린샷 2025-07-15 오후 10 21 05" src="https://github.com/user-attachments/assets/74545091-170a-4634-b549-b7a970274375" />

<!-- (없을 경우 삭제) 작업한 내용에 대한 스크린샷을 첨부해주세요._ -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Chores**
  * Gradle 캐싱 방식을 간소화하여 워크플로우 속도를 향상시켰습니다.
  * 빌드 및 배포 실패 시 Slack 알림을 제거하고 Discord 알림으로 전환하였습니다.
  * 개발 및 프로덕션 배포 파이프라인에 Discord 알림 기능을 추가하였습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->