### PR TITLE
Fix : Bill 순환 참조 문제 해결

### DIFF
--- a/src/main/kotlin/com/server/dpmcore/bill/bill/application/BillCommandService.kt
+++ b/src/main/kotlin/com/server/dpmcore/bill/bill/application/BillCommandService.kt
@@ -1,13 +1,13 @@
 package com.server.dpmcore.bill.bill.application
 
+import com.server.dpmcore.bill.bill.application.mapper.BillGatheringMapper.toCommand
 import com.server.dpmcore.bill.bill.domain.model.Bill
-import com.server.dpmcore.bill.bill.domain.port.BillPersistencePort
+import com.server.dpmcore.bill.bill.domain.model.BillId
+import com.server.dpmcore.bill.bill.domain.port.outbound.BillPersistencePort
 import com.server.dpmcore.bill.bill.presentation.dto.request.CreateBillRequest
-import com.server.dpmcore.bill.bill.presentation.mapper.BillMapper.toBill
 import com.server.dpmcore.bill.billAccount.application.BillAccountQueryService
-import com.server.dpmcore.bill.exception.BillException
-import com.server.dpmcore.gathering.gathering.application.GatheringCommandService
-import com.server.dpmcore.gathering.gathering.presentation.mapper.GatheringMapper.toGathering
+import com.server.dpmcore.gathering.gathering.domain.port.inbound.GatheringCreateUseCase
+import com.server.dpmcore.member.member.domain.model.MemberId
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
@@ -15,31 +15,65 @@ import org.springframework.transaction.annotation.Transactional
 @Transactional
 class BillCommandService(
     private val billPersistencePort: BillPersistencePort,
-    private val gatheringCommandService: GatheringCommandService,
     private val billAccountQueryService: BillAccountQueryService,
+    private val gatheringCreateUseCase: GatheringCreateUseCase,
 ) {
-    fun save(createBillRequest: CreateBillRequest): Bill {
-//            TODO : 외에 다른 것들도 실드할 게 있으면 추가
-        billAccountQueryService.findBy(createBillRequest.billAccountId).also {
-            if (it.id?.value != createBillRequest.billAccountId) throw BillException.BillAccountNotFoundException()
-        }
-        if (createBillRequest.gatherings.isEmpty()) {
-            throw BillException.GatheringRequiredException()
-        }
-        val bill = toBill(createBillRequest)
-        val savedBill = billPersistencePort.save(bill)
-//        TODO : 값 주입 도메인 로직으로 변경
-
-        gatheringCommandService.save(
-            bill = savedBill,
-            createBillRequest.gatherings
-                .map { createGatheringRequest ->
-                    toGathering(
-                        createGatheringRequest,
-                        savedBill.id ?: throw BillException.BillIdRequiredException(),
-                    )
-                }.toMutableList(),
-        )
-        return savedBill
+    fun saveBillWithGatherings(request: CreateBillRequest): BillId {
+        val billId = verifyAccountThenCreateBill(request)
+        saveRelatedGatherings(request, billId)
+        return billId
     }
+
+    private fun saveRelatedGatherings(
+        request: CreateBillRequest,
+        billId: BillId,
+    ) {
+        val gatheringCommands = request.gatherings.map { it.toCommand() }
+        gatheringCreateUseCase.saveAllGatherings(gatheringCommands, billId)
+    }
+
+    private fun verifyAccountThenCreateBill(request: CreateBillRequest): BillId {
+        val account = billAccountQueryService.findBy(request.billAccountId)
+        return billPersistencePort.save(
+            Bill.create(
+                account,
+                request.title,
+                request.description,
+                MemberId(request.hostUserId),
+            ),
+        )
+    }
+
+    /*
+    fun save(createBillRequest: CreateBillRequest): Bill {
+        try {
+ //            TODO : 외에 다른 것들도 실드할 게 있으면 추가
+            billAccountQueryService.findBy(createBillRequest.billAccountId).also {
+                if (it.id?.value != createBillRequest.billAccountId) throw BillException.BillAccountNotFoundException()
+            }
+            if (createBillRequest.gatherings.isEmpty()) {
+                throw BillException.GatheringRequiredException()
+            }
+            val bill = toBill(createBillRequest)
+            val savedBill = billPersistencePort.save(bill)
+ //        TODO : 값 주입 도메인 로직으로 변경
+
+            gatheringCommandService.save(
+                bill = savedBill,
+                createBillRequest.gatherings
+                    .map { createGatheringRequest ->
+                        toGathering(
+                            createGatheringRequest,
+                            savedBill.id ?: throw BillException.BillIdRequiredException(),
+                        )
+                    }.toMutableList(),
+            )
+            return savedBill
+        } catch (e: Exception) {
+            e.printStackTrace()
+        }
+        throw BillException.BillIdRequiredException()
+    }
+
+     */
 }

--- a/src/main/kotlin/com/server/dpmcore/bill/bill/application/BillQueryService.kt
+++ b/src/main/kotlin/com/server/dpmcore/bill/bill/application/BillQueryService.kt
@@ -1,0 +1,17 @@
+package com.server.dpmcore.bill.bill.application
+
+import com.server.dpmcore.bill.bill.domain.model.Bill
+import com.server.dpmcore.bill.bill.domain.model.BillId
+import com.server.dpmcore.bill.bill.domain.port.inbound.BillQueryUseCase
+import com.server.dpmcore.bill.bill.domain.port.outbound.BillPersistencePort
+import com.server.dpmcore.bill.exception.BillException
+import org.springframework.stereotype.Service
+
+@Service
+class BillQueryService(
+    private val billPersistencePort: BillPersistencePort,
+) : BillQueryUseCase {
+    override fun getById(billId: BillId): Bill =
+        billPersistencePort.findById(billId.value)
+            ?: throw BillException.BillNotFoundException()
+}

--- a/src/main/kotlin/com/server/dpmcore/bill/bill/application/mapper/BillGatheringMapper.kt
+++ b/src/main/kotlin/com/server/dpmcore/bill/bill/application/mapper/BillGatheringMapper.kt
@@ -1,0 +1,38 @@
+package com.server.dpmcore.bill.bill.application.mapper
+
+import com.server.dpmcore.bill.bill.presentation.dto.request.GatheringForBillCreateRequest
+import com.server.dpmcore.gathering.gathering.domain.port.inbound.command.GatheringCreateCommand
+import com.server.dpmcore.gathering.gathering.domain.port.inbound.command.GatheringMemberCommand
+import com.server.dpmcore.gathering.gathering.domain.port.inbound.command.ReceiptCommand
+import com.server.dpmcore.gathering.gathering.domain.port.inbound.command.ReceiptPhotoCommand
+import com.server.dpmcore.member.member.domain.model.MemberId
+
+object BillGatheringMapper {
+    fun GatheringForBillCreateRequest.toCommand(): GatheringCreateCommand =
+        GatheringCreateCommand(
+            title = this.title,
+            description = this.description,
+            hostUserId = MemberId(this.hostUserId),
+            roundNumber = this.roundNumber,
+            heldAt = this.heldAt,
+            receipt =
+                ReceiptCommand(
+                    amount = this.receipt.amount,
+                    photos =
+                        this.receipt.receiptPhotos?.map {
+                            ReceiptPhotoCommand(
+                                receiptId = it.receiptId,
+                                photoUrl = it.photoUrl,
+                            )
+                        } ?: emptyList(),
+                ),
+            members =
+                this.gatheringMembers?.map {
+                    GatheringMemberCommand(
+                        memberId = it.memberId,
+                        isJoined = it.isJoined,
+                        isCompleted = it.isCompleted,
+                    )
+                } ?: emptyList(),
+        )
+}

--- a/src/main/kotlin/com/server/dpmcore/bill/bill/domain/model/Bill.kt
+++ b/src/main/kotlin/com/server/dpmcore/bill/bill/domain/model/Bill.kt
@@ -35,9 +35,15 @@ class Bill(
     val completedAt: Instant? = null,
     val billStatus: BillStatus = BillStatus.PENDING,
     val createdAt: Instant? = null,
-    val updatedAt: Instant? = null,
-    val deletedAt: Instant? = null,
+    updatedAt: Instant? = null,
+    deletedAt: Instant? = null,
 ) {
+    var updatedAt: Instant? = updatedAt
+        private set
+
+    var deletedAt: Instant? = deletedAt
+        private set
+
     fun isCompleted(): Boolean = completedAt != null
 
     fun complete(now: Instant): Bill {
@@ -66,4 +72,21 @@ class Bill(
     }
 
     override fun hashCode(): Int = id?.hashCode() ?: 0
+
+    companion object {
+        fun create(
+            billAccount: BillAccount,
+            title: String,
+            description: String? = null,
+            hostUserId: MemberId,
+        ): Bill =
+            Bill(
+                billAccount = billAccount,
+                title = title,
+                hostUserId = hostUserId,
+                description = description,
+                createdAt = Instant.now(),
+                updatedAt = Instant.now(),
+            )
+    }
 }

--- a/src/main/kotlin/com/server/dpmcore/bill/bill/domain/model/Bill.kt
+++ b/src/main/kotlin/com/server/dpmcore/bill/bill/domain/model/Bill.kt
@@ -1,7 +1,7 @@
 package com.server.dpmcore.bill.bill.domain.model
 
 import com.server.dpmcore.bill.billAccount.domain.model.BillAccount
-import com.server.dpmcore.gathering.gathering.domain.model.Gathering
+import com.server.dpmcore.gathering.gathering.domain.model.GatheringId
 import com.server.dpmcore.member.member.domain.model.MemberId
 import java.time.Instant
 
@@ -31,7 +31,7 @@ class Bill(
     val title: String,
     val description: String? = null,
     val hostUserId: MemberId,
-    var gatherings: MutableList<Gathering> = mutableListOf(),
+    var gatheringIds: MutableList<GatheringId> = mutableListOf(),
     val completedAt: Instant? = null,
     val billStatus: BillStatus = BillStatus.PENDING,
     val createdAt: Instant? = null,
@@ -51,7 +51,7 @@ class Bill(
             title = title,
             hostUserId = hostUserId,
             description = description,
-            gatherings = gatherings,
+            gatheringIds = gatheringIds,
             completedAt = now,
             createdAt = createdAt,
             updatedAt = now,

--- a/src/main/kotlin/com/server/dpmcore/bill/bill/domain/model/BillStatus.kt
+++ b/src/main/kotlin/com/server/dpmcore/bill/bill/domain/model/BillStatus.kt
@@ -1,5 +1,10 @@
 package com.server.dpmcore.bill.bill.domain.model
 
+import com.server.dpmcore.bill.bill.domain.model.BillStatus.COMPLETED
+import com.server.dpmcore.bill.bill.domain.model.BillStatus.IN_PROGRESS
+import com.server.dpmcore.bill.bill.domain.model.BillStatus.OPEN
+import com.server.dpmcore.bill.bill.domain.model.BillStatus.PENDING
+
 /**
  * 정산의 상태를 나타냅니다.
  *
@@ -13,9 +18,18 @@ package com.server.dpmcore.bill.bill.domain.model
  *  - 정산이 완료되기 전까지의 상태입니다.
  * @property COMPLETED : 정산이 완료된 상태입니다.
  */
-enum class BillStatus(val value: String) {
+enum class BillStatus(
+    val value: String,
+) {
     PENDING("참여 대기 중"),
     OPEN("참여 중"),
     IN_PROGRESS("정산 중"),
     COMPLETED("정산 완료"),
+    ;
+
+    companion object {
+        fun from(value: String): BillStatus =
+            values().firstOrNull { it.value == value }
+                ?: throw IllegalArgumentException("존재하지 않는 정산 상태입니다: $value")
+    }
 }

--- a/src/main/kotlin/com/server/dpmcore/bill/bill/domain/port/BillPersistencePort.kt
+++ b/src/main/kotlin/com/server/dpmcore/bill/bill/domain/port/BillPersistencePort.kt
@@ -1,7 +1,0 @@
-package com.server.dpmcore.bill.bill.domain.port
-
-import com.server.dpmcore.bill.bill.domain.model.Bill
-
-interface BillPersistencePort {
-    fun save(bill: Bill): Bill
-}

--- a/src/main/kotlin/com/server/dpmcore/bill/bill/domain/port/inbound/BillQueryUseCase.kt
+++ b/src/main/kotlin/com/server/dpmcore/bill/bill/domain/port/inbound/BillQueryUseCase.kt
@@ -1,0 +1,8 @@
+package com.server.dpmcore.bill.bill.domain.port.inbound
+
+import com.server.dpmcore.bill.bill.domain.model.Bill
+import com.server.dpmcore.bill.bill.domain.model.BillId
+
+interface BillQueryUseCase {
+    fun getById(billId: BillId): Bill
+}

--- a/src/main/kotlin/com/server/dpmcore/bill/bill/domain/port/outbound/BillPersistencePort.kt
+++ b/src/main/kotlin/com/server/dpmcore/bill/bill/domain/port/outbound/BillPersistencePort.kt
@@ -1,0 +1,10 @@
+package com.server.dpmcore.bill.bill.domain.port.outbound
+
+import com.server.dpmcore.bill.bill.domain.model.Bill
+import com.server.dpmcore.bill.bill.domain.model.BillId
+
+interface BillPersistencePort {
+    fun save(bill: Bill): BillId
+
+    fun findById(billId: Long): Bill?
+}

--- a/src/main/kotlin/com/server/dpmcore/bill/bill/infrastructure/entity/BillEntity.kt
+++ b/src/main/kotlin/com/server/dpmcore/bill/bill/infrastructure/entity/BillEntity.kt
@@ -3,6 +3,7 @@ package com.server.dpmcore.bill.bill.infrastructure.entity
 import com.server.dpmcore.bill.bill.domain.model.Bill
 import com.server.dpmcore.bill.bill.domain.model.BillId
 import com.server.dpmcore.bill.billAccount.infrastructure.entity.BillAccountEntity
+import com.server.dpmcore.gathering.gathering.domain.model.GatheringId
 import com.server.dpmcore.gathering.gathering.infrastructure.entity.GatheringEntity
 import com.server.dpmcore.member.member.domain.model.MemberId
 import jakarta.persistence.CascadeType
@@ -67,7 +68,7 @@ class BillEntity(
             title = title,
             description = description,
             hostUserId = MemberId(hostUserId),
-            gatherings = gatherings.map { it.toDomain() }.toMutableList(),
+            gatheringIds = gatherings.map { GatheringId(it.id) }.toMutableList(),
             completedAt = completedAt,
             createdAt = createdAt,
             updatedAt = updatedAt,

--- a/src/main/kotlin/com/server/dpmcore/bill/bill/infrastructure/entity/BillEntity.kt
+++ b/src/main/kotlin/com/server/dpmcore/bill/bill/infrastructure/entity/BillEntity.kt
@@ -33,6 +33,8 @@ class BillEntity(
     val title: String,
     @Column(name = "description")
     val description: String,
+    @Column(name = "bill_status", nullable = false)
+    val billStatus: String,
     @Column(name = "host_user_id")
     val hostUserId: Long,
     @OneToMany(mappedBy = "bill", fetch = FetchType.LAZY, cascade = [CascadeType.ALL], orphanRemoval = true)
@@ -53,6 +55,7 @@ class BillEntity(
                 billAccount = BillAccountEntity.from(bill.billAccount),
                 title = bill.title,
                 description = bill.description ?: "",
+                billStatus = bill.billStatus.name,
                 hostUserId = bill.hostUserId.value,
                 completedAt = bill.completedAt,
                 createdAt = bill.createdAt ?: Instant.now(),

--- a/src/main/kotlin/com/server/dpmcore/bill/bill/infrastructure/repository/BillRepository.kt
+++ b/src/main/kotlin/com/server/dpmcore/bill/bill/infrastructure/repository/BillRepository.kt
@@ -1,13 +1,26 @@
 package com.server.dpmcore.bill.bill.infrastructure.repository
 
+import com.linecorp.kotlinjdsl.querydsl.expression.col
+import com.linecorp.kotlinjdsl.spring.data.SpringDataQueryFactory
+import com.linecorp.kotlinjdsl.spring.data.singleQuery
 import com.server.dpmcore.bill.bill.domain.model.Bill
-import com.server.dpmcore.bill.bill.domain.port.BillPersistencePort
+import com.server.dpmcore.bill.bill.domain.model.BillId
+import com.server.dpmcore.bill.bill.domain.port.outbound.BillPersistencePort
 import com.server.dpmcore.bill.bill.infrastructure.entity.BillEntity
 import org.springframework.stereotype.Repository
 
 @Repository
 class BillRepository(
     private val billJpaRepository: BillJpaRepository,
+    private val queryFactory: SpringDataQueryFactory,
 ) : BillPersistencePort {
-    override fun save(bill: Bill): Bill = billJpaRepository.save(BillEntity.from(bill)).toDomain()
+    override fun save(bill: Bill): BillId = BillId(billJpaRepository.save(BillEntity.from(bill)).id)
+
+    override fun findById(billId: Long): Bill? =
+        queryFactory
+            .singleQuery<BillEntity> {
+                select(entity(BillEntity::class))
+                from(entity(BillEntity::class))
+                where(col(BillEntity::id).equal(billId))
+            }.toDomain()
 }

--- a/src/main/kotlin/com/server/dpmcore/bill/bill/presentation/controller/BillCommandApi.kt
+++ b/src/main/kotlin/com/server/dpmcore/bill/bill/presentation/controller/BillCommandApi.kt
@@ -1,7 +1,7 @@
 package com.server.dpmcore.bill.bill.presentation.controller
 
 import com.server.dpmcore.bill.bill.presentation.dto.request.CreateBillRequest
-import com.server.dpmcore.bill.bill.presentation.dto.response.CreateBillResponse
+import com.server.dpmcore.bill.bill.presentation.dto.response.BillPersistenceResponse
 import com.server.dpmcore.common.exception.CustomResponse
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.media.Content
@@ -13,6 +13,7 @@ import io.swagger.v3.oas.annotations.tags.Tag
 
 @Tag(name = "정산(Bill)")
 interface BillCommandApi {
+    /*
     @Operation(
         summary = "정산 추가",
         description =
@@ -33,9 +34,9 @@ interface BillCommandApi {
                                 name = "정산 추가 성공 응답",
                                 value = """
                                     {
-                                        "status": "CREATE",
-                                        "message": "요청에 성공했습니다",
-                                        "code": "G000",
+                                        "status": "CREATED",
+                                        "message": "요청에 성공하여 리소스가 생성되었습니다.",
+                                        "code": "G001",
                                         "data": {
                                             "billId": 1,
                                             "title": "17기 OT세션 공식 회식",
@@ -121,5 +122,44 @@ interface BillCommandApi {
             ),
         ],
     )
-    fun createBill(createBillRequest: CreateBillRequest): CustomResponse<CreateBillResponse>
+    fun createBill(createBillRequest: CreateBillRequest): CustomResponse<Void>
+
+     */
+
+    @Operation(
+        summary = "정산 추가",
+        description =
+            "정산을 추가합니다. 각 차수의 회식과 정산서, 참여 멤버 등을 함께 추가해야 합니다. \n" +
+                "추후에는 영수증 사진이 추가될 수 있습니다.",
+    )
+    @ApiResponses(
+        value = [
+            ApiResponse(
+                responseCode = "201",
+                description = "정산 추가 성공",
+                content = [
+                    Content(
+                        mediaType = "application/json",
+                        schema = Schema(implementation = CustomResponse::class),
+                        examples = [
+                            ExampleObject(
+                                name = "정산 추가 성공 응답",
+                                value = """
+                                    {
+                                        "status": "CREATED",
+                                        "message": "요청에 성공하여 리소스가 생성되었습니다.",
+                                        "code": "G001",
+                                        "data": {
+                                            "billId": 11
+                                            }
+                                    }
+                                """,
+                            ),
+                        ],
+                    ),
+                ],
+            ),
+        ],
+    )
+    fun createBill(createBillRequest: CreateBillRequest): CustomResponse<BillPersistenceResponse>
 }

--- a/src/main/kotlin/com/server/dpmcore/bill/bill/presentation/controller/BillCommandController.kt
+++ b/src/main/kotlin/com/server/dpmcore/bill/bill/presentation/controller/BillCommandController.kt
@@ -5,6 +5,7 @@ import com.server.dpmcore.bill.bill.presentation.dto.request.CreateBillRequest
 import com.server.dpmcore.bill.bill.presentation.dto.response.CreateBillResponse
 import com.server.dpmcore.bill.bill.presentation.mapper.BillMapper.toCreateBillResponse
 import com.server.dpmcore.common.exception.CustomResponse
+import com.server.dpmcore.gathering.gathering.application.GatheringQueryService
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
@@ -14,6 +15,7 @@ import org.springframework.web.bind.annotation.RestController
 @RequestMapping("/v1/bills")
 class BillCommandController(
     private val billCommandService: BillCommandService,
+    private val gatheringQueryService: GatheringQueryService,
 //    TODO : 도메인끼리 의존성을 어떻게 하면 좋을지 논의해보고 싶음.
 //    매퍼에서 port를 사용하게 되면 매퍼도 bean이되고, 물흐르듯 정방향으로 가던게 갑자기 역방향이 돼서 맘에 안듦.
 ) : BillCommandApi {
@@ -22,7 +24,11 @@ class BillCommandController(
         @RequestBody createBillRequest: CreateBillRequest,
     ): CustomResponse<CreateBillResponse> {
         val bill = billCommandService.save(createBillRequest)
-
-        return CustomResponse.created(toCreateBillResponse(bill))
+        val gatherings =
+            bill.gatheringIds
+                .map { gatheringId ->
+                    gatheringQueryService.findById(gatheringId.value)
+                }.toMutableList()
+        return CustomResponse.created(toCreateBillResponse(bill, gatherings))
     }
 }

--- a/src/main/kotlin/com/server/dpmcore/bill/bill/presentation/controller/BillCommandController.kt
+++ b/src/main/kotlin/com/server/dpmcore/bill/bill/presentation/controller/BillCommandController.kt
@@ -2,10 +2,10 @@ package com.server.dpmcore.bill.bill.presentation.controller
 
 import com.server.dpmcore.bill.bill.application.BillCommandService
 import com.server.dpmcore.bill.bill.presentation.dto.request.CreateBillRequest
-import com.server.dpmcore.bill.bill.presentation.dto.response.CreateBillResponse
-import com.server.dpmcore.bill.bill.presentation.mapper.BillMapper.toCreateBillResponse
+import com.server.dpmcore.bill.bill.presentation.dto.response.BillPersistenceResponse
 import com.server.dpmcore.common.exception.CustomResponse
 import com.server.dpmcore.gathering.gathering.application.GatheringQueryService
+import jakarta.validation.Valid
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
@@ -21,14 +21,15 @@ class BillCommandController(
 ) : BillCommandApi {
     @PostMapping
     override fun createBill(
-        @RequestBody createBillRequest: CreateBillRequest,
-    ): CustomResponse<CreateBillResponse> {
-        val bill = billCommandService.save(createBillRequest)
-        val gatherings =
-            bill.gatheringIds
-                .map { gatheringId ->
-                    gatheringQueryService.findById(gatheringId.value)
-                }.toMutableList()
-        return CustomResponse.created(toCreateBillResponse(bill, gatherings))
+        @Valid @RequestBody createBillRequest: CreateBillRequest,
+    ): CustomResponse<BillPersistenceResponse> {
+        val billId = billCommandService.saveBillWithGatherings(createBillRequest)
+//        val gatherings =
+//            bill.gatheringIds
+//                .map { gatheringId ->
+//                    gatheringQueryService.findById(gatheringId.value)
+//                }.toMutableList()
+//        return CustomResponse.created(toCreateBillResponse(bill, gatherings))
+        return CustomResponse.ok(BillPersistenceResponse(billId))
     }
 }

--- a/src/main/kotlin/com/server/dpmcore/bill/bill/presentation/dto/request/CreateBillRequest.kt
+++ b/src/main/kotlin/com/server/dpmcore/bill/bill/presentation/dto/request/CreateBillRequest.kt
@@ -1,10 +1,12 @@
 package com.server.dpmcore.bill.bill.presentation.dto.request
 
+import jakarta.validation.constraints.NotEmpty
+
 data class CreateBillRequest(
     val title: String,
     val description: String?,
     val hostUserId: Long,
     val billAccountId: Long,
     val inviteGroupIds: MutableList<Long>?,
-    val gatherings: MutableList<CreateGatheringRequest>,
+    @NotEmpty val gatherings: MutableList<GatheringForBillCreateRequest>,
 )

--- a/src/main/kotlin/com/server/dpmcore/bill/bill/presentation/dto/request/CreateReceiptRequest.kt
+++ b/src/main/kotlin/com/server/dpmcore/bill/bill/presentation/dto/request/CreateReceiptRequest.kt
@@ -1,6 +1,0 @@
-package com.server.dpmcore.bill.bill.presentation.dto.request
-
-data class CreateReceiptRequest(
-    val amount: Int,
-    val receiptPhotos: MutableList<CreateReceiptPhotoRequest>?,
-)

--- a/src/main/kotlin/com/server/dpmcore/bill/bill/presentation/dto/request/GatheringForBillCreateRequest.kt
+++ b/src/main/kotlin/com/server/dpmcore/bill/bill/presentation/dto/request/GatheringForBillCreateRequest.kt
@@ -2,13 +2,12 @@ package com.server.dpmcore.bill.bill.presentation.dto.request
 
 import java.time.LocalDateTime
 
-data class CreateGatheringRequest(
+data class GatheringForBillCreateRequest(
     val title: String,
     val description: String?,
     val hostUserId: Long,
     val roundNumber: Int,
     val heldAt: LocalDateTime,
-    val category: String = "GATHERING",
-    val receipt: CreateReceiptRequest,
-    val gatheringMembers: MutableList<CreateGatheringMemberRequest>?,
+    val receipt: ReceiptForBillCreateRequest,
+    val gatheringMembers: MutableList<GatheringMemberForBillCreateRequest>?,
 )

--- a/src/main/kotlin/com/server/dpmcore/bill/bill/presentation/dto/request/GatheringMemberForBillCreateRequest.kt
+++ b/src/main/kotlin/com/server/dpmcore/bill/bill/presentation/dto/request/GatheringMemberForBillCreateRequest.kt
@@ -1,6 +1,6 @@
 package com.server.dpmcore.bill.bill.presentation.dto.request
 
-data class CreateGatheringMemberRequest(
+data class GatheringMemberForBillCreateRequest(
     val memberId: Long,
     val isJoined: Boolean = true,
     val isCompleted: Boolean = false,

--- a/src/main/kotlin/com/server/dpmcore/bill/bill/presentation/dto/request/ReceiptForBillCreateRequest.kt
+++ b/src/main/kotlin/com/server/dpmcore/bill/bill/presentation/dto/request/ReceiptForBillCreateRequest.kt
@@ -1,0 +1,6 @@
+package com.server.dpmcore.bill.bill.presentation.dto.request
+
+data class ReceiptForBillCreateRequest(
+    val amount: Int,
+    val receiptPhotos: MutableList<ReceiptPhotoForBillCreateRequest>?,
+)

--- a/src/main/kotlin/com/server/dpmcore/bill/bill/presentation/dto/request/ReceiptPhotoForBillCreateRequest.kt
+++ b/src/main/kotlin/com/server/dpmcore/bill/bill/presentation/dto/request/ReceiptPhotoForBillCreateRequest.kt
@@ -1,6 +1,6 @@
 package com.server.dpmcore.bill.bill.presentation.dto.request
 
-data class CreateReceiptPhotoRequest(
+data class ReceiptPhotoForBillCreateRequest(
     val receiptId: Long,
     val photoUrl: String?,
 )

--- a/src/main/kotlin/com/server/dpmcore/bill/bill/presentation/dto/response/BillPersistenceResponse.kt
+++ b/src/main/kotlin/com/server/dpmcore/bill/bill/presentation/dto/response/BillPersistenceResponse.kt
@@ -1,0 +1,7 @@
+package com.server.dpmcore.bill.bill.presentation.dto.response
+
+import com.server.dpmcore.bill.bill.domain.model.BillId
+
+data class BillPersistenceResponse(
+    val billId: BillId,
+)

--- a/src/main/kotlin/com/server/dpmcore/bill/bill/presentation/mapper/BillMapper.kt
+++ b/src/main/kotlin/com/server/dpmcore/bill/bill/presentation/mapper/BillMapper.kt
@@ -6,8 +6,8 @@ import com.server.dpmcore.bill.bill.presentation.dto.response.CreateBillResponse
 import com.server.dpmcore.bill.bill.presentation.dto.response.CreateInviteGroupResponse
 import com.server.dpmcore.bill.billAccount.presentation.mapper.BillAccountMapper.toBillAccount
 import com.server.dpmcore.bill.exception.BillException
+import com.server.dpmcore.gathering.gathering.domain.model.Gathering
 import com.server.dpmcore.gathering.gathering.presentation.mapper.GatheringMapper.toCreateGatheringResponse
-import com.server.dpmcore.gathering.gathering.presentation.mapper.GatheringMapper.toGathering
 import com.server.dpmcore.member.member.domain.model.MemberId
 import java.time.LocalDateTime
 import java.time.ZoneId
@@ -19,25 +19,23 @@ object BillMapper {
             hostUserId = MemberId(createBillRequest.hostUserId),
             billAccount = toBillAccount(createBillRequest.billAccountId),
             description = createBillRequest.description,
-            gatherings =
-                createBillRequest.gatherings
-                    .map { gathering ->
-                        toGathering(gathering)
-                    }.toMutableList(),
         )
 
-    fun toCreateBillResponse(bill: Bill): CreateBillResponse =
+    fun toCreateBillResponse(
+        bill: Bill,
+        gatherings: MutableList<Gathering>,
+    ): CreateBillResponse =
         CreateBillResponse(
             billId = bill.id?.value ?: throw BillException.BillIdRequiredException(),
             title = bill.title,
             description = bill.description,
             hostUserId = bill.hostUserId.value,
-            billTotalAmount = bill.gatherings.sumOf { gathering -> gathering.receipt!!.amount }.toLong(),
-            heldAt = LocalDateTime.ofInstant(bill.gatherings.get(0).heldAt, ZoneId.of("Asia/Seoul")),
+            billTotalAmount = gatherings.sumOf { gathering -> gathering.receipt!!.amount }.toLong(),
+            heldAt = LocalDateTime.ofInstant(gatherings.get(0).heldAt, ZoneId.of("Asia/Seoul")),
             billAccountId = bill.billAccount.id?.value ?: throw BillException.BillAccountIdRequiredException(),
 //            TODO : 회식 참여 가능 인원 태그 추가
             inviteGroups = mutableListOf(),
-            gatherings = bill.gatherings.map { gathering -> toCreateGatheringResponse(gathering) }.toMutableList(),
+            gatherings = gatherings.map { gathering -> toCreateGatheringResponse(gathering) }.toMutableList(),
         )
 
     fun toCreateInviteGroupResponse(): CreateInviteGroupResponse = CreateInviteGroupResponse()

--- a/src/main/kotlin/com/server/dpmcore/bill/exception/BillException.kt
+++ b/src/main/kotlin/com/server/dpmcore/bill/exception/BillException.kt
@@ -14,4 +14,8 @@ open class BillException(
     class BillIdRequiredException : BillException(BillExceptionCode.BILL_ID_REQUIRED)
 
     class GatheringMembersRequiredException : BillException(BillExceptionCode.GATHERING_MEMBERS_REQUIRED)
+
+    class BillNotFoundException : BillException(BillExceptionCode.BILL_NOT_FOUND)
+
+    class GatheringNotFoundException : BillException(BillExceptionCode.GATHERING_NOT_FOUND)
 }

--- a/src/main/kotlin/com/server/dpmcore/bill/exception/BillExceptionCode.kt
+++ b/src/main/kotlin/com/server/dpmcore/bill/exception/BillExceptionCode.kt
@@ -12,11 +12,13 @@ enum class BillExceptionCode(
     CREATE(HttpStatus.CREATED, "BILL-001", "리소스 생성에 성공했습니다"),
     INVALID_INPUT(HttpStatus.BAD_REQUEST, "BILL-400", "올바른 입력 형식이 아닙니다."),
     BILL_ACCOUNT_NOT_FOUND(HttpStatus.BAD_REQUEST, "BILL-401", "존재하지 않는 회식계좌입니다."),
-    GATHERING_REQUIRED(HttpStatus.BAD_REQUEST, "BILL-402", "회식은 필수로 존재해야합니다."),
+    GATHERING_REQUIRED(HttpStatus.BAD_REQUEST, "GATHERING-402", "회식은 필수로 존재해야합니다."),
     BILL_ACCOUNT_ID_REQUIRED(HttpStatus.BAD_REQUEST, "BILL-403", "BillAccount ID는 null일 수 없습니다."),
     BILL_ID_REQUIRED(HttpStatus.BAD_REQUEST, "BILL-404", "Bill ID는 null일 수 없습니다."),
     GATHERING_MEMBERS_REQUIRED(HttpStatus.BAD_REQUEST, "BILL-405", "회식 참여 멤버는 필수로 존재해야합니다."),
     SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "BILL-500", "예상치 못한 서버 에러가 발생했습니다"),
+    BILL_NOT_FOUND(HttpStatus.BAD_REQUEST, "BILL-404-01", "존재하지 않는 정산입니다."),
+    GATHERING_NOT_FOUND(HttpStatus.BAD_REQUEST, "GATHERING-404-01", "존재하지 않는 회식입니다."),
     ;
 
     override fun getStatus(): HttpStatus = status

--- a/src/main/kotlin/com/server/dpmcore/gathering/gathering/application/GatheringCommandService.kt
+++ b/src/main/kotlin/com/server/dpmcore/gathering/gathering/application/GatheringCommandService.kt
@@ -1,14 +1,15 @@
 package com.server.dpmcore.gathering.gathering.application
 
-import com.server.dpmcore.bill.bill.domain.model.Bill
-import com.server.dpmcore.bill.exception.BillException
+import com.server.dpmcore.bill.bill.domain.model.BillId
+import com.server.dpmcore.bill.bill.domain.port.inbound.BillQueryUseCase
 import com.server.dpmcore.gathering.gathering.domain.model.Gathering
-import com.server.dpmcore.gathering.gathering.domain.port.GatheringPersistencePort
+import com.server.dpmcore.gathering.gathering.domain.port.inbound.GatheringCreateUseCase
+import com.server.dpmcore.gathering.gathering.domain.port.inbound.command.GatheringCreateCommand
+import com.server.dpmcore.gathering.gathering.domain.port.outbound.GatheringPersistencePort
 import com.server.dpmcore.gathering.gatheringMember.application.GatheringMemberCommandService
 import com.server.dpmcore.gathering.gatheringReceipt.application.ReceiptCommandService
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
-import java.time.ZoneId
 
 @Service
 @Transactional
@@ -16,7 +17,9 @@ class GatheringCommandService(
     private val gatheringPersistencePort: GatheringPersistencePort,
     private val gatheringMemberCommandService: GatheringMemberCommandService,
     private val receiptCommandService: ReceiptCommandService,
-) {
+    private val billQueryUseCase: BillQueryUseCase,
+) : GatheringCreateUseCase {
+    /*
     fun save(
         bill: Bill,
         gathering: Gathering,
@@ -61,5 +64,23 @@ class GatheringCommandService(
         }
 //        TODO : 벌크 insert 로직 추가
         return gatherings.map { save(bill, it) }.toMutableList()
+    }
+
+
+     */
+
+    override fun saveAllGatherings(
+        commands: List<GatheringCreateCommand>,
+        billId: BillId,
+    ) {
+        try {
+            val bill = billQueryUseCase.getById(billId)
+            commands.forEach {
+                val gathering = gatheringPersistencePort.save(bill, Gathering.create(it))
+                receiptCommandService.saveReceiptDetails(it.receipt, gathering)
+            }
+        } catch (e: Exception) {
+            e.printStackTrace()
+        }
     }
 }

--- a/src/main/kotlin/com/server/dpmcore/gathering/gathering/application/GatheringCommandService.kt
+++ b/src/main/kotlin/com/server/dpmcore/gathering/gathering/application/GatheringCommandService.kt
@@ -37,7 +37,7 @@ class GatheringCommandService(
             )
 
         gathering.gatheringMembers.map { gatheringMember ->
-            gatheringMember.gatheringId = savedGathering
+            gatheringMember.gatheringId = savedGathering.id
         }
         if (gathering.gatheringMembers.isNotEmpty()) {
 //            TODO 준원 : 회식 참여 멤버 저장 로직 추가

--- a/src/main/kotlin/com/server/dpmcore/gathering/gathering/application/GatheringCommandService.kt
+++ b/src/main/kotlin/com/server/dpmcore/gathering/gathering/application/GatheringCommandService.kt
@@ -1,5 +1,6 @@
 package com.server.dpmcore.gathering.gathering.application
 
+import com.server.dpmcore.bill.bill.domain.model.Bill
 import com.server.dpmcore.bill.exception.BillException
 import com.server.dpmcore.gathering.gathering.domain.model.Gathering
 import com.server.dpmcore.gathering.gathering.domain.port.GatheringPersistencePort
@@ -16,10 +17,14 @@ class GatheringCommandService(
     private val gatheringMemberCommandService: GatheringMemberCommandService,
     private val receiptCommandService: ReceiptCommandService,
 ) {
-    fun save(gathering: Gathering): Gathering {
+    fun save(
+        bill: Bill,
+        gathering: Gathering,
+    ): Gathering {
         val savedGathering =
             gatheringPersistencePort.save(
 //                TODO : 팩토리 도입하기
+                bill,
                 Gathering(
                     title = gathering.title,
                     description = gathering.description,
@@ -27,12 +32,12 @@ class GatheringCommandService(
                     category = gathering.category,
                     hostUserId = gathering.hostUserId,
                     roundNumber = gathering.roundNumber,
-                    bill = gathering.bill,
+                    billId = gathering.billId,
                 ),
             )
 
         gathering.gatheringMembers.map { gatheringMember ->
-            gatheringMember.gathering = savedGathering
+            gatheringMember.gatheringId = savedGathering
         }
         if (gathering.gatheringMembers.isNotEmpty()) {
 //            TODO 준원 : 회식 참여 멤버 저장 로직 추가
@@ -47,11 +52,14 @@ class GatheringCommandService(
         return savedGathering
     }
 
-    fun save(gatherings: MutableList<Gathering>): MutableList<Gathering> {
+    fun save(
+        bill: Bill,
+        gatherings: MutableList<Gathering>,
+    ): MutableList<Gathering> {
         if (gatherings.isEmpty()) {
             throw BillException.GatheringRequiredException()
         }
 //        TODO : 벌크 insert 로직 추가
-        return gatherings.map { save(it) }.toMutableList()
+        return gatherings.map { save(bill, it) }.toMutableList()
     }
 }

--- a/src/main/kotlin/com/server/dpmcore/gathering/gathering/application/GatheringQueryService.kt
+++ b/src/main/kotlin/com/server/dpmcore/gathering/gathering/application/GatheringQueryService.kt
@@ -1,0 +1,15 @@
+package com.server.dpmcore.gathering.gathering.application
+
+import com.server.dpmcore.gathering.gathering.infrastructure.repository.GatheringRepository
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+@Transactional(readOnly = true)
+class GatheringQueryService(
+    private val gatheringRepository: GatheringRepository,
+) {
+    fun findById(gatheringId: Long) =
+        gatheringRepository
+            .findById(gatheringId)
+}

--- a/src/main/kotlin/com/server/dpmcore/gathering/gathering/domain/model/Gathering.kt
+++ b/src/main/kotlin/com/server/dpmcore/gathering/gathering/domain/model/Gathering.kt
@@ -1,6 +1,6 @@
 package com.server.dpmcore.gathering.gathering.domain.model
 
-import com.server.dpmcore.bill.bill.domain.model.Bill
+import com.server.dpmcore.bill.bill.domain.model.BillId
 import com.server.dpmcore.gathering.gatheringMember.domain.model.GatheringMember
 import com.server.dpmcore.gathering.gatheringReceipt.domain.model.Receipt
 import com.server.dpmcore.member.member.domain.model.MemberId
@@ -29,7 +29,7 @@ class Gathering(
     val createdAt: Instant? = null,
     val updatedAt: Instant? = null,
     val deletedAt: Instant? = null,
-    var bill: Bill? = null,
+    var billId: BillId? = null,
     var gatheringMembers: MutableList<GatheringMember> = mutableListOf(),
     var receipt: Receipt? = null,
 ) {
@@ -54,5 +54,5 @@ class Gathering(
     override fun hashCode(): Int = id?.hashCode() ?: 0
 
     override fun toString(): String =
-        "Gathering(id=$id, title='$title', description=$description, heldAt=$heldAt, category=$category, hostUserId=$hostUserId, roundNumber=$roundNumber, createdAt=$createdAt, updatedAt=$updatedAt, deletedAt=$deletedAt, bill=$bill, gatheringMembers=$gatheringMembers)"
+        "Gathering(id=$id, title='$title', description=$description, heldAt=$heldAt, category=$category, hostUserId=$hostUserId, roundNumber=$roundNumber, createdAt=$createdAt, updatedAt=$updatedAt, deletedAt=$deletedAt, bill=$billId, gatheringMembers=$gatheringMembers)"
 }

--- a/src/main/kotlin/com/server/dpmcore/gathering/gathering/domain/model/Gathering.kt
+++ b/src/main/kotlin/com/server/dpmcore/gathering/gathering/domain/model/Gathering.kt
@@ -1,10 +1,12 @@
 package com.server.dpmcore.gathering.gathering.domain.model
 
 import com.server.dpmcore.bill.bill.domain.model.BillId
+import com.server.dpmcore.gathering.gathering.domain.port.inbound.command.GatheringCreateCommand
 import com.server.dpmcore.gathering.gatheringMember.domain.model.GatheringMember
 import com.server.dpmcore.gathering.gatheringReceipt.domain.model.Receipt
 import com.server.dpmcore.member.member.domain.model.MemberId
 import java.time.Instant
+import java.time.ZoneId
 
 /**
  * 회식 차수(Gathering)를 표현하는 도메인 모델입니다.
@@ -27,12 +29,21 @@ class Gathering(
     val hostUserId: MemberId,
     val roundNumber: Int,
     val createdAt: Instant? = null,
-    val updatedAt: Instant? = null,
-    val deletedAt: Instant? = null,
-    var billId: BillId? = null,
+    updatedAt: Instant? = null,
+    deletedAt: Instant? = null,
+    billId: BillId? = null,
     var gatheringMembers: MutableList<GatheringMember> = mutableListOf(),
     var receipt: Receipt? = null,
 ) {
+    var updatedAt: Instant? = updatedAt
+        private set
+
+    var deletedAt: Instant? = deletedAt
+        private set
+
+    var billId: BillId? = billId
+        private set
+
     fun isDeleted(): Boolean = deletedAt != null
 
     fun getGatheringJoinMemberCount() =
@@ -45,6 +56,11 @@ class Gathering(
             gatheringMember.isChecked
         }
 
+    fun addGatheringReceipt(receipt: Receipt) {
+        this.receipt = receipt
+        this.receipt?.gathering = this
+    }
+
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
         if (other !is Gathering) return false
@@ -54,5 +70,20 @@ class Gathering(
     override fun hashCode(): Int = id?.hashCode() ?: 0
 
     override fun toString(): String =
-        "Gathering(id=$id, title='$title', description=$description, heldAt=$heldAt, category=$category, hostUserId=$hostUserId, roundNumber=$roundNumber, createdAt=$createdAt, updatedAt=$updatedAt, deletedAt=$deletedAt, bill=$billId, gatheringMembers=$gatheringMembers)"
+        "Gathering(id=$id, title='$title', description=$description, heldAt=$heldAt, category=$category, " +
+            "hostUserId=$hostUserId, roundNumber=$roundNumber, createdAt=$createdAt, updatedAt=$updatedAt, " +
+            "deletedAt=$deletedAt, bill=$billId, gatheringMembers=$gatheringMembers)"
+
+    companion object {
+        fun create(command: GatheringCreateCommand): Gathering =
+            Gathering(
+                title = command.title,
+                description = command.description,
+                heldAt = command.heldAt.atZone(ZoneId.of("Asia/Seoul")).toInstant(),
+                hostUserId = command.hostUserId,
+                roundNumber = command.roundNumber,
+                createdAt = Instant.now(),
+                updatedAt = Instant.now(),
+            )
+    }
 }

--- a/src/main/kotlin/com/server/dpmcore/gathering/gathering/domain/port/GatheringPersistencePort.kt
+++ b/src/main/kotlin/com/server/dpmcore/gathering/gathering/domain/port/GatheringPersistencePort.kt
@@ -1,9 +1,15 @@
 package com.server.dpmcore.gathering.gathering.domain.port
 
+import com.server.dpmcore.bill.bill.domain.model.Bill
 import com.server.dpmcore.gathering.gathering.domain.model.Gathering
 
 interface GatheringPersistencePort {
     fun findGatheringById(id: Long): Gathering
 
-    fun save(gathering: Gathering): Gathering
+    fun save(
+        bill: Bill,
+        gathering: Gathering,
+    ): Gathering
+
+    fun findById(id: Long): Gathering
 }

--- a/src/main/kotlin/com/server/dpmcore/gathering/gathering/domain/port/inbound/GatheringCreateUseCase.kt
+++ b/src/main/kotlin/com/server/dpmcore/gathering/gathering/domain/port/inbound/GatheringCreateUseCase.kt
@@ -1,0 +1,11 @@
+package com.server.dpmcore.gathering.gathering.domain.port.inbound
+
+import com.server.dpmcore.bill.bill.domain.model.BillId
+import com.server.dpmcore.gathering.gathering.domain.port.inbound.command.GatheringCreateCommand
+
+interface GatheringCreateUseCase {
+    fun saveAllGatherings(
+        commands: List<GatheringCreateCommand>,
+        billId: BillId,
+    )
+}

--- a/src/main/kotlin/com/server/dpmcore/gathering/gathering/domain/port/inbound/command/GatheringCreateCommand.kt
+++ b/src/main/kotlin/com/server/dpmcore/gathering/gathering/domain/port/inbound/command/GatheringCreateCommand.kt
@@ -1,0 +1,31 @@
+package com.server.dpmcore.gathering.gathering.domain.port.inbound.command
+
+import com.server.dpmcore.member.member.domain.model.MemberId
+import jakarta.validation.constraints.NotEmpty
+import java.time.LocalDateTime
+
+data class GatheringCreateCommand(
+    val title: String,
+    val description: String?,
+    val hostUserId: MemberId,
+    val roundNumber: Int,
+    val heldAt: LocalDateTime,
+    val receipt: ReceiptCommand,
+    @NotEmpty val members: List<GatheringMemberCommand>,
+)
+
+data class ReceiptCommand(
+    val amount: Int,
+    val photos: List<ReceiptPhotoCommand>,
+)
+
+data class ReceiptPhotoCommand(
+    val receiptId: Long,
+    val photoUrl: String?,
+)
+
+data class GatheringMemberCommand(
+    val memberId: Long,
+    val isJoined: Boolean = true,
+    val isCompleted: Boolean = false,
+)

--- a/src/main/kotlin/com/server/dpmcore/gathering/gathering/domain/port/outbound/GatheringPersistencePort.kt
+++ b/src/main/kotlin/com/server/dpmcore/gathering/gathering/domain/port/outbound/GatheringPersistencePort.kt
@@ -1,4 +1,4 @@
-package com.server.dpmcore.gathering.gathering.domain.port
+package com.server.dpmcore.gathering.gathering.domain.port.outbound
 
 import com.server.dpmcore.bill.bill.domain.model.Bill
 import com.server.dpmcore.gathering.gathering.domain.model.Gathering
@@ -12,4 +12,9 @@ interface GatheringPersistencePort {
     ): Gathering
 
     fun findById(id: Long): Gathering
+
+    fun saveAll(
+        bill: Bill,
+        gatherings: List<Gathering>,
+    )
 }

--- a/src/main/kotlin/com/server/dpmcore/gathering/gathering/infrastructure/entity/GatheringEntity.kt
+++ b/src/main/kotlin/com/server/dpmcore/gathering/gathering/infrastructure/entity/GatheringEntity.kt
@@ -12,8 +12,10 @@ import com.server.dpmcore.gathering.gatheringReceipt.infrastructure.entity.Recei
 import com.server.dpmcore.member.member.domain.model.MemberId
 import jakarta.persistence.CascadeType
 import jakarta.persistence.Column
+import jakarta.persistence.ConstraintMode
 import jakarta.persistence.Entity
 import jakarta.persistence.FetchType
+import jakarta.persistence.ForeignKey
 import jakarta.persistence.GeneratedValue
 import jakarta.persistence.GenerationType
 import jakarta.persistence.Id
@@ -30,7 +32,7 @@ class GatheringEntity(
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "gathering_id", nullable = false, updatable = false)
-    val id: Long = 0,
+    val id: Long,
     @Column(name = "title", nullable = false)
     val title: String,
     @Column(name = "description")
@@ -50,7 +52,7 @@ class GatheringEntity(
     @Column(name = "deleted_at")
     val deletedAt: Instant? = null,
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "bill_id", nullable = false)
+    @JoinColumn(name = "bill_id", foreignKey = ForeignKey(ConstraintMode.NO_CONSTRAINT))
     val bill: BillEntity? = null,
     @OneToMany(mappedBy = "gathering", fetch = FetchType.LAZY, cascade = [CascadeType.ALL], orphanRemoval = true)
     val gatheringMembers: MutableList<GatheringMemberEntity> = mutableListOf(),

--- a/src/main/kotlin/com/server/dpmcore/gathering/gathering/infrastructure/entity/GatheringEntity.kt
+++ b/src/main/kotlin/com/server/dpmcore/gathering/gathering/infrastructure/entity/GatheringEntity.kt
@@ -1,5 +1,7 @@
 package com.server.dpmcore.gathering.gathering.infrastructure.entity
 
+import com.server.dpmcore.bill.bill.domain.model.Bill
+import com.server.dpmcore.bill.bill.domain.model.BillId
 import com.server.dpmcore.bill.bill.infrastructure.entity.BillEntity
 import com.server.dpmcore.gathering.gathering.domain.model.Gathering
 import com.server.dpmcore.gathering.gathering.domain.model.GatheringCategory
@@ -55,7 +57,10 @@ class GatheringEntity(
     val receipt: ReceiptEntity? = null,
 ) {
     companion object {
-        fun from(gathering: Gathering): GatheringEntity =
+        fun from(
+            bill: Bill,
+            gathering: Gathering,
+        ): GatheringEntity =
             GatheringEntity(
                 id = gathering.id?.value ?: 0L,
                 title = gathering.title,
@@ -67,7 +72,7 @@ class GatheringEntity(
                 createdAt = gathering.createdAt ?: Instant.now(),
                 updatedAt = gathering.updatedAt ?: Instant.now(),
                 deletedAt = gathering.deletedAt,
-                bill = BillEntity.from(gathering.bill!!),
+                bill = BillEntity.from(bill),
                 receipt = gathering.receipt?.let { ReceiptEntity.from(it) },
             )
     }
@@ -84,7 +89,7 @@ class GatheringEntity(
             createdAt = createdAt,
             updatedAt = updatedAt,
             deletedAt = deletedAt,
-            bill = bill.toDomain(),
+            billId = BillId(bill.id),
             gatheringMembers = gatheringMembers.map { it.toDomain() }.toMutableList(),
             receipt = receipt?.toDomain(),
         )

--- a/src/main/kotlin/com/server/dpmcore/gathering/gathering/infrastructure/repository/GatheringRepository.kt
+++ b/src/main/kotlin/com/server/dpmcore/gathering/gathering/infrastructure/repository/GatheringRepository.kt
@@ -2,6 +2,8 @@ package com.server.dpmcore.gathering.gathering.infrastructure.repository
 
 import com.linecorp.kotlinjdsl.spring.data.SpringDataQueryFactory
 import com.linecorp.kotlinjdsl.spring.data.singleQuery
+import com.server.dpmcore.bill.bill.domain.model.Bill
+import com.server.dpmcore.bill.exception.BillException
 import com.server.dpmcore.gathering.gathering.domain.model.Gathering
 import com.server.dpmcore.gathering.gathering.domain.port.GatheringPersistencePort
 import com.server.dpmcore.gathering.gathering.infrastructure.entity.GatheringEntity
@@ -12,8 +14,10 @@ class GatheringRepository(
     private val gatheringJpaRepository: GatheringJpaRepository,
     private val queryFactory: SpringDataQueryFactory,
 ) : GatheringPersistencePort {
-    override fun save(gathering: Gathering): Gathering =
-        gatheringJpaRepository.save(GatheringEntity.from(gathering)).toDomain()
+    override fun save(
+        bill: Bill,
+        gathering: Gathering,
+    ): Gathering = gatheringJpaRepository.save(GatheringEntity.from(bill, gathering)).toDomain()
 
     override fun findGatheringById(id: Long) =
         queryFactory
@@ -22,4 +26,10 @@ class GatheringRepository(
                 from(entity(GatheringEntity::class))
 //                where(GatheringEntity::id id)
             }.toDomain()
+
+    override fun findById(id: Long): Gathering =
+        gatheringJpaRepository
+            .findById(id)
+            .orElseThrow { BillException.GatheringNotFoundException() }
+            .toDomain()
 }

--- a/src/main/kotlin/com/server/dpmcore/gathering/gathering/infrastructure/repository/GatheringRepository.kt
+++ b/src/main/kotlin/com/server/dpmcore/gathering/gathering/infrastructure/repository/GatheringRepository.kt
@@ -5,7 +5,7 @@ import com.linecorp.kotlinjdsl.spring.data.singleQuery
 import com.server.dpmcore.bill.bill.domain.model.Bill
 import com.server.dpmcore.bill.exception.BillException
 import com.server.dpmcore.gathering.gathering.domain.model.Gathering
-import com.server.dpmcore.gathering.gathering.domain.port.GatheringPersistencePort
+import com.server.dpmcore.gathering.gathering.domain.port.outbound.GatheringPersistencePort
 import com.server.dpmcore.gathering.gathering.infrastructure.entity.GatheringEntity
 import org.springframework.stereotype.Repository
 
@@ -32,4 +32,14 @@ class GatheringRepository(
             .findById(id)
             .orElseThrow { BillException.GatheringNotFoundException() }
             .toDomain()
+
+    override fun saveAll(
+        bill: Bill,
+        gatherings: List<Gathering>,
+    ) {
+        gatheringJpaRepository
+            .saveAll(
+                gatherings.map { GatheringEntity.from(bill, it) },
+            ).map { it.toDomain() }
+    }
 }

--- a/src/main/kotlin/com/server/dpmcore/gathering/gathering/presentation/mapper/GatheringMapper.kt
+++ b/src/main/kotlin/com/server/dpmcore/gathering/gathering/presentation/mapper/GatheringMapper.kt
@@ -1,5 +1,6 @@
 package com.server.dpmcore.gathering.gathering.presentation.mapper
 
+import com.server.dpmcore.bill.bill.domain.model.BillId
 import com.server.dpmcore.bill.bill.presentation.dto.request.CreateGatheringRequest
 import com.server.dpmcore.bill.bill.presentation.dto.response.CreateGatheringResponse
 import com.server.dpmcore.gathering.gathering.domain.model.Gathering
@@ -13,7 +14,10 @@ import java.time.LocalDateTime
 import java.time.ZoneId
 
 object GatheringMapper {
-    fun toGathering(createGatheringRequest: CreateGatheringRequest): Gathering =
+    fun toGathering(
+        createGatheringRequest: CreateGatheringRequest,
+        billId: BillId,
+    ): Gathering =
         Gathering(
             title = createGatheringRequest.title,
             description = createGatheringRequest.description,
@@ -21,6 +25,7 @@ object GatheringMapper {
             heldAt = createGatheringRequest.heldAt.atZone(ZoneId.of("Asia/Seoul")).toInstant(),
             category = GatheringCategory.valueOf(createGatheringRequest.category),
             roundNumber = createGatheringRequest.roundNumber,
+            billId = billId,
             gatheringMembers =
                 createGatheringRequest.gatheringMembers
                     ?.map { gatheringMember ->

--- a/src/main/kotlin/com/server/dpmcore/gathering/gathering/presentation/mapper/GatheringMapper.kt
+++ b/src/main/kotlin/com/server/dpmcore/gathering/gathering/presentation/mapper/GatheringMapper.kt
@@ -1,39 +1,36 @@
 package com.server.dpmcore.gathering.gathering.presentation.mapper
 
-import com.server.dpmcore.bill.bill.domain.model.BillId
-import com.server.dpmcore.bill.bill.presentation.dto.request.CreateGatheringRequest
 import com.server.dpmcore.bill.bill.presentation.dto.response.CreateGatheringResponse
 import com.server.dpmcore.gathering.gathering.domain.model.Gathering
-import com.server.dpmcore.gathering.gathering.domain.model.GatheringCategory
 import com.server.dpmcore.gathering.gatheringMember.presentation.mapper.GatheringMemberMapper.toCreateGatheringMemberResponse
-import com.server.dpmcore.gathering.gatheringMember.presentation.mapper.GatheringMemberMapper.toGatheringMember
 import com.server.dpmcore.gathering.gatheringReceipt.presentation.mapper.ReceiptMapper.toCreateReceiptResponse
-import com.server.dpmcore.gathering.gatheringReceipt.presentation.mapper.ReceiptMapper.toReceipt
-import com.server.dpmcore.member.member.domain.model.MemberId
 import java.time.LocalDateTime
 import java.time.ZoneId
 
 object GatheringMapper {
+    /*
     fun toGathering(
-        createGatheringRequest: CreateGatheringRequest,
+        gatheringForBillCreateRequest: GatheringForBillCreateRequest,
         billId: BillId,
     ): Gathering =
         Gathering(
-            title = createGatheringRequest.title,
-            description = createGatheringRequest.description,
-            hostUserId = MemberId(createGatheringRequest.hostUserId),
-            heldAt = createGatheringRequest.heldAt.atZone(ZoneId.of("Asia/Seoul")).toInstant(),
-            category = GatheringCategory.valueOf(createGatheringRequest.category),
-            roundNumber = createGatheringRequest.roundNumber,
+            title = gatheringForBillCreateRequest.title,
+            description = gatheringForBillCreateRequest.description,
+            hostUserId = MemberId(gatheringForBillCreateRequest.hostUserId),
+            heldAt = gatheringForBillCreateRequest.heldAt.atZone(ZoneId.of("Asia/Seoul")).toInstant(),
+            category = GatheringCategory.valueOf(gatheringForBillCreateRequest.category),
+            roundNumber = gatheringForBillCreateRequest.roundNumber,
             billId = billId,
             gatheringMembers =
-                createGatheringRequest.gatheringMembers
+                gatheringForBillCreateRequest.gatheringMembers
                     ?.map { gatheringMember ->
                         toGatheringMember(gatheringMember)
                     }?.toMutableList() ?: mutableListOf(),
-            receipt = toReceipt(createGatheringRequest.receipt),
+            receipt = toReceipt(gatheringForBillCreateRequest.receipt),
         )
 
+
+     */
     fun toCreateGatheringResponse(gathering: Gathering): CreateGatheringResponse =
         CreateGatheringResponse(
             title = gathering.title,

--- a/src/main/kotlin/com/server/dpmcore/gathering/gatheringMember/domain/model/GatheringMember.kt
+++ b/src/main/kotlin/com/server/dpmcore/gathering/gatheringMember/domain/model/GatheringMember.kt
@@ -1,6 +1,6 @@
 package com.server.dpmcore.gathering.gatheringMember.domain.model
 
-import com.server.dpmcore.gathering.gathering.domain.model.Gathering
+import com.server.dpmcore.gathering.gathering.domain.model.GatheringId
 import com.server.dpmcore.member.member.domain.model.MemberId
 import java.time.Instant
 
@@ -13,7 +13,7 @@ import java.time.Instant
  */
 class GatheringMember(
     val id: GatheringMemberId? = null,
-    var gathering: Gathering? = null,
+    var gatheringId: GatheringId? = null,
     val memberId: MemberId,
     val isChecked: Boolean = false,
     val isJoined: Boolean = false,
@@ -39,7 +39,7 @@ class GatheringMember(
 
         return GatheringMember(
             id = id,
-            gathering = gathering,
+            gatheringId = gatheringId,
             memberId = memberId,
             isChecked = true,
             completedAt = now,

--- a/src/main/kotlin/com/server/dpmcore/gathering/gatheringMember/infrastructure/entity/GatheringMemberEntity.kt
+++ b/src/main/kotlin/com/server/dpmcore/gathering/gatheringMember/infrastructure/entity/GatheringMemberEntity.kt
@@ -1,5 +1,7 @@
 package com.server.dpmcore.gathering.gatheringMember.infrastructure.entity
 
+import com.server.dpmcore.bill.exception.BillException
+import com.server.dpmcore.gathering.gathering.domain.model.GatheringId
 import com.server.dpmcore.gathering.gathering.infrastructure.entity.GatheringEntity
 import com.server.dpmcore.gathering.gatheringMember.domain.model.GatheringMember
 import com.server.dpmcore.gathering.gatheringMember.domain.model.GatheringMemberId
@@ -24,7 +26,7 @@ class GatheringMemberEntity(
     val id: Long = 0,
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "gathering_id", nullable = false)
-    val gathering: GatheringEntity,
+    val gathering: GatheringEntity? = null,
     @Column(name = "member_id", nullable = false)
     val memberId: Long,
     @Column(name = "is_checked", nullable = false)
@@ -44,7 +46,6 @@ class GatheringMemberEntity(
         fun from(gatheringMember: GatheringMember): GatheringMemberEntity =
             GatheringMemberEntity(
                 id = gatheringMember.id?.value ?: 0L,
-                gathering = GatheringEntity.from(gatheringMember.gathering!!),
                 memberId = gatheringMember.memberId.value,
                 isChecked = gatheringMember.isChecked,
                 isJoined = gatheringMember.isJoined,
@@ -58,7 +59,7 @@ class GatheringMemberEntity(
     fun toDomain(): GatheringMember =
         GatheringMember(
             id = GatheringMemberId(id),
-            gathering = gathering.toDomain(),
+            gatheringId = GatheringId(gathering?.id ?: throw BillException.GatheringNotFoundException()),
             memberId = MemberId(memberId),
             isChecked = isChecked,
             isJoined = isJoined,

--- a/src/main/kotlin/com/server/dpmcore/gathering/gatheringMember/presentation/mapper/GatheringMemberMapper.kt
+++ b/src/main/kotlin/com/server/dpmcore/gathering/gatheringMember/presentation/mapper/GatheringMemberMapper.kt
@@ -1,16 +1,16 @@
 package com.server.dpmcore.gathering.gatheringMember.presentation.mapper
 
-import com.server.dpmcore.bill.bill.presentation.dto.request.CreateGatheringMemberRequest
+import com.server.dpmcore.bill.bill.presentation.dto.request.GatheringMemberForBillCreateRequest
 import com.server.dpmcore.bill.bill.presentation.dto.response.CreateGatheringMemberResponse
 import com.server.dpmcore.gathering.gatheringMember.domain.model.GatheringMember
 import com.server.dpmcore.member.member.domain.model.MemberId
 
 object GatheringMemberMapper {
-    fun toGatheringMember(createGatheringMemberRequest: CreateGatheringMemberRequest): GatheringMember =
+    fun toGatheringMember(gatheringMemberForBillCreateRequest: GatheringMemberForBillCreateRequest): GatheringMember =
         GatheringMember(
-            memberId = MemberId(createGatheringMemberRequest.memberId),
-            isChecked = createGatheringMemberRequest.isCompleted,
-            isJoined = createGatheringMemberRequest.isJoined,
+            memberId = MemberId(gatheringMemberForBillCreateRequest.memberId),
+            isChecked = gatheringMemberForBillCreateRequest.isCompleted,
+            isJoined = gatheringMemberForBillCreateRequest.isJoined,
         )
 
     fun toCreateGatheringMemberResponse(gatheringMember: GatheringMember): CreateGatheringMemberResponse =

--- a/src/main/kotlin/com/server/dpmcore/gathering/gatheringReceipt/application/ReceiptCommandService.kt
+++ b/src/main/kotlin/com/server/dpmcore/gathering/gatheringReceipt/application/ReceiptCommandService.kt
@@ -1,5 +1,7 @@
 package com.server.dpmcore.gathering.gatheringReceipt.application
 
+import com.server.dpmcore.gathering.gathering.domain.model.Gathering
+import com.server.dpmcore.gathering.gathering.domain.port.inbound.command.ReceiptCommand
 import com.server.dpmcore.gathering.gatheringReceipt.domain.model.Receipt
 import com.server.dpmcore.gathering.gatheringReceipt.domain.port.ReceiptPersistencePort
 import org.springframework.stereotype.Service
@@ -10,6 +12,9 @@ import org.springframework.transaction.annotation.Transactional
 class ReceiptCommandService(
     private val receiptPersistencePort: ReceiptPersistencePort,
 ) {
-//    TODO 준원 : 영수증 사진 저장 로직 추가
-    fun save(receipt: Receipt): Receipt = receiptPersistencePort.save(receipt)
+    //    TODO 준원 : 영수증 사진 저장 로직 추가
+    fun saveReceiptDetails(
+        receipt: ReceiptCommand,
+        gathering: Gathering,
+    ) = receiptPersistencePort.save(Receipt.create(receipt, gathering))
 }

--- a/src/main/kotlin/com/server/dpmcore/gathering/gatheringReceipt/domain/model/Receipt.kt
+++ b/src/main/kotlin/com/server/dpmcore/gathering/gatheringReceipt/domain/model/Receipt.kt
@@ -1,6 +1,7 @@
 package com.server.dpmcore.gathering.gatheringReceipt.domain.model
 
 import com.server.dpmcore.gathering.gathering.domain.model.Gathering
+import com.server.dpmcore.gathering.gathering.domain.port.inbound.command.ReceiptCommand
 import com.server.dpmcore.gathering.gatheringReceiptPhoto.domain.model.ReceiptPhoto
 import java.time.Instant
 
@@ -16,11 +17,17 @@ class Receipt(
     val splitAmount: Int? = null,
     val amount: Int,
     val createdAt: Instant? = null,
-    val updatedAt: Instant? = null,
-    val deletedAt: Instant? = null,
+    updatedAt: Instant? = null,
+    deletedAt: Instant? = null,
     val receiptPhotos: MutableList<ReceiptPhoto>? = mutableListOf(),
     var gathering: Gathering? = null,
 ) {
+    var updatedAt: Instant? = updatedAt
+        private set
+
+    var deletedAt: Instant? = deletedAt
+        private set
+
     fun isDeleted(): Boolean = deletedAt != null
 
     override fun equals(other: Any?): Boolean {
@@ -32,5 +39,17 @@ class Receipt(
     override fun hashCode(): Int = id?.hashCode() ?: 0
 
     override fun toString(): String =
-        "Receipt(id=$id, splitAmount=$splitAmount, amount=$amount, createdAt=$createdAt, updatedAt=$updatedAt, deletedAt=$deletedAt, receiptPhotos=$receiptPhotos, gathering=$gathering)"
+        "Receipt(id=$id, splitAmount=$splitAmount, amount=$amount, createdAt=$createdAt, updatedAt=$updatedAt, " +
+            "deletedAt=$deletedAt, receiptPhotos=$receiptPhotos, gathering=$gathering)"
+
+    companion object {
+        fun create(
+            receiptCommand: ReceiptCommand,
+            gathering: Gathering,
+        ): Receipt =
+            Receipt(
+                amount = receiptCommand.amount,
+                gathering = gathering,
+            )
+    }
 }

--- a/src/main/kotlin/com/server/dpmcore/gathering/gatheringReceipt/domain/port/ReceiptPersistencePort.kt
+++ b/src/main/kotlin/com/server/dpmcore/gathering/gatheringReceipt/domain/port/ReceiptPersistencePort.kt
@@ -3,5 +3,5 @@ package com.server.dpmcore.gathering.gatheringReceipt.domain.port
 import com.server.dpmcore.gathering.gatheringReceipt.domain.model.Receipt
 
 interface ReceiptPersistencePort {
-    fun save(receipt: Receipt): Receipt
+    fun save(receipt: Receipt)
 }

--- a/src/main/kotlin/com/server/dpmcore/gathering/gatheringReceipt/infrastructure/repository/ReceiptRepository.kt
+++ b/src/main/kotlin/com/server/dpmcore/gathering/gatheringReceipt/infrastructure/repository/ReceiptRepository.kt
@@ -9,5 +9,7 @@ import org.springframework.stereotype.Repository
 class ReceiptRepository(
     private val receiptJpaRepository: ReceiptJpaRepository,
 ) : ReceiptPersistencePort {
-    override fun save(receipt: Receipt): Receipt = receiptJpaRepository.save(ReceiptEntity.from(receipt)).toDomain()
+    override fun save(receipt: Receipt) {
+        receiptJpaRepository.save(ReceiptEntity.from(receipt))
+    }
 }

--- a/src/main/kotlin/com/server/dpmcore/gathering/gatheringReceipt/presentation/mapper/ReceiptMapper.kt
+++ b/src/main/kotlin/com/server/dpmcore/gathering/gatheringReceipt/presentation/mapper/ReceiptMapper.kt
@@ -1,6 +1,6 @@
 package com.server.dpmcore.gathering.gatheringReceipt.presentation.mapper
 
-import com.server.dpmcore.bill.bill.presentation.dto.request.CreateReceiptRequest
+import com.server.dpmcore.bill.bill.presentation.dto.request.ReceiptForBillCreateRequest
 import com.server.dpmcore.bill.bill.presentation.dto.response.CreateReceiptResponse
 import com.server.dpmcore.gathering.gatheringReceipt.domain.model.Receipt
 import com.server.dpmcore.gathering.gatheringReceiptPhoto.presentation.mapper.ReceiptPhotoMapper.toReceiptPhoto
@@ -8,9 +8,9 @@ import com.server.dpmcore.gathering.gatheringReceiptPhoto.presentation.mapper.Re
 object ReceiptMapper {
     fun toCreateReceiptResponse(receipt: Receipt): CreateReceiptResponse = CreateReceiptResponse()
 
-    fun toReceipt(createReceiptRequest: CreateReceiptRequest): Receipt =
+    fun toReceipt(receiptForBillCreateRequest: ReceiptForBillCreateRequest): Receipt =
         Receipt(
-            amount = createReceiptRequest.amount,
-            receiptPhotos = createReceiptRequest.receiptPhotos?.map { toReceiptPhoto(it) }?.toMutableList(),
+            amount = receiptForBillCreateRequest.amount,
+            receiptPhotos = receiptForBillCreateRequest.receiptPhotos?.map { toReceiptPhoto(it) }?.toMutableList(),
         )
 }

--- a/src/main/kotlin/com/server/dpmcore/gathering/gatheringReceiptPhoto/presentation/mapper/ReceiptPhotoMapper.kt
+++ b/src/main/kotlin/com/server/dpmcore/gathering/gatheringReceiptPhoto/presentation/mapper/ReceiptPhotoMapper.kt
@@ -1,8 +1,9 @@
 package com.server.dpmcore.gathering.gatheringReceiptPhoto.presentation.mapper
 
-import com.server.dpmcore.bill.bill.presentation.dto.request.CreateReceiptPhotoRequest
+import com.server.dpmcore.bill.bill.presentation.dto.request.ReceiptPhotoForBillCreateRequest
 import com.server.dpmcore.gathering.gatheringReceiptPhoto.domain.model.ReceiptPhoto
 
 object ReceiptPhotoMapper {
-    fun toReceiptPhoto(createReceiptPhotoRequest: CreateReceiptPhotoRequest): ReceiptPhoto = ReceiptPhoto()
+    fun toReceiptPhoto(receiptPhotoForBillCreateRequest: ReceiptPhotoForBillCreateRequest): ReceiptPhoto =
+        ReceiptPhoto()
 }


### PR DESCRIPTION
## Summary

>- 관련 있는 Issue를 태그해주세요.

<!-- 해당 PR에 대한 요약을 작성해주세요. -->

## Tasks

- Bill, Gathering 순환 참조 문제 해결
  - 도메인 단에서 도메인 직접 참조 -> Id 값만 참조하도록 수정

## ETC

<!-- 추가적인 정보나 참고 사항을 작성해주세요. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 정산 및 회식 조회를 위한 서비스가 추가되었습니다.
  * 정산 및 회식이 존재하지 않을 때를 처리하는 예외가 추가되었습니다.
  * 정산 및 회식 생성 시 요청 DTO와 커맨드 객체 간 매핑 기능이 도입되었습니다.
  * 정산 생성 응답이 정산 ID만 포함하는 간소화된 형태로 변경되었습니다.

* **기능 개선**
  * 정산과 회식, 회식 멤버 간의 관계가 ID 기반으로 변경되어 데이터 처리 방식이 개선되었습니다.
  * 정산 상태 문자열 변환 기능이 추가되었습니다.
  * 정산 생성 시 회식 정보가 응답에 포함되지 않고, 내부 처리 로직이 분리되어 효율성이 향상되었습니다.
  * 회식 및 영수증 저장 로직이 커맨드 패턴과 서비스 계층 중심으로 재구성되었습니다.
  * 일부 오류 코드 및 예외 메시지가 명확하게 수정되었습니다.

* **기타**
  * 관련 DTO 및 매퍼 클래스 명칭과 구조가 변경되어 요청 및 응답 데이터 모델이 정비되었습니다.
  * 기존 일부 인터페이스 및 메서드가 제거되거나 통합되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->