### PR TITLE
refactor: Member 회원 가입 시 OAuth 연관 관계 정보 저장하도록 수정

### DIFF
--- a/src/main/kotlin/com/server/dpmcore/cohort/domain/exception/CohortExceptionCode.kt
+++ b/src/main/kotlin/com/server/dpmcore/cohort/domain/exception/CohortExceptionCode.kt
@@ -8,9 +8,9 @@ enum class CohortExceptionCode(
     @JvmField val code: String,
     @JvmField val message: String,
 ) : ExceptionCode {
-    COHORT_NOT_FOUND(HttpStatus.NOT_FOUND, "C404", "기수를 찾을 수 없습니다"),
-    COHORT_ALREADY_EXISTS(HttpStatus.CONFLICT, "C409", "이미 존재하는 기수입니다"),
-    INVALID_COHORT_STATE(HttpStatus.BAD_REQUEST, "C400", "유효하지 않은 기수 상태입니다"),
+    COHORT_NOT_FOUND(HttpStatus.NOT_FOUND, "COHORT-404-1", "기수를 찾을 수 없습니다"),
+    COHORT_ALREADY_EXISTS(HttpStatus.CONFLICT, "COHORT-409-1", "이미 존재하는 기수입니다"),
+    INVALID_COHORT_STATE(HttpStatus.BAD_REQUEST, "COHORT-400-1", "유효하지 않은 기수 상태입니다"),
     ;
 
     override fun getStatus(): HttpStatus = this.status

--- a/src/main/kotlin/com/server/dpmcore/member/member/application/MemberLoginService.kt
+++ b/src/main/kotlin/com/server/dpmcore/member/member/application/MemberLoginService.kt
@@ -13,6 +13,7 @@ import com.server.dpmcore.security.oauth.dto.LoginResult
 import com.server.dpmcore.security.oauth.dto.OAuthAttributes
 import com.server.dpmcore.security.oauth.token.JwtTokenProvider
 import com.server.dpmcore.security.properties.SecurityProperties
+import org.springframework.core.env.Environment
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
@@ -24,6 +25,7 @@ class MemberLoginService(
     private val refreshTokenPersistencePort: RefreshTokenPersistencePort,
     private val securityProperties: SecurityProperties,
     private val tokenProvider: JwtTokenProvider,
+    private val environment: Environment,
 ) : HandleMemberLoginUseCase {
     @Transactional
     override fun handleLoginSuccess(authAttributes: OAuthAttributes): LoginResult =
@@ -69,7 +71,7 @@ class MemberLoginService(
     }
 
     private fun handleUnregisteredMember(authAttributes: OAuthAttributes): LoginResult {
-        val member = memberPersistencePort.save(Member.create(authAttributes.getEmail()))
+        val member = memberPersistencePort.save(Member.create(authAttributes.getEmail(), environment))
         memberOAuthService.addMemberOAuthProvider(member, authAttributes)
 
         return generateLoginResult(

--- a/src/main/kotlin/com/server/dpmcore/member/member/application/MemberLoginService.kt
+++ b/src/main/kotlin/com/server/dpmcore/member/member/application/MemberLoginService.kt
@@ -1,5 +1,6 @@
 package com.server.dpmcore.member.member.application
 
+import com.server.dpmcore.member.member.application.exception.MemberIdCanNotBeNullException
 import com.server.dpmcore.member.member.domain.model.Member
 import com.server.dpmcore.member.member.domain.model.MemberId
 import com.server.dpmcore.member.member.domain.port.inbound.HandleMemberLoginUseCase
@@ -71,7 +72,10 @@ class MemberLoginService(
         val member = memberPersistencePort.save(Member.create(authAttributes.getEmail()))
         memberOAuthService.addMemberOAuthProvider(member, authAttributes)
 
-        return generateLoginResult(member.id!!, securityProperties.restrictedRedirectUrl)
+        return generateLoginResult(
+            member.id ?: throw MemberIdCanNotBeNullException(),
+            securityProperties.restrictedRedirectUrl,
+        )
     }
 
     companion object {

--- a/src/main/kotlin/com/server/dpmcore/member/member/application/exception/MemberExceptionCode.kt
+++ b/src/main/kotlin/com/server/dpmcore/member/member/application/exception/MemberExceptionCode.kt
@@ -13,6 +13,7 @@ enum class MemberExceptionCode(
 ) : ExceptionCode {
     MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "MEMBER-404-1", "멤버를 찾을 수 없습니다"),
     INVALID_MEMBER_ID(HttpStatus.BAD_REQUEST, "MEMBER-400-1", "유효하지 않은 멤버 ID입니다"),
+    COHORT_MEMBERS_NOT_FOUND(HttpStatus.NOT_FOUND, "MEMBER-404-2", "기수에 속한 멤버를 찾을 수 없습니다"),
     ;
 
     override fun getStatus(): HttpStatus = status

--- a/src/main/kotlin/com/server/dpmcore/member/member/application/exception/MemberExceptionCode.kt
+++ b/src/main/kotlin/com/server/dpmcore/member/member/application/exception/MemberExceptionCode.kt
@@ -11,8 +11,8 @@ enum class MemberExceptionCode(
     @JvmField
     val message: String,
 ) : ExceptionCode {
-    MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "M404", "멤버를 찾을 수 없습니다"),
-    INVALID_MEMBER_ID(HttpStatus.BAD_REQUEST, "M400", "유효하지 않은 멤버 ID입니다"),
+    MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "MEMBER-404-1", "멤버를 찾을 수 없습니다"),
+    INVALID_MEMBER_ID(HttpStatus.BAD_REQUEST, "MEMBER-400-1", "유효하지 않은 멤버 ID입니다"),
     ;
 
     override fun getStatus(): HttpStatus = status

--- a/src/main/kotlin/com/server/dpmcore/member/member/application/exception/MemberExceptionCode.kt
+++ b/src/main/kotlin/com/server/dpmcore/member/member/application/exception/MemberExceptionCode.kt
@@ -14,6 +14,7 @@ enum class MemberExceptionCode(
     MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "MEMBER-404-1", "멤버를 찾을 수 없습니다"),
     INVALID_MEMBER_ID(HttpStatus.BAD_REQUEST, "MEMBER-400-1", "유효하지 않은 멤버 ID입니다"),
     COHORT_MEMBERS_NOT_FOUND(HttpStatus.NOT_FOUND, "MEMBER-404-2", "기수에 속한 멤버를 찾을 수 없습니다"),
+    MEMBER_ID_CAN_NOT_BE_NULL(HttpStatus.BAD_REQUEST, "MEMBER-400-2", "멤버 ID는 null일 수 없습니다"),
     ;
 
     override fun getStatus(): HttpStatus = status

--- a/src/main/kotlin/com/server/dpmcore/member/member/application/exception/MemberIdCanNotBeNullException.kt
+++ b/src/main/kotlin/com/server/dpmcore/member/member/application/exception/MemberIdCanNotBeNullException.kt
@@ -1,0 +1,8 @@
+package com.server.dpmcore.member.member.application.exception
+
+import com.server.dpmcore.common.exception.BusinessException
+
+class MemberIdCanNotBeNullException :
+    BusinessException(
+        MemberExceptionCode.MEMBER_ID_CAN_NOT_BE_NULL,
+    )

--- a/src/main/kotlin/com/server/dpmcore/member/member/domain/model/Member.kt
+++ b/src/main/kotlin/com/server/dpmcore/member/member/domain/model/Member.kt
@@ -25,7 +25,7 @@ class Member(
     val name: String? = null,
     val email: String,
     val part: MemberPart? = null,
-    val status: MemberStatus,
+    status: MemberStatus,
     createdAt: Instant? = null,
     updatedAt: Instant? = null,
     deletedAt: Instant? = null,
@@ -33,6 +33,9 @@ class Member(
     val memberCohorts: List<MemberCohort> = emptyList(),
     val memberTeams: List<MemberTeam> = emptyList(),
 ) {
+    var status: MemberStatus = status
+        private set
+
     var createdAt: Instant? = createdAt
         private set
 

--- a/src/main/kotlin/com/server/dpmcore/member/member/domain/model/Member.kt
+++ b/src/main/kotlin/com/server/dpmcore/member/member/domain/model/Member.kt
@@ -2,6 +2,7 @@ package com.server.dpmcore.member.member.domain.model
 
 import com.server.dpmcore.member.memberAuthority.domain.model.MemberAuthority
 import com.server.dpmcore.member.memberCohort.domain.MemberCohort
+import com.server.dpmcore.member.memberOAuth.domain.model.MemberOAuth
 import com.server.dpmcore.member.memberTeam.domain.MemberTeam
 import java.time.Instant
 
@@ -32,6 +33,7 @@ class Member(
     val memberAuthorities: List<MemberAuthority> = emptyList(),
     val memberCohorts: List<MemberCohort> = emptyList(),
     val memberTeams: List<MemberTeam> = emptyList(),
+    val memberOAuths: List<MemberOAuth> = emptyList(),
 ) {
     var status: MemberStatus = status
         private set
@@ -68,7 +70,7 @@ class Member(
     override fun toString(): String =
         "Member(id=$id, name='$name', email='$email', part=$part, status=$status, createdAt=$createdAt, " +
             "updatedAt=$updatedAt, deletedAt=$deletedAt, memberAuthorities=$memberAuthorities, " +
-            "memberCohorts=$memberCohorts, memberTeams=$memberTeams)"
+            "memberCohorts=$memberCohorts, memberTeams=$memberTeams, memberOAuths=$memberOAuths)"
 
     companion object {
         fun create(email: String): Member =

--- a/src/main/kotlin/com/server/dpmcore/member/member/domain/model/Member.kt
+++ b/src/main/kotlin/com/server/dpmcore/member/member/domain/model/Member.kt
@@ -4,6 +4,7 @@ import com.server.dpmcore.member.memberAuthority.domain.model.MemberAuthority
 import com.server.dpmcore.member.memberCohort.domain.MemberCohort
 import com.server.dpmcore.member.memberOAuth.domain.model.MemberOAuth
 import com.server.dpmcore.member.memberTeam.domain.MemberTeam
+import org.springframework.core.env.Environment
 import java.time.Instant
 
 /**
@@ -73,13 +74,29 @@ class Member(
             "memberCohorts=$memberCohorts, memberTeams=$memberTeams, memberOAuths=$memberOAuths)"
 
     companion object {
-        fun create(email: String): Member =
-            Member(
+        fun create(
+            email: String,
+            environment: Environment,
+        ): Member {
+            val profileStatusMap =
+                mapOf(
+                    "prod" to MemberStatus.PENDING,
+                    "dev" to MemberStatus.ACTIVE,
+                    "local" to MemberStatus.ACTIVE,
+                )
+
+            val matchedStatus =
+                environment.activeProfiles
+                    .firstNotNullOfOrNull { profileStatusMap[it] }
+                    ?: MemberStatus.WITHDRAWN
+
+            val now = Instant.now()
+            return Member(
                 email = email,
-                // TODO : 운영 환경에서는 PENDING
-                status = MemberStatus.INACTIVE,
-                createdAt = Instant.now(),
-                updatedAt = Instant.now(),
+                status = matchedStatus,
+                createdAt = now,
+                updatedAt = now,
             )
+        }
     }
 }

--- a/src/main/kotlin/com/server/dpmcore/member/member/domain/model/Member.kt
+++ b/src/main/kotlin/com/server/dpmcore/member/member/domain/model/Member.kt
@@ -76,7 +76,8 @@ class Member(
         fun create(email: String): Member =
             Member(
                 email = email,
-                status = MemberStatus.PENDING,
+                // TODO : 운영 환경에서는 PENDING
+                status = MemberStatus.INACTIVE,
                 createdAt = Instant.now(),
                 updatedAt = Instant.now(),
             )

--- a/src/main/kotlin/com/server/dpmcore/member/member/domain/port/outbound/MemberPersistencePort.kt
+++ b/src/main/kotlin/com/server/dpmcore/member/member/domain/port/outbound/MemberPersistencePort.kt
@@ -5,7 +5,7 @@ import com.server.dpmcore.member.member.domain.model.Member
 import com.server.dpmcore.member.member.domain.model.MemberId
 
 interface MemberPersistencePort {
-    fun save(member: Member): Long
+    fun save(member: Member): Member
 
     fun findByEmail(email: String): Member?
 

--- a/src/main/kotlin/com/server/dpmcore/member/member/infrastructure/entity/MemberEntity.kt
+++ b/src/main/kotlin/com/server/dpmcore/member/member/infrastructure/entity/MemberEntity.kt
@@ -6,6 +6,7 @@ import com.server.dpmcore.member.member.domain.model.MemberPart
 import com.server.dpmcore.member.member.domain.model.MemberStatus
 import com.server.dpmcore.member.memberAuthority.infrastructure.entity.MemberAuthorityEntity
 import com.server.dpmcore.member.memberCohort.infrastructure.entity.MemberCohortEntity
+import com.server.dpmcore.member.memberOAuth.infrastructure.entity.MemberOAuthEntity
 import com.server.dpmcore.member.memberTeam.infrastructure.entity.MemberTeamEntity
 import jakarta.persistence.CascadeType
 import jakarta.persistence.Column
@@ -45,6 +46,8 @@ class MemberEntity(
     val memberCohorts: MutableList<MemberCohortEntity> = mutableListOf(),
     @OneToMany(mappedBy = "member", fetch = FetchType.LAZY, cascade = [CascadeType.ALL], orphanRemoval = true)
     val memberTeams: MutableList<MemberTeamEntity> = mutableListOf(),
+    @OneToMany(mappedBy = "member", fetch = FetchType.LAZY, cascade = [CascadeType.ALL], orphanRemoval = true)
+    val memberOAuths: MutableList<MemberOAuthEntity> = mutableListOf(),
 ) {
     fun toDomain(): Member =
         Member(

--- a/src/main/kotlin/com/server/dpmcore/member/member/infrastructure/repository/MemberRepository.kt
+++ b/src/main/kotlin/com/server/dpmcore/member/member/infrastructure/repository/MemberRepository.kt
@@ -31,7 +31,7 @@ class MemberRepository(
                 where(col(MemberEntity::email).equal(email))
             }?.toDomain()
 
-    override fun save(member: Member): Long = memberJpaRepository.save(MemberEntity.from(member)).id
+    override fun save(member: Member): Member = memberJpaRepository.save(MemberEntity.from(member)).toDomain()
 
     override fun findById(memberId: Long): Member? =
         queryFactory

--- a/src/main/kotlin/com/server/dpmcore/member/memberAuthority/application/MemberAuthorityService.kt
+++ b/src/main/kotlin/com/server/dpmcore/member/memberAuthority/application/MemberAuthorityService.kt
@@ -1,0 +1,14 @@
+package com.server.dpmcore.member.memberAuthority.application
+
+import com.server.dpmcore.member.member.domain.model.MemberId
+import com.server.dpmcore.member.memberAuthority.domain.port.outbound.MemberAuthorityPersistencePort
+import org.springframework.stereotype.Service
+
+@Service
+class MemberAuthorityService(
+    private val memberAuthorityPersistencePort: MemberAuthorityPersistencePort,
+) {
+    fun getAuthorityNamesByMemberId(memberId: MemberId): List<String> =
+        memberAuthorityPersistencePort
+            .findAuthorityNamesByMemberId(memberId.value)
+}

--- a/src/main/kotlin/com/server/dpmcore/member/memberOAuth/application/MemberOAuthService.kt
+++ b/src/main/kotlin/com/server/dpmcore/member/memberOAuth/application/MemberOAuthService.kt
@@ -1,0 +1,26 @@
+package com.server.dpmcore.member.memberOAuth.application
+
+import com.server.dpmcore.member.member.domain.model.Member
+import com.server.dpmcore.member.memberOAuth.domain.model.MemberOAuth
+import com.server.dpmcore.member.memberOAuth.domain.port.MemberOAuthPersistencePort
+import com.server.dpmcore.security.oauth.dto.OAuthAttributes
+import org.springframework.stereotype.Service
+
+@Service
+class MemberOAuthService(
+    private val memberOAuthPersistencePort: MemberOAuthPersistencePort,
+) {
+    fun addMemberOAuthProvider(
+        member: Member,
+        authAttribute: OAuthAttributes,
+    ) {
+        memberOAuthPersistencePort.save(
+            MemberOAuth.of(
+                authAttribute.getExternalId(),
+                authAttribute.getProvider(),
+                member.id!!,
+            ),
+            member,
+        )
+    }
+}

--- a/src/main/kotlin/com/server/dpmcore/member/memberOAuth/domain/MemberOAuthId.kt
+++ b/src/main/kotlin/com/server/dpmcore/member/memberOAuth/domain/MemberOAuthId.kt
@@ -1,6 +1,0 @@
-package com.server.dpmcore.member.memberOAuth.domain
-
-@JvmInline
-value class MemberOAuthId(val value: Long) {
-    override fun toString(): String = value.toString()
-}

--- a/src/main/kotlin/com/server/dpmcore/member/memberOAuth/domain/model/MemberOAuth.kt
+++ b/src/main/kotlin/com/server/dpmcore/member/memberOAuth/domain/model/MemberOAuth.kt
@@ -1,4 +1,4 @@
-package com.server.dpmcore.member.memberOAuth.domain
+package com.server.dpmcore.member.memberOAuth.domain.model
 
 import com.server.dpmcore.member.member.domain.model.MemberId
 
@@ -26,7 +26,19 @@ class MemberOAuth(
         return result
     }
 
-    override fun toString(): String {
-        return "MemberOAuth(id=$id, externalId='$externalId', provider=$provider, memberId=$memberId)"
+    override fun toString(): String =
+        "MemberOAuth(id=$id, externalId='$externalId', provider=$provider, memberId=$memberId)"
+
+    companion object {
+        fun of(
+            externalId: String,
+            provider: OAuthProvider,
+            memberId: MemberId,
+        ): MemberOAuth =
+            MemberOAuth(
+                externalId = externalId,
+                provider = provider,
+                memberId = memberId,
+            )
     }
 }

--- a/src/main/kotlin/com/server/dpmcore/member/memberOAuth/domain/model/MemberOAuthId.kt
+++ b/src/main/kotlin/com/server/dpmcore/member/memberOAuth/domain/model/MemberOAuthId.kt
@@ -1,0 +1,8 @@
+package com.server.dpmcore.member.memberOAuth.domain.model
+
+@JvmInline
+value class MemberOAuthId(
+    val value: Long,
+) {
+    override fun toString(): String = value.toString()
+}

--- a/src/main/kotlin/com/server/dpmcore/member/memberOAuth/domain/model/OAuthProvider.kt
+++ b/src/main/kotlin/com/server/dpmcore/member/memberOAuth/domain/model/OAuthProvider.kt
@@ -1,4 +1,4 @@
-package com.server.dpmcore.member.memberOAuth.domain
+package com.server.dpmcore.member.memberOAuth.domain.model
 
 /**
  * 서비스에서 지원하는 OAuth 제공자를 나타냅니다.
@@ -12,7 +12,5 @@ enum class OAuthProvider {
     KAKAO,
     ;
 
-    fun isProviderOf(provider: String): Boolean {
-        return this.name == provider
-    }
+    fun isProviderOf(provider: String): Boolean = this.name == provider
 }

--- a/src/main/kotlin/com/server/dpmcore/member/memberOAuth/domain/port/MemberOAuthPersistencePort.kt
+++ b/src/main/kotlin/com/server/dpmcore/member/memberOAuth/domain/port/MemberOAuthPersistencePort.kt
@@ -1,0 +1,11 @@
+package com.server.dpmcore.member.memberOAuth.domain.port
+
+import com.server.dpmcore.member.member.domain.model.Member
+import com.server.dpmcore.member.memberOAuth.domain.model.MemberOAuth
+
+interface MemberOAuthPersistencePort {
+    fun save(
+        memberOAuth: MemberOAuth,
+        member: Member,
+    )
+}

--- a/src/main/kotlin/com/server/dpmcore/member/memberOAuth/infrastructure/entity/MemberOAuthEntity.kt
+++ b/src/main/kotlin/com/server/dpmcore/member/memberOAuth/infrastructure/entity/MemberOAuthEntity.kt
@@ -1,6 +1,8 @@
 package com.server.dpmcore.member.memberOAuth.infrastructure.entity
 
+import com.server.dpmcore.member.member.domain.model.Member
 import com.server.dpmcore.member.member.infrastructure.entity.MemberEntity
+import com.server.dpmcore.member.memberOAuth.domain.model.MemberOAuth
 import jakarta.persistence.Column
 import jakarta.persistence.ConstraintMode
 import jakarta.persistence.Entity
@@ -27,4 +29,17 @@ class MemberOAuthEntity(
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id", nullable = false, foreignKey = ForeignKey(ConstraintMode.NO_CONSTRAINT))
     val member: MemberEntity,
-)
+) {
+    companion object {
+        fun from(
+            memberOAuth: MemberOAuth,
+            member: Member,
+        ): MemberOAuthEntity =
+            MemberOAuthEntity(
+                id = memberOAuth.id?.value ?: 0L,
+                externalId = memberOAuth.externalId,
+                provider = memberOAuth.provider.name,
+                member = MemberEntity.from(member),
+            )
+    }
+}

--- a/src/main/kotlin/com/server/dpmcore/member/memberOAuth/infrastructure/entity/MemberOAuthEntity.kt
+++ b/src/main/kotlin/com/server/dpmcore/member/memberOAuth/infrastructure/entity/MemberOAuthEntity.kt
@@ -31,7 +31,7 @@ class MemberOAuthEntity(
     val member: MemberEntity,
 ) {
     companion object {
-        fun from(
+        fun of(
             memberOAuth: MemberOAuth,
             member: Member,
         ): MemberOAuthEntity =

--- a/src/main/kotlin/com/server/dpmcore/member/memberOAuth/infrastructure/repository/MemberOAuthJpaRepository.kt
+++ b/src/main/kotlin/com/server/dpmcore/member/memberOAuth/infrastructure/repository/MemberOAuthJpaRepository.kt
@@ -1,0 +1,6 @@
+package com.server.dpmcore.member.memberOAuth.infrastructure.repository
+
+import com.server.dpmcore.member.memberOAuth.infrastructure.entity.MemberOAuthEntity
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface MemberOAuthJpaRepository : JpaRepository<MemberOAuthEntity, Long>

--- a/src/main/kotlin/com/server/dpmcore/member/memberOAuth/infrastructure/repository/MemberOAuthRepository.kt
+++ b/src/main/kotlin/com/server/dpmcore/member/memberOAuth/infrastructure/repository/MemberOAuthRepository.kt
@@ -14,6 +14,6 @@ class MemberOAuthRepository(
         memberOAuth: MemberOAuth,
         member: Member,
     ) {
-        memberOAuthJpaRepository.save(MemberOAuthEntity.from(memberOAuth, member))
+        memberOAuthJpaRepository.save(MemberOAuthEntity.of(memberOAuth, member))
     }
 }

--- a/src/main/kotlin/com/server/dpmcore/member/memberOAuth/infrastructure/repository/MemberOAuthRepository.kt
+++ b/src/main/kotlin/com/server/dpmcore/member/memberOAuth/infrastructure/repository/MemberOAuthRepository.kt
@@ -1,0 +1,19 @@
+package com.server.dpmcore.member.memberOAuth.infrastructure.repository
+
+import com.server.dpmcore.member.member.domain.model.Member
+import com.server.dpmcore.member.memberOAuth.domain.model.MemberOAuth
+import com.server.dpmcore.member.memberOAuth.domain.port.MemberOAuthPersistencePort
+import com.server.dpmcore.member.memberOAuth.infrastructure.entity.MemberOAuthEntity
+import org.springframework.stereotype.Repository
+
+@Repository
+class MemberOAuthRepository(
+    private val memberOAuthJpaRepository: MemberOAuthJpaRepository,
+) : MemberOAuthPersistencePort {
+    override fun save(
+        memberOAuth: MemberOAuth,
+        member: Member,
+    ) {
+        memberOAuthJpaRepository.save(MemberOAuthEntity.from(memberOAuth, member))
+    }
+}

--- a/src/main/kotlin/com/server/dpmcore/security/oauth/dto/KakaoAuthAttributes.kt
+++ b/src/main/kotlin/com/server/dpmcore/security/oauth/dto/KakaoAuthAttributes.kt
@@ -1,6 +1,6 @@
 package com.server.dpmcore.security.oauth.dto
 
-import com.server.dpmcore.member.memberOAuth.domain.OAuthProvider
+import com.server.dpmcore.member.memberOAuth.domain.model.OAuthProvider
 
 /**
  * 카카오 OAuth 인증 정보를 나타내는 데이터 클래스입니다.

--- a/src/main/kotlin/com/server/dpmcore/security/oauth/dto/OAuthAttributes.kt
+++ b/src/main/kotlin/com/server/dpmcore/security/oauth/dto/OAuthAttributes.kt
@@ -1,6 +1,7 @@
 package com.server.dpmcore.security.oauth.dto
 
 import com.server.dpmcore.member.memberOAuth.domain.model.OAuthProvider
+import com.server.dpmcore.security.oauth.exception.UnsupportedOAuthProviderException
 
 interface OAuthAttributes {
     fun getExternalId(): String
@@ -16,7 +17,7 @@ interface OAuthAttributes {
         ): OAuthAttributes =
             when {
                 OAuthProvider.KAKAO.isProviderOf(providerId) -> KakaoAuthAttributes.of(attributes)
-                else -> throw IllegalArgumentException("Unsupported provider: $providerId")
+                else -> throw UnsupportedOAuthProviderException()
             }
     }
 }

--- a/src/main/kotlin/com/server/dpmcore/security/oauth/dto/OAuthAttributes.kt
+++ b/src/main/kotlin/com/server/dpmcore/security/oauth/dto/OAuthAttributes.kt
@@ -1,6 +1,6 @@
 package com.server.dpmcore.security.oauth.dto
 
-import com.server.dpmcore.member.memberOAuth.domain.OAuthProvider
+import com.server.dpmcore.member.memberOAuth.domain.model.OAuthProvider
 
 interface OAuthAttributes {
     fun getExternalId(): String
@@ -13,11 +13,10 @@ interface OAuthAttributes {
         fun of(
             providerId: String,
             attributes: Map<String, Any>,
-        ): OAuthAttributes {
-            return when {
+        ): OAuthAttributes =
+            when {
                 OAuthProvider.KAKAO.isProviderOf(providerId) -> KakaoAuthAttributes.of(attributes)
                 else -> throw IllegalArgumentException("Unsupported provider: $providerId")
             }
-        }
     }
 }

--- a/src/main/kotlin/com/server/dpmcore/security/oauth/exception/OAuthExceptionCode.kt
+++ b/src/main/kotlin/com/server/dpmcore/security/oauth/exception/OAuthExceptionCode.kt
@@ -8,7 +8,8 @@ enum class OAuthExceptionCode(
     @JvmField val code: String,
     @JvmField val message: String,
 ) : ExceptionCode {
-    AUTHENTICATION_FAILED(HttpStatus.BAD_REQUEST, "A400", "소셜 로그인에 실패했습니다"),
+    AUTHENTICATION_FAILED(HttpStatus.BAD_REQUEST, "OAUTH-400-1", "소셜 로그인에 실패했습니다"),
+    UNSUPPORTED_OAUTH_PROVIDER(HttpStatus.BAD_REQUEST, "OAUTH-400-2", "지원하지 않는 OAuth 제공자입니다"),
     ;
 
     override fun getStatus(): HttpStatus = status

--- a/src/main/kotlin/com/server/dpmcore/security/oauth/exception/UnsupportedOAuthProviderException.kt
+++ b/src/main/kotlin/com/server/dpmcore/security/oauth/exception/UnsupportedOAuthProviderException.kt
@@ -1,0 +1,8 @@
+package com.server.dpmcore.security.oauth.exception
+
+import com.server.dpmcore.common.exception.BusinessException
+
+class UnsupportedOAuthProviderException :
+    BusinessException(
+        OAuthExceptionCode.UNSUPPORTED_OAUTH_PROVIDER,
+    )


### PR DESCRIPTION
## Summary

>- #76 

Member 회원 가입 시 OAuth 연관 관계를 저장하지 않는 이슈를 픽스하였습니다

<!-- 해당 PR에 대한 요약을 작성해주세요. -->

## Tasks

- Member 회원 가입 시 OAuth 연관 관계 정보 저장하도록 수정

## ETC

<!-- 추가적인 정보나 참고 사항을 작성해주세요. -->

## Screenshot

<!-- (없을 경우 삭제) 작업한 내용에 대한 스크린샷을 첨부해주세요._ -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 멤버의 OAuth 제공자 정보를 관리하는 서비스 및 저장소가 추가되었습니다.
  * 멤버 권한을 조회하는 별도의 서비스가 도입되었습니다.

* **변경 사항**
  * 멤버 저장 시 반환값이 ID에서 전체 멤버 객체로 변경되었습니다.
  * 멤버 생성 시 기본 상태가 PENDING에서 INACTIVE로 변경되었습니다.
  * 멤버 엔티티 및 도메인에 OAuth 관련 속성이 추가되었습니다.
  * 예외 코드 및 메시지가 더 명확하고 구조적으로 개선되었습니다.

* **버그 수정**
  * 없음

* **기타**
  * 내부 구조 개선 및 패키지 경로 정리, 일부 함수 표현 간소화가 이루어졌습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->