### PR TITLE
refactor: 출석 페이지네이션 쿼리 조건 변경 및 출석일자 nullable 처리

### DIFF
--- a/src/main/kotlin/com/server/dpmcore/attendance/application/query/model/MyDetailAttendanceQueryModel.kt
+++ b/src/main/kotlin/com/server/dpmcore/attendance/application/query/model/MyDetailAttendanceQueryModel.kt
@@ -4,7 +4,7 @@ import java.time.Instant
 
 data class MyDetailAttendanceQueryModel(
     val attendanceStatus: String,
-    val attendedAt: Instant,
+    val attendedAt: Instant?,
     val sessionWeek: Int,
     val sessionEventName: String,
     val sessionDate: Instant,

--- a/src/main/kotlin/com/server/dpmcore/attendance/application/query/model/SessionDetailAttendanceQueryModel.kt
+++ b/src/main/kotlin/com/server/dpmcore/attendance/application/query/model/SessionDetailAttendanceQueryModel.kt
@@ -15,5 +15,5 @@ data class SessionDetailAttendanceQueryModel(
     val sessionEventName: String,
     val sessionDate: Instant,
     val attendanceStatus: String,
-    val attendedAt: Instant,
+    val attendedAt: Instant?,
 )

--- a/src/main/kotlin/com/server/dpmcore/attendance/infrastructure/repository/AttendanceRepository.kt
+++ b/src/main/kotlin/com/server/dpmcore/attendance/infrastructure/repository/AttendanceRepository.kt
@@ -62,8 +62,7 @@ class AttendanceRepository(
     ): List<SessionAttendanceQueryModel> =
         dsl
             .select(
-                ATTENDANCES.ATTENDANCE_ID,
-                MEMBERS.MEMBER_ID,
+                ATTENDANCES.MEMBER_ID,
                 MEMBERS.NAME,
                 TEAMS.NUMBER,
                 MEMBERS.PART,
@@ -79,7 +78,7 @@ class AttendanceRepository(
             .on(MEMBER_TEAMS.TEAM_ID.eq(TEAMS.TEAM_ID))
             .where(
                 query.toCondition(),
-            ).orderBy(ATTENDANCES.ATTENDANCE_ID.asc(), TEAMS.NUMBER.asc())
+            ).orderBy(ATTENDANCES.MEMBER_ID.asc(), TEAMS.NUMBER.asc())
             .limit(PAGE_SIZE + 1)
             .fetch { record ->
                 SessionAttendanceQueryModel(
@@ -210,7 +209,7 @@ class AttendanceRepository(
                     sessionEventName = it[SESSIONS.EVENT_NAME]!!,
                     sessionDate = it[SESSIONS.DATE]!!,
                     attendanceStatus = it[ATTENDANCES.STATUS]!!,
-                    attendedAt = it[ATTENDANCES.ATTENDED_AT]!!,
+                    attendedAt = it[ATTENDANCES.ATTENDED_AT],
                 )
             }
 
@@ -321,7 +320,7 @@ class AttendanceRepository(
             .fetchOne {
                 MyDetailAttendanceQueryModel(
                     attendanceStatus = it[ATTENDANCES.STATUS]!!,
-                    attendedAt = it[ATTENDANCES.ATTENDED_AT]!!,
+                    attendedAt = it[ATTENDANCES.ATTENDED_AT],
                     sessionWeek = it[SESSIONS.WEEK]!!,
                     sessionEventName = it[SESSIONS.EVENT_NAME]!!,
                     sessionDate = it[SESSIONS.DATE]!!,

--- a/src/main/kotlin/com/server/dpmcore/attendance/infrastructure/repository/QueryConditionExtensions.kt
+++ b/src/main/kotlin/com/server/dpmcore/attendance/infrastructure/repository/QueryConditionExtensions.kt
@@ -29,7 +29,7 @@ fun GetAttendancesBySessionWeekQuery.toCondition(): List<Condition> {
     }
 
     this.cursorId?.let {
-        conditions += ATTENDANCES.ATTENDANCE_ID.gt(it)
+        conditions += ATTENDANCES.MEMBER_ID.greaterOrEqual(it)
     }
 
     return conditions
@@ -51,7 +51,7 @@ fun GetMemberAttendancesQuery.toCondition(): List<Condition> {
     }
 
     this.cursorId?.let {
-        conditions += ATTENDANCES.ATTENDANCE_ID.gt(it)
+        conditions += ATTENDANCES.MEMBER_ID.greaterOrEqual(it)
     }
 
     return conditions

--- a/src/main/kotlin/com/server/dpmcore/attendance/presentation/dto/response/DetailAttendancesBySessionResponse.kt
+++ b/src/main/kotlin/com/server/dpmcore/attendance/presentation/dto/response/DetailAttendancesBySessionResponse.kt
@@ -24,6 +24,6 @@ data class DetailAttendancesBySessionResponse(
 
     data class DetailAttendance(
         val status: String,
-        val attendedAt: LocalDateTime,
+        val attendedAt: LocalDateTime?,
     )
 }

--- a/src/main/kotlin/com/server/dpmcore/attendance/presentation/dto/response/MyDetailAttendanceBySessionResponse.kt
+++ b/src/main/kotlin/com/server/dpmcore/attendance/presentation/dto/response/MyDetailAttendanceBySessionResponse.kt
@@ -9,7 +9,7 @@ data class MyDetailAttendanceBySessionResponse(
 
 data class MyDetailAttendanceInfo(
     val status: String,
-    val attendedAt: LocalDateTime,
+    val attendedAt: LocalDateTime?,
 )
 
 data class MyDetailAttendanceSessionInfo(

--- a/src/main/kotlin/com/server/dpmcore/attendance/presentation/mapper/AttendanceMapper.kt
+++ b/src/main/kotlin/com/server/dpmcore/attendance/presentation/mapper/AttendanceMapper.kt
@@ -100,7 +100,7 @@ object AttendanceMapper {
             attendance =
                 DetailAttendancesBySessionResponse.DetailAttendance(
                     status = model.attendanceStatus,
-                    attendedAt = instantToLocalDateTime(model.attendedAt),
+                    attendedAt = model.attendedAt?.let { instantToLocalDateTime(it) },
                 ),
         )
 
@@ -142,7 +142,7 @@ object AttendanceMapper {
             attendance =
                 MyDetailAttendanceInfo(
                     status = myAttendanceModel.attendanceStatus,
-                    attendedAt = instantToLocalDateTime(myAttendanceModel.attendedAt),
+                    attendedAt = myAttendanceModel.attendedAt?.let { instantToLocalDateTime(it) },
                 ),
             session =
                 MyDetailAttendanceSessionInfo(


### PR DESCRIPTION
## Summary

>- close #78 

<!-- 해당 PR에 대한 요약을 작성해주세요. -->

## Tasks

- 출석 페이지네이션 cursorId where 조건을 member_id로 변경하였습니다.
- 출석의 attended_at을 미출석을 고려해 nullable하게 처리하였습니다.
