### PR TITLE
feat: 세션 생성 이벤트 발행 및 구독을 통한 출석부 생성 구현

### DIFF
--- a/src/main/kotlin/com/server/dpmcore/attendance/application/AttendanceCommandService.kt
+++ b/src/main/kotlin/com/server/dpmcore/attendance/application/AttendanceCommandService.kt
@@ -1,12 +1,17 @@
 package com.server.dpmcore.attendance.application
 
 import com.server.dpmcore.attendance.domain.exception.AttendanceNotFoundException
+import com.server.dpmcore.attendance.domain.model.Attendance
 import com.server.dpmcore.attendance.domain.model.AttendanceStatus
+import com.server.dpmcore.attendance.domain.port.inbound.command.AttendanceCreateCommand
 import com.server.dpmcore.attendance.domain.port.inbound.command.AttendanceRecordCommand
 import com.server.dpmcore.attendance.domain.port.inbound.command.AttendanceStatusUpdateCommand
 import com.server.dpmcore.attendance.domain.port.outbound.AttendancePersistencePort
+import com.server.dpmcore.cohort.application.config.CohortProperties
+import com.server.dpmcore.member.member.application.MemberService
 import com.server.dpmcore.session.application.SessionQueryService
 import com.server.dpmcore.session.domain.exception.CheckedAttendanceException
+import com.server.dpmcore.session.domain.model.SessionId
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
@@ -15,6 +20,8 @@ import org.springframework.transaction.annotation.Transactional
 class AttendanceCommandService(
     private val attendancePersistencePort: AttendancePersistencePort,
     private val sessionQueryService: SessionQueryService,
+    private val memberService: MemberService,
+    private val cohortProperties: CohortProperties,
 ) {
     fun attendSession(command: AttendanceRecordCommand): AttendanceStatus {
         val attendance =
@@ -45,5 +52,19 @@ class AttendanceCommandService(
 
         attendance.updateStatus(command.attendanceStatus)
         attendancePersistencePort.save(attendance)
+    }
+
+    fun createAttendances(sessionId: SessionId) {
+        val memberIds = memberService.getMembersByCohort(cohortProperties.value)
+
+        val attendances =
+            memberIds
+                .map { memberId ->
+                    Attendance.create(
+                        AttendanceCreateCommand(sessionId, memberId),
+                    )
+                }.toList()
+
+        attendancePersistencePort.saveInBatch(attendances)
     }
 }

--- a/src/main/kotlin/com/server/dpmcore/attendance/application/AttendanceCommandService.kt
+++ b/src/main/kotlin/com/server/dpmcore/attendance/application/AttendanceCommandService.kt
@@ -63,7 +63,7 @@ class AttendanceCommandService(
                     Attendance.create(
                         AttendanceCreateCommand(sessionId, memberId),
                     )
-                }.toList()
+                }
 
         attendancePersistencePort.saveInBatch(attendances)
     }

--- a/src/main/kotlin/com/server/dpmcore/attendance/application/AttendanceCommandService.kt
+++ b/src/main/kotlin/com/server/dpmcore/attendance/application/AttendanceCommandService.kt
@@ -9,6 +9,7 @@ import com.server.dpmcore.attendance.domain.port.inbound.command.AttendanceStatu
 import com.server.dpmcore.attendance.domain.port.outbound.AttendancePersistencePort
 import com.server.dpmcore.cohort.application.config.CohortProperties
 import com.server.dpmcore.member.member.application.MemberService
+import com.server.dpmcore.member.member.domain.exception.CohortMembersNotFoundException
 import com.server.dpmcore.session.application.SessionQueryService
 import com.server.dpmcore.session.domain.exception.CheckedAttendanceException
 import com.server.dpmcore.session.domain.model.SessionId
@@ -56,6 +57,9 @@ class AttendanceCommandService(
 
     fun createAttendances(sessionId: SessionId) {
         val memberIds = memberService.getMembersByCohort(cohortProperties.value)
+        if (memberIds.isEmpty()) {
+            throw CohortMembersNotFoundException()
+        }
 
         val attendances =
             memberIds

--- a/src/main/kotlin/com/server/dpmcore/attendance/application/AttendanceQueryService.kt
+++ b/src/main/kotlin/com/server/dpmcore/attendance/application/AttendanceQueryService.kt
@@ -1,7 +1,7 @@
 package com.server.dpmcore.attendance.application
 
 import com.server.dpmcore.attendance.domain.exception.AttendanceNotFoundException
-import com.server.dpmcore.attendance.domain.port.inbound.query.GetAttendancesBySessionIdQuery
+import com.server.dpmcore.attendance.domain.port.inbound.query.GetAttendancesBySessionWeekQuery
 import com.server.dpmcore.attendance.domain.port.inbound.query.GetDetailAttendanceBySessionQuery
 import com.server.dpmcore.attendance.domain.port.inbound.query.GetDetailMemberAttendancesQuery
 import com.server.dpmcore.attendance.domain.port.inbound.query.GetMemberAttendancesQuery
@@ -26,7 +26,7 @@ class AttendanceQueryService(
     private val attendancePersistencePort: AttendancePersistencePort,
     private val attendanceGraduationEvaluator: AttendanceGraduationEvaluator,
 ) {
-    fun getAttendancesBySession(query: GetAttendancesBySessionIdQuery): SessionAttendancesResponse {
+    fun getAttendancesBySession(query: GetAttendancesBySessionWeekQuery): SessionAttendancesResponse {
         val queryResult =
             attendancePersistencePort
                 .findSessionAttendancesByQuery(query)

--- a/src/main/kotlin/com/server/dpmcore/attendance/domain/port/inbound/query/GetAttendancesBySessionIdQuery.kt
+++ b/src/main/kotlin/com/server/dpmcore/attendance/domain/port/inbound/query/GetAttendancesBySessionIdQuery.kt
@@ -1,10 +1,9 @@
 package com.server.dpmcore.attendance.domain.port.inbound.query
 
 import com.server.dpmcore.attendance.domain.model.AttendanceStatus
-import com.server.dpmcore.session.domain.model.SessionId
 
 data class GetAttendancesBySessionIdQuery(
-    val sessionId: SessionId,
+    val week: Int,
     val statuses: List<AttendanceStatus>?,
     val teams: List<Int>?,
     val name: String?,

--- a/src/main/kotlin/com/server/dpmcore/attendance/domain/port/inbound/query/GetAttendancesBySessionWeekQuery.kt
+++ b/src/main/kotlin/com/server/dpmcore/attendance/domain/port/inbound/query/GetAttendancesBySessionWeekQuery.kt
@@ -2,7 +2,7 @@ package com.server.dpmcore.attendance.domain.port.inbound.query
 
 import com.server.dpmcore.attendance.domain.model.AttendanceStatus
 
-data class GetAttendancesBySessionIdQuery(
+data class GetAttendancesBySessionWeekQuery(
     val week: Int,
     val statuses: List<AttendanceStatus>?,
     val teams: List<Int>?,

--- a/src/main/kotlin/com/server/dpmcore/attendance/domain/port/outbound/AttendancePersistencePort.kt
+++ b/src/main/kotlin/com/server/dpmcore/attendance/domain/port/outbound/AttendancePersistencePort.kt
@@ -7,7 +7,7 @@ import com.server.dpmcore.attendance.application.query.model.MyDetailAttendanceQ
 import com.server.dpmcore.attendance.application.query.model.SessionAttendanceQueryModel
 import com.server.dpmcore.attendance.application.query.model.SessionDetailAttendanceQueryModel
 import com.server.dpmcore.attendance.domain.model.Attendance
-import com.server.dpmcore.attendance.domain.port.inbound.query.GetAttendancesBySessionIdQuery
+import com.server.dpmcore.attendance.domain.port.inbound.query.GetAttendancesBySessionWeekQuery
 import com.server.dpmcore.attendance.domain.port.inbound.query.GetDetailAttendanceBySessionQuery
 import com.server.dpmcore.attendance.domain.port.inbound.query.GetDetailMemberAttendancesQuery
 import com.server.dpmcore.attendance.domain.port.inbound.query.GetMemberAttendancesQuery
@@ -23,7 +23,7 @@ interface AttendancePersistencePort {
 
     fun save(attendance: Attendance)
 
-    fun findSessionAttendancesByQuery(query: GetAttendancesBySessionIdQuery): List<SessionAttendanceQueryModel>
+    fun findSessionAttendancesByQuery(query: GetAttendancesBySessionWeekQuery): List<SessionAttendanceQueryModel>
 
     fun findMemberAttendancesByQuery(query: GetMemberAttendancesQuery): List<MemberAttendanceQueryModel>
 

--- a/src/main/kotlin/com/server/dpmcore/attendance/domain/port/outbound/AttendancePersistencePort.kt
+++ b/src/main/kotlin/com/server/dpmcore/attendance/domain/port/outbound/AttendancePersistencePort.kt
@@ -34,4 +34,6 @@ interface AttendancePersistencePort {
     fun findMemberSessionAttendances(query: GetDetailMemberAttendancesQuery): List<MemberSessionAttendanceQueryModel>
 
     fun findMyDetailAttendanceBySession(query: GetMyAttendanceBySessionQuery): MyDetailAttendanceQueryModel?
+
+    fun saveInBatch(attendances: List<Attendance>)
 }

--- a/src/main/kotlin/com/server/dpmcore/attendance/infrastructure/entity/AttendanceEntity.kt
+++ b/src/main/kotlin/com/server/dpmcore/attendance/infrastructure/entity/AttendanceEntity.kt
@@ -18,6 +18,7 @@ import java.time.Instant
 class AttendanceEntity(
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "attendance_id", nullable = false, updatable = false)
     val id: Long,
     @Column(nullable = false)
     val sessionId: Long,

--- a/src/main/kotlin/com/server/dpmcore/attendance/infrastructure/event/listener/SessionCreateEventListener.kt
+++ b/src/main/kotlin/com/server/dpmcore/attendance/infrastructure/event/listener/SessionCreateEventListener.kt
@@ -1,0 +1,19 @@
+package com.server.dpmcore.attendance.infrastructure.event.listener
+
+import com.server.dpmcore.attendance.application.AttendanceCommandService
+import com.server.dpmcore.session.domain.event.SessionCreateEvent
+import org.springframework.stereotype.Component
+import org.springframework.transaction.event.TransactionPhase
+import org.springframework.transaction.event.TransactionalEventListener
+
+@Component
+class SessionCreateEventListener(
+    private val attendanceCommandService: AttendanceCommandService,
+) {
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    fun handle(event: SessionCreateEvent) {
+        attendanceCommandService.createAttendances(
+            sessionId = event.sessionId,
+        )
+    }
+}

--- a/src/main/kotlin/com/server/dpmcore/attendance/infrastructure/repository/AttendanceRepository.kt
+++ b/src/main/kotlin/com/server/dpmcore/attendance/infrastructure/repository/AttendanceRepository.kt
@@ -331,6 +331,20 @@ class AttendanceRepository(
                 )
             }
 
+    override fun saveInBatch(attendances: List<Attendance>) {
+        val records =
+            attendances.map { attendance ->
+                dsl.newRecord(ATTENDANCES).apply {
+                    memberId = attendance.memberId.value
+                    sessionId = attendance.sessionId.value
+                    status = attendance.status.name
+                    attendedAt = attendance.attendedAt
+                }
+            }
+
+        dsl.batchInsert(records).execute()
+    }
+
     companion object {
         private const val LATE_COUNT = "late_count"
         private const val ONLINE_ABSENT_COUNT = "online_absent_count"

--- a/src/main/kotlin/com/server/dpmcore/attendance/infrastructure/repository/AttendanceRepository.kt
+++ b/src/main/kotlin/com/server/dpmcore/attendance/infrastructure/repository/AttendanceRepository.kt
@@ -10,7 +10,7 @@ import com.server.dpmcore.attendance.application.query.model.SessionAttendanceQu
 import com.server.dpmcore.attendance.application.query.model.SessionDetailAttendanceQueryModel
 import com.server.dpmcore.attendance.domain.model.Attendance
 import com.server.dpmcore.attendance.domain.model.AttendanceStatus
-import com.server.dpmcore.attendance.domain.port.inbound.query.GetAttendancesBySessionIdQuery
+import com.server.dpmcore.attendance.domain.port.inbound.query.GetAttendancesBySessionWeekQuery
 import com.server.dpmcore.attendance.domain.port.inbound.query.GetDetailAttendanceBySessionQuery
 import com.server.dpmcore.attendance.domain.port.inbound.query.GetDetailMemberAttendancesQuery
 import com.server.dpmcore.attendance.domain.port.inbound.query.GetMemberAttendancesQuery
@@ -58,7 +58,7 @@ class AttendanceRepository(
     }
 
     override fun findSessionAttendancesByQuery(
-        query: GetAttendancesBySessionIdQuery,
+        query: GetAttendancesBySessionWeekQuery,
     ): List<SessionAttendanceQueryModel> =
         dsl
             .select(

--- a/src/main/kotlin/com/server/dpmcore/attendance/infrastructure/repository/QueryConditionExtensions.kt
+++ b/src/main/kotlin/com/server/dpmcore/attendance/infrastructure/repository/QueryConditionExtensions.kt
@@ -1,6 +1,6 @@
 package com.server.dpmcore.attendance.infrastructure.repository
 
-import com.server.dpmcore.attendance.domain.port.inbound.query.GetAttendancesBySessionIdQuery
+import com.server.dpmcore.attendance.domain.port.inbound.query.GetAttendancesBySessionWeekQuery
 import com.server.dpmcore.attendance.domain.port.inbound.query.GetDetailAttendanceBySessionQuery
 import com.server.dpmcore.attendance.domain.port.inbound.query.GetDetailMemberAttendancesQuery
 import com.server.dpmcore.attendance.domain.port.inbound.query.GetMemberAttendancesQuery
@@ -11,7 +11,7 @@ import org.jooq.generated.tables.references.MEMBERS
 import org.jooq.generated.tables.references.SESSIONS
 import org.jooq.generated.tables.references.TEAMS
 
-fun GetAttendancesBySessionIdQuery.toCondition(): List<Condition> {
+fun GetAttendancesBySessionWeekQuery.toCondition(): List<Condition> {
     val conditions = mutableListOf<Condition>()
 
     conditions += SESSIONS.WEEK.eq(this.week)

--- a/src/main/kotlin/com/server/dpmcore/attendance/infrastructure/repository/QueryConditionExtensions.kt
+++ b/src/main/kotlin/com/server/dpmcore/attendance/infrastructure/repository/QueryConditionExtensions.kt
@@ -8,12 +8,13 @@ import com.server.dpmcore.attendance.domain.port.inbound.query.GetMyAttendanceBy
 import org.jooq.Condition
 import org.jooq.generated.tables.references.ATTENDANCES
 import org.jooq.generated.tables.references.MEMBERS
+import org.jooq.generated.tables.references.SESSIONS
 import org.jooq.generated.tables.references.TEAMS
 
 fun GetAttendancesBySessionIdQuery.toCondition(): List<Condition> {
     val conditions = mutableListOf<Condition>()
 
-    conditions += ATTENDANCES.SESSION_ID.eq(this.sessionId.value)
+    conditions += SESSIONS.WEEK.eq(this.week)
 
     this.statuses?.takeIf { it.isNotEmpty() }?.let {
         conditions += ATTENDANCES.STATUS.`in`(it)

--- a/src/main/kotlin/com/server/dpmcore/attendance/presentation/AttendanceApi.kt
+++ b/src/main/kotlin/com/server/dpmcore/attendance/presentation/AttendanceApi.kt
@@ -135,7 +135,7 @@ interface AttendanceApi {
         ],
     )
     fun getAttendancesBySessionId(
-        sessionId: SessionId,
+        week: Int,
         statuses: List<AttendanceStatus>?,
         teams: List<Int>?,
         name: String?,

--- a/src/main/kotlin/com/server/dpmcore/attendance/presentation/AttendanceApi.kt
+++ b/src/main/kotlin/com/server/dpmcore/attendance/presentation/AttendanceApi.kt
@@ -134,7 +134,7 @@ interface AttendanceApi {
             ),
         ],
     )
-    fun getAttendancesBySessionId(
+    fun getAttendancesByWeek(
         week: Int,
         statuses: List<AttendanceStatus>?,
         teams: List<Int>?,

--- a/src/main/kotlin/com/server/dpmcore/attendance/presentation/AttendanceController.kt
+++ b/src/main/kotlin/com/server/dpmcore/attendance/presentation/AttendanceController.kt
@@ -57,9 +57,9 @@ class AttendanceController(
         return CustomResponse.ok(toAttendanceResponse(attendanceStatus, attendedAt))
     }
 
-    @GetMapping("/v1/sessions/{sessionId}/attendances")
+    @GetMapping("/v1/sessions/{week}/attendances")
     override fun getAttendancesBySessionId(
-        @PathVariable sessionId: SessionId,
+        @PathVariable week: Int,
         @RequestParam(name = "statuses", required = false) statuses: List<AttendanceStatus>?,
         @RequestParam(name = "teams", required = false) teams: List<Int>?,
         @RequestParam(name = "name", required = false) name: String?,
@@ -68,7 +68,7 @@ class AttendanceController(
         val response =
             attendanceQueryService.getAttendancesBySession(
                 GetAttendancesBySessionIdQuery(
-                    sessionId = sessionId,
+                    week = week,
                     statuses = statuses,
                     teams = teams,
                     name = name,

--- a/src/main/kotlin/com/server/dpmcore/attendance/presentation/AttendanceController.kt
+++ b/src/main/kotlin/com/server/dpmcore/attendance/presentation/AttendanceController.kt
@@ -4,7 +4,7 @@ import com.server.dpmcore.attendance.application.AttendanceCommandService
 import com.server.dpmcore.attendance.application.AttendanceQueryService
 import com.server.dpmcore.attendance.domain.model.AttendanceStatus
 import com.server.dpmcore.attendance.domain.port.inbound.command.AttendanceRecordCommand
-import com.server.dpmcore.attendance.domain.port.inbound.query.GetAttendancesBySessionIdQuery
+import com.server.dpmcore.attendance.domain.port.inbound.query.GetAttendancesBySessionWeekQuery
 import com.server.dpmcore.attendance.domain.port.inbound.query.GetDetailAttendanceBySessionQuery
 import com.server.dpmcore.attendance.domain.port.inbound.query.GetDetailMemberAttendancesQuery
 import com.server.dpmcore.attendance.domain.port.inbound.query.GetMemberAttendancesQuery
@@ -58,7 +58,7 @@ class AttendanceController(
     }
 
     @GetMapping("/v1/sessions/{week}/attendances")
-    override fun getAttendancesBySessionId(
+    override fun getAttendancesByWeek(
         @PathVariable week: Int,
         @RequestParam(name = "statuses", required = false) statuses: List<AttendanceStatus>?,
         @RequestParam(name = "teams", required = false) teams: List<Int>?,
@@ -67,7 +67,7 @@ class AttendanceController(
     ): CustomResponse<SessionAttendancesResponse> {
         val response =
             attendanceQueryService.getAttendancesBySession(
-                GetAttendancesBySessionIdQuery(
+                GetAttendancesBySessionWeekQuery(
                     week = week,
                     statuses = statuses,
                     teams = teams,

--- a/src/main/kotlin/com/server/dpmcore/cohort/application/config/CohortProperties.kt
+++ b/src/main/kotlin/com/server/dpmcore/cohort/application/config/CohortProperties.kt
@@ -1,0 +1,10 @@
+package com.server.dpmcore.cohort.application.config
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+@ConfigurationProperties(prefix = "cohort")
+data class CohortProperties(
+    var value: String = "17",
+)

--- a/src/main/kotlin/com/server/dpmcore/common/exception/CustomResponseStatusAspect.kt
+++ b/src/main/kotlin/com/server/dpmcore/common/exception/CustomResponseStatusAspect.kt
@@ -3,13 +3,15 @@ package com.server.dpmcore.common.exception
 import jakarta.servlet.http.HttpServletResponse
 import org.aspectj.lang.ProceedingJoinPoint
 import org.aspectj.lang.annotation.Around
+import org.aspectj.lang.annotation.Aspect
 import org.springframework.stereotype.Component
 
+@Aspect
 @Component
 class CustomResponseStatusAspect(
     private val response: HttpServletResponse,
 ) {
-    @Around("within(* com.server.dpmcore..*Controller.*(..))")
+    @Around("within(com.server.dpmcore..*Controller)")
     @Throws(Throwable::class)
     fun handleResponseStatus(joinPoint: ProceedingJoinPoint): Any? {
         val result = joinPoint.proceed()

--- a/src/main/kotlin/com/server/dpmcore/common/exception/CustomResponseStatusAspect.kt
+++ b/src/main/kotlin/com/server/dpmcore/common/exception/CustomResponseStatusAspect.kt
@@ -3,15 +3,13 @@ package com.server.dpmcore.common.exception
 import jakarta.servlet.http.HttpServletResponse
 import org.aspectj.lang.ProceedingJoinPoint
 import org.aspectj.lang.annotation.Around
-import org.aspectj.lang.annotation.Aspect
 import org.springframework.stereotype.Component
 
-@Aspect
 @Component
 class CustomResponseStatusAspect(
     private val response: HttpServletResponse,
 ) {
-    @Around("execution(* com.server.dpmcore..*Controller.*(..))")
+    @Around("within(* com.server.dpmcore..*Controller.*(..))")
     @Throws(Throwable::class)
     fun handleResponseStatus(joinPoint: ProceedingJoinPoint): Any? {
         val result = joinPoint.proceed()

--- a/src/main/kotlin/com/server/dpmcore/member/member/application/MemberService.kt
+++ b/src/main/kotlin/com/server/dpmcore/member/member/application/MemberService.kt
@@ -44,4 +44,8 @@ class MemberService(
     override fun findAllMemberIdByAuthorityIds(authorityIds: List<AuthorityId>): List<MemberId> =
         memberPersistencePort
             .findAllMemberIdByAuthorityIds(authorityIds)
+
+    fun getMembersByCohort(value: String): List<MemberId> =
+        memberPersistencePort
+            .findAllByCohort(value)
 }

--- a/src/main/kotlin/com/server/dpmcore/member/member/application/exception/MemberExceptionCode.kt
+++ b/src/main/kotlin/com/server/dpmcore/member/member/application/exception/MemberExceptionCode.kt
@@ -11,8 +11,9 @@ enum class MemberExceptionCode(
     @JvmField
     val message: String,
 ) : ExceptionCode {
-    MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "M404", "멤버를 찾을 수 없습니다"),
-    INVALID_MEMBER_ID(HttpStatus.BAD_REQUEST, "M400", "유효하지 않은 멤버 ID입니다"),
+    MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "MEMBER-404-1", "멤버를 찾을 수 없습니다"),
+    INVALID_MEMBER_ID(HttpStatus.BAD_REQUEST, "MEMBER-400-1", "유효하지 않은 멤버 ID입니다"),
+    COHORT_MEMBERS_NOT_FOUND(HttpStatus.NOT_FOUND, "MEMBER-404-2", "기수에 해당하는 멤버가 없습니다"),
     ;
 
     override fun getStatus(): HttpStatus = status

--- a/src/main/kotlin/com/server/dpmcore/member/member/domain/exception/CohortMembersNotFoundException.kt
+++ b/src/main/kotlin/com/server/dpmcore/member/member/domain/exception/CohortMembersNotFoundException.kt
@@ -1,0 +1,9 @@
+package com.server.dpmcore.member.member.domain.exception
+
+import com.server.dpmcore.common.exception.BusinessException
+import com.server.dpmcore.common.exception.ExceptionCode
+import com.server.dpmcore.member.member.application.exception.MemberExceptionCode
+
+class CohortMembersNotFoundException(
+    code: ExceptionCode = MemberExceptionCode.COHORT_MEMBERS_NOT_FOUND,
+) : BusinessException(code)

--- a/src/main/kotlin/com/server/dpmcore/member/member/domain/port/outbound/MemberPersistencePort.kt
+++ b/src/main/kotlin/com/server/dpmcore/member/member/domain/port/outbound/MemberPersistencePort.kt
@@ -18,4 +18,6 @@ interface MemberPersistencePort {
     fun existsDeletedMemberById(memberId: Long): Boolean
 
     fun findAllMemberIdByAuthorityIds(authorityIds: List<AuthorityId>): List<MemberId>
+
+    fun findAllByCohort(value: String): List<MemberId>
 }

--- a/src/main/kotlin/com/server/dpmcore/member/member/infrastructure/repository/MemberRepository.kt
+++ b/src/main/kotlin/com/server/dpmcore/member/member/infrastructure/repository/MemberRepository.kt
@@ -10,8 +10,10 @@ import com.server.dpmcore.member.member.domain.port.outbound.MemberPersistencePo
 import com.server.dpmcore.member.member.infrastructure.entity.MemberEntity
 import org.jooq.DSLContext
 import org.jooq.generated.tables.references.AUTHORITIES
+import org.jooq.generated.tables.references.COHORTS
 import org.jooq.generated.tables.references.MEMBERS
 import org.jooq.generated.tables.references.MEMBER_AUTHORITIES
+import org.jooq.generated.tables.references.MEMBER_COHORTS
 import org.springframework.stereotype.Repository
 import java.time.Instant
 
@@ -78,4 +80,19 @@ class MemberRepository(
             .where(AUTHORITIES.AUTHORITY_ID.`in`(authorityIds.map { it.value }))
             .fetch(MEMBERS.MEMBER_ID)
             .map { MemberId(it ?: 0L) }
+
+    override fun findAllByCohort(value: String): List<MemberId> =
+        dsl
+            .select(MEMBERS.MEMBER_ID)
+            .from(MEMBERS)
+            .join(MEMBER_COHORTS)
+            .on(MEMBERS.MEMBER_ID.eq(MEMBER_COHORTS.MEMBER_ID))
+            .join(COHORTS)
+            .on(MEMBER_COHORTS.COHORT_ID.eq(COHORTS.COHORT_ID))
+            .where(COHORTS.VALUE.eq(value))
+            .fetch(MEMBERS.MEMBER_ID)
+            .filterNotNull()
+            .map {
+                MemberId(it)
+            }
 }

--- a/src/main/kotlin/com/server/dpmcore/session/domain/event/SessionCreateEvent.kt
+++ b/src/main/kotlin/com/server/dpmcore/session/domain/event/SessionCreateEvent.kt
@@ -1,0 +1,7 @@
+package com.server.dpmcore.session.domain.event
+
+import com.server.dpmcore.session.domain.model.SessionId
+
+data class SessionCreateEvent(
+    val sessionId: SessionId,
+)

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -56,15 +56,11 @@ management:
       exposure:
         include: health
       base-path: /actuator
-    jmx:
-      exposure:
-        exclude: "*"
     access:
       default: none
-
   endpoint:
     health:
-      enabled: true
+      access: read_only
 logging:
   level:
     org.jooq.tools.LoggerListener: DEBUG

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -65,6 +65,9 @@ logging:
   level:
     org.jooq.tools.LoggerListener: DEBUG
 
+cohort:
+  value: 17
+
 session:
   attendance:
     start-hour: 14


### PR DESCRIPTION
## Summary

>- close #71 

<!-- 해당 PR에 대한 요약을 작성해주세요. -->

## Tasks

- Spring 내부 이벤트를 발행하는 `ApplicationEventPublisher`를 통해 도메인 애그리거트 간 커플링을 완화하였습니다.
- 세션 생성 이벤트 `SessionCreateEvent`를 발행합니다.
- `Attendance` 도메인의 `SessonCreateEventListener`는 이벤트를 수신하여 `AttendanceCommandService`를 호출하고 현 기수 디퍼들의 출석부를 생성합니다.
- 이 때 `TransactionPhase`는 `AFTER_COMMIT`으로 세션이 저장된 이후에 출석부가 만들어짐을 보장합니다.

## ETC

<!-- 추가적인 정보나 참고 사항을 작성해주세요. -->
- jOOQ와 Spring AOP의 execution과의 스캔 문제로 인하여 execution을 within으로 변경하였습니다.
- spring actuator의 불필요한 jmx 설정을 삭제하였습니다.
- 세션별 디퍼 출석 리스트 조회 API의 path인 sessionId가 아닌 week으로 변경하였습니다.

## Screenshot

<!-- (없을 경우 삭제) 작업한 내용에 대한 스크린샷을 첨부해주세요._ -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 세션 생성 시 해당 기수의 모든 멤버 출석 정보가 자동으로 생성됩니다.
  * 주차(week) 기준으로 출석 정보를 조회할 수 있는 기능이 추가되었습니다.

* **버그 수정**
  * 일부 예외 코드가 보다 명확하고 일관성 있게 개선되었습니다.

* **설정**
  * 외부 설정에서 기수(cohort) 값을 관리할 수 있도록 설정 항목이 추가되었습니다.

* **기타**
  * 출석 및 멤버 관련 예외와 오류 메시지가 추가 및 개선되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->