### PR TITLE
feat: 정산서 조회 체크 및 회식 참여 관련 API 구현

### DIFF
--- a/src/main/kotlin/com/server/dpmcore/bill/bill/presentation/controller/BillCommandApi.kt
+++ b/src/main/kotlin/com/server/dpmcore/bill/bill/presentation/controller/BillCommandApi.kt
@@ -1,5 +1,6 @@
 package com.server.dpmcore.bill.bill.presentation.controller
 
+import com.server.dpmcore.bill.bill.domain.model.BillId
 import com.server.dpmcore.bill.bill.presentation.dto.request.CreateBillRequest
 import com.server.dpmcore.bill.bill.presentation.dto.response.BillPersistenceResponse
 import com.server.dpmcore.common.exception.CustomResponse
@@ -12,6 +13,8 @@ import io.swagger.v3.oas.annotations.parameters.RequestBody
 import io.swagger.v3.oas.annotations.responses.ApiResponse
 import io.swagger.v3.oas.annotations.responses.ApiResponses
 import io.swagger.v3.oas.annotations.tags.Tag
+import jakarta.validation.Valid
+import jakarta.validation.constraints.Positive
 import org.springframework.http.MediaType.APPLICATION_JSON_VALUE
 
 @Tag(name = "Bill", description = "정산 API")
@@ -90,7 +93,7 @@ interface BillCommandApi {
     )
     fun createBill(
         hostUserId: MemberId,
-        createBillRequest: CreateBillRequest,
+        @Valid createBillRequest: CreateBillRequest,
     ): CustomResponse<BillPersistenceResponse>
 
     @Operation(
@@ -128,4 +131,23 @@ interface BillCommandApi {
         ],
     )
     fun closeBillParticipation(billId: Long): CustomResponse<BillPersistenceResponse>
+
+    @Operation(
+        summary = "정산서 조회 처리",
+        description = "정산서를 조회 처리합니다. 회식 참여 멤버의 조회 상태를 업데이트합니다.",
+    )
+    @ApiResponse(
+        responseCode = "204",
+        description = "정산서 조회 처리",
+        content = [
+            Content(
+                mediaType = APPLICATION_JSON_VALUE,
+                schema = Schema(implementation = CustomResponse::class),
+            ),
+        ],
+    )
+    fun markBillAsChecked(
+        @Positive billId: BillId,
+        memberId: MemberId,
+    ): CustomResponse<Void>
 }

--- a/src/main/kotlin/com/server/dpmcore/bill/bill/presentation/controller/BillCommandController.kt
+++ b/src/main/kotlin/com/server/dpmcore/bill/bill/presentation/controller/BillCommandController.kt
@@ -42,7 +42,7 @@ class BillCommandController(
         return CustomResponse.ok(BillPersistenceResponse(updatedBillId))
     }
 
-    @PostMapping("/{billId}/confirmed")
+    @PatchMapping("/{billId}/confirm")
     override fun markBillAsChecked(
         @Positive @PathVariable billId: BillId,
         @CurrentMemberId memberId: MemberId,

--- a/src/main/kotlin/com/server/dpmcore/bill/bill/presentation/controller/BillCommandController.kt
+++ b/src/main/kotlin/com/server/dpmcore/bill/bill/presentation/controller/BillCommandController.kt
@@ -9,6 +9,7 @@ import com.server.dpmcore.gathering.gathering.application.GatheringQueryService
 import com.server.dpmcore.member.member.domain.model.MemberId
 import com.server.dpmcore.security.annotation.CurrentMemberId
 import jakarta.validation.Valid
+import jakarta.validation.constraints.Positive
 import org.springframework.web.bind.annotation.PatchMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
@@ -39,5 +40,14 @@ class BillCommandController(
     ): CustomResponse<BillPersistenceResponse> {
         val updatedBillId = billCommandService.closeBillParticipation(BillId(billId))
         return CustomResponse.ok(BillPersistenceResponse(updatedBillId))
+    }
+
+    @PostMapping("/{billId}/confirmed")
+    override fun markBillAsChecked(
+        @Positive @PathVariable billId: BillId,
+        @CurrentMemberId memberId: MemberId,
+    ): CustomResponse<Void> {
+        billCommandService.markBillAsChecked(billId, memberId)
+        return CustomResponse.noContent()
     }
 }

--- a/src/main/kotlin/com/server/dpmcore/bill/bill/presentation/mapper/BillMapper.kt
+++ b/src/main/kotlin/com/server/dpmcore/bill/bill/presentation/mapper/BillMapper.kt
@@ -21,7 +21,8 @@ class BillMapper(
     private val gatheringQueryUseCase: GatheringQueryUseCase,
 ) {
     fun toBillDetailResponse(bill: Bill): BillDetailResponse {
-        val gatherings = gatheringQueryUseCase.findByBillId(bill.id ?: throw BillException.BillNotFoundException())
+        val gatherings =
+            gatheringQueryUseCase.getAllGatheringsByBillId(bill.id ?: throw BillException.BillNotFoundException())
 
         val gatheringReceipt =
             gatherings.map { gathering ->
@@ -75,7 +76,7 @@ class BillMapper(
 
     fun toBillListDetailResponse(bill: Bill): BillListDetailResponse {
         val gatheringDetails =
-            gatheringQueryUseCase.findByBillId(bill.id ?: throw BillException.BillNotFoundException()).map {
+            gatheringQueryUseCase.getAllGatheringsByBillId(bill.id ?: throw BillException.BillNotFoundException()).map {
                 toBillListGatheringDetailResponse(it)
             }
         val billTotalAmount =

--- a/src/main/kotlin/com/server/dpmcore/gathering/exception/GatheringException.kt
+++ b/src/main/kotlin/com/server/dpmcore/gathering/exception/GatheringException.kt
@@ -10,4 +10,6 @@ open class GatheringException(
     class GatheringRequiredException : GatheringException(GatheringExceptionCode.GATHERING_REQUIRED)
 
     class GatheringNotFoundException : GatheringException(GatheringExceptionCode.GATHERING_NOT_FOUND)
+
+    class GatheringIdRequiredException : GatheringException(GatheringExceptionCode.GATHERING_ID_REQUIRED)
 }

--- a/src/main/kotlin/com/server/dpmcore/gathering/exception/GatheringExceptionCode.kt
+++ b/src/main/kotlin/com/server/dpmcore/gathering/exception/GatheringExceptionCode.kt
@@ -15,6 +15,7 @@ enum class GatheringExceptionCode(
 
     GATHERING_NOT_FOUND(HttpStatus.BAD_REQUEST, "GATHERING-404-01", "존재하지 않는 회식입니다."),
     GATHERING_REQUIRED(HttpStatus.BAD_REQUEST, "GATHERING-404-02", "회식은 필수로 존재해야합니다."),
+    GATHERING_ID_REQUIRED(HttpStatus.BAD_REQUEST, "GATHERING-404-03", "회식 ID는 필수로 존재해야합니다."),
     ;
 
     override fun getStatus(): HttpStatus = status

--- a/src/main/kotlin/com/server/dpmcore/gathering/gathering/application/GatheringCommandService.kt
+++ b/src/main/kotlin/com/server/dpmcore/gathering/gathering/application/GatheringCommandService.kt
@@ -9,6 +9,7 @@ import com.server.dpmcore.gathering.gathering.domain.model.GatheringId
 import com.server.dpmcore.gathering.gathering.domain.port.inbound.GatheringCommandUseCase
 import com.server.dpmcore.gathering.gathering.domain.port.inbound.command.GatheringCreateCommand
 import com.server.dpmcore.gathering.gathering.domain.port.outbound.GatheringPersistencePort
+import com.server.dpmcore.gathering.gathering.presentation.request.UpdateGatheringJoinsRequest
 import com.server.dpmcore.gathering.gatheringMember.application.GatheringMemberCommandService
 import com.server.dpmcore.gathering.gatheringMember.application.GatheringMemberQueryService
 import com.server.dpmcore.gathering.gatheringReceipt.application.GatheringReceiptCommandService
@@ -79,11 +80,13 @@ class GatheringCommandService(
     }
 
     fun markAsJoinedEachGatheringMember(
-        gatheringId: GatheringId,
+        request: UpdateGatheringJoinsRequest,
         memberId: MemberId,
     ) {
-        val gatheringMembers =
-            gatheringMemberQueryService.getGatheringMembersByGatheringIdAndMemberId(gatheringId, memberId)
-        gatheringMemberCommandService.markAsJoined(gatheringMembers)
+        request.gatheringJoins.forEach {
+            val gatheringMembers =
+                gatheringMemberQueryService.getGatheringMembersByGatheringIdAndMemberId(it.gatheringId, memberId)
+            gatheringMemberCommandService.markAsJoined(gatheringMembers, it.isJoined)
+        }
     }
 }

--- a/src/main/kotlin/com/server/dpmcore/gathering/gathering/application/GatheringCommandService.kt
+++ b/src/main/kotlin/com/server/dpmcore/gathering/gathering/application/GatheringCommandService.kt
@@ -5,10 +5,12 @@ import com.server.dpmcore.bill.bill.domain.model.Bill
 import com.server.dpmcore.bill.bill.domain.model.BillId
 import com.server.dpmcore.bill.bill.domain.port.inbound.BillQueryUseCase
 import com.server.dpmcore.gathering.gathering.domain.model.Gathering
+import com.server.dpmcore.gathering.gathering.domain.model.GatheringId
 import com.server.dpmcore.gathering.gathering.domain.port.inbound.GatheringCommandUseCase
 import com.server.dpmcore.gathering.gathering.domain.port.inbound.command.GatheringCreateCommand
 import com.server.dpmcore.gathering.gathering.domain.port.outbound.GatheringPersistencePort
 import com.server.dpmcore.gathering.gatheringMember.application.GatheringMemberCommandService
+import com.server.dpmcore.gathering.gatheringMember.application.GatheringMemberQueryService
 import com.server.dpmcore.gathering.gatheringReceipt.application.GatheringReceiptCommandService
 import com.server.dpmcore.gathering.gatheringReceipt.domain.model.GatheringReceipt
 import com.server.dpmcore.member.member.domain.model.MemberId
@@ -22,6 +24,7 @@ class GatheringCommandService(
     private val gatheringPersistencePort: GatheringPersistencePort,
     private val gatheringReceiptCommandService: GatheringReceiptCommandService,
     private val gatheringMemberCommandService: GatheringMemberCommandService,
+    private val gatheringMemberQueryService: GatheringMemberQueryService,
     private val queryMemberByAuthorityUseCase: QueryMemberByAuthorityUseCase,
     private val billQueryUseCase: BillQueryUseCase,
 ) : GatheringCommandUseCase {
@@ -64,4 +67,14 @@ class GatheringCommandService(
 
     override fun updateGatheringReceiptSplitAmount(receipt: GatheringReceipt): Boolean =
         gatheringReceiptCommandService.updateSplitAmount(receipt)
+
+    override fun markAsCheckedEachGatheringMember(
+        gatheringIds: List<GatheringId>,
+        memberId: MemberId,
+    ) {
+        gatheringIds.forEach {
+            val gatheringMembers = gatheringMemberQueryService.getGatheringMembersByGatheringIdAndMemberId(it, memberId)
+            gatheringMemberCommandService.markAsChecked(gatheringMembers)
+        }
+    }
 }

--- a/src/main/kotlin/com/server/dpmcore/gathering/gathering/application/GatheringCommandService.kt
+++ b/src/main/kotlin/com/server/dpmcore/gathering/gathering/application/GatheringCommandService.kt
@@ -77,4 +77,13 @@ class GatheringCommandService(
             gatheringMemberCommandService.markAsChecked(gatheringMembers)
         }
     }
+
+    fun markAsJoinedEachGatheringMember(
+        gatheringId: GatheringId,
+        memberId: MemberId,
+    ) {
+        val gatheringMembers =
+            gatheringMemberQueryService.getGatheringMembersByGatheringIdAndMemberId(gatheringId, memberId)
+        gatheringMemberCommandService.markAsJoined(gatheringMembers)
+    }
 }

--- a/src/main/kotlin/com/server/dpmcore/gathering/gathering/application/GatheringQueryService.kt
+++ b/src/main/kotlin/com/server/dpmcore/gathering/gathering/application/GatheringQueryService.kt
@@ -26,9 +26,12 @@ class GatheringQueryService(
     override fun getAllGatheringsByGatheringIds(gatheringIds: List<GatheringId>): List<Gathering> =
         gatheringPersistencePort.findAllByGatheringIds(gatheringIds)
 
-    override fun findByBillId(billId: BillId): List<Gathering> =
+    override fun getAllGatheringsByBillId(billId: BillId): List<Gathering> =
         gatheringPersistencePort
             .findByBillId(billId)
+
+    override fun getAllGatheringIdsByBillId(billId: BillId): List<GatheringId> =
+        gatheringPersistencePort.findAllGatheringIdsByBillId(billId)
 
     override fun findGatheringReceiptByGatheringId(gatheringId: GatheringId): GatheringReceipt =
         gatheringReceiptQueryService

--- a/src/main/kotlin/com/server/dpmcore/gathering/gathering/domain/port/inbound/GatheringCommandUseCase.kt
+++ b/src/main/kotlin/com/server/dpmcore/gathering/gathering/domain/port/inbound/GatheringCommandUseCase.kt
@@ -2,8 +2,10 @@ package com.server.dpmcore.gathering.gathering.domain.port.inbound
 
 import com.server.dpmcore.authority.domain.model.AuthorityId
 import com.server.dpmcore.bill.bill.domain.model.BillId
+import com.server.dpmcore.gathering.gathering.domain.model.GatheringId
 import com.server.dpmcore.gathering.gathering.domain.port.inbound.command.GatheringCreateCommand
 import com.server.dpmcore.gathering.gatheringReceipt.domain.model.GatheringReceipt
+import com.server.dpmcore.member.member.domain.model.MemberId
 
 interface GatheringCommandUseCase {
     fun saveAllGatherings(
@@ -13,4 +15,9 @@ interface GatheringCommandUseCase {
     )
 
     fun updateGatheringReceiptSplitAmount(receipt: GatheringReceipt): Boolean
+
+    fun markAsCheckedEachGatheringMember(
+        gatheringIds: List<GatheringId>,
+        memberId: MemberId,
+    )
 }

--- a/src/main/kotlin/com/server/dpmcore/gathering/gathering/domain/port/inbound/GatheringQueryUseCase.kt
+++ b/src/main/kotlin/com/server/dpmcore/gathering/gathering/domain/port/inbound/GatheringQueryUseCase.kt
@@ -9,7 +9,9 @@ import com.server.dpmcore.gathering.gatheringReceipt.domain.model.GatheringRecei
 interface GatheringQueryUseCase {
     fun getAllGatheringsByGatheringIds(gatheringIds: List<GatheringId>): List<Gathering>
 
-    fun findByBillId(billId: BillId): List<Gathering>
+    fun getAllGatheringsByBillId(billId: BillId): List<Gathering>
+
+    fun getAllGatheringIdsByBillId(billId: BillId): List<GatheringId>
 
     fun findGatheringReceiptByGatheringId(gatheringId: GatheringId): GatheringReceipt
 

--- a/src/main/kotlin/com/server/dpmcore/gathering/gathering/domain/port/outbound/GatheringPersistencePort.kt
+++ b/src/main/kotlin/com/server/dpmcore/gathering/gathering/domain/port/outbound/GatheringPersistencePort.kt
@@ -23,4 +23,6 @@ interface GatheringPersistencePort {
     )
 
     fun findAllByGatheringIds(gatheringIds: List<GatheringId>): List<Gathering>
+
+    fun findAllGatheringIdsByBillId(billId: BillId): List<GatheringId>
 }

--- a/src/main/kotlin/com/server/dpmcore/gathering/gathering/presentation/controller/GatheringApi.kt
+++ b/src/main/kotlin/com/server/dpmcore/gathering/gathering/presentation/controller/GatheringApi.kt
@@ -1,0 +1,34 @@
+package com.server.dpmcore.gathering.gathering.presentation.controller
+
+import com.server.dpmcore.common.exception.CustomResponse
+import com.server.dpmcore.gathering.gathering.domain.model.GatheringId
+import com.server.dpmcore.member.member.domain.model.MemberId
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.media.Content
+import io.swagger.v3.oas.annotations.media.Schema
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.tags.Tag
+import jakarta.validation.constraints.Positive
+import org.springframework.http.MediaType.APPLICATION_JSON_VALUE
+
+@Tag(name = "Gathering", description = "회식 API")
+interface GatheringApi {
+    @ApiResponse(
+        responseCode = "204",
+        description = "단일 회식 참여 추가",
+        content = [
+            Content(
+                mediaType = APPLICATION_JSON_VALUE,
+                schema = Schema(implementation = CustomResponse::class),
+            ),
+        ],
+    )
+    @Operation(
+        summary = "단일 회식 참여 추가",
+        description = "특정 단일 회식에 참여 하였음으로 표시합니다.",
+    )
+    fun markAsJoined(
+        @Positive gatheringId: GatheringId,
+        memberId: MemberId,
+    ): CustomResponse<Void>
+}

--- a/src/main/kotlin/com/server/dpmcore/gathering/gathering/presentation/controller/GatheringApi.kt
+++ b/src/main/kotlin/com/server/dpmcore/gathering/gathering/presentation/controller/GatheringApi.kt
@@ -1,21 +1,20 @@
 package com.server.dpmcore.gathering.gathering.presentation.controller
 
 import com.server.dpmcore.common.exception.CustomResponse
-import com.server.dpmcore.gathering.gathering.domain.model.GatheringId
+import com.server.dpmcore.gathering.gathering.presentation.request.UpdateGatheringJoinsRequest
 import com.server.dpmcore.member.member.domain.model.MemberId
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.media.Content
 import io.swagger.v3.oas.annotations.media.Schema
 import io.swagger.v3.oas.annotations.responses.ApiResponse
 import io.swagger.v3.oas.annotations.tags.Tag
-import jakarta.validation.constraints.Positive
 import org.springframework.http.MediaType.APPLICATION_JSON_VALUE
 
 @Tag(name = "Gathering", description = "회식 API")
 interface GatheringApi {
     @ApiResponse(
         responseCode = "204",
-        description = "단일 회식 참여 추가",
+        description = "각 회식 참여 추가",
         content = [
             Content(
                 mediaType = APPLICATION_JSON_VALUE,
@@ -24,11 +23,11 @@ interface GatheringApi {
         ],
     )
     @Operation(
-        summary = "단일 회식 참여 추가",
-        description = "특정 단일 회식에 참여 하였음으로 표시합니다.",
+        summary = "각 회식 참여 추가",
+        description = "여러 회식의 참여 여부를 표시합니다.",
     )
     fun markAsJoined(
-        @Positive gatheringId: GatheringId,
+        request: UpdateGatheringJoinsRequest,
         memberId: MemberId,
     ): CustomResponse<Void>
 }

--- a/src/main/kotlin/com/server/dpmcore/gathering/gathering/presentation/controller/GatheringController.kt
+++ b/src/main/kotlin/com/server/dpmcore/gathering/gathering/presentation/controller/GatheringController.kt
@@ -1,0 +1,27 @@
+package com.server.dpmcore.gathering.gathering.presentation.controller
+
+import com.server.dpmcore.common.exception.CustomResponse
+import com.server.dpmcore.gathering.gathering.application.GatheringCommandService
+import com.server.dpmcore.gathering.gathering.domain.model.GatheringId
+import com.server.dpmcore.member.member.domain.model.MemberId
+import com.server.dpmcore.security.annotation.CurrentMemberId
+import jakarta.validation.constraints.Positive
+import org.springframework.web.bind.annotation.PatchMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/v1/gatherings")
+class GatheringController(
+    private val gatheringCommandService: GatheringCommandService,
+) : GatheringApi {
+    @PatchMapping("/{gatheringId}/join")
+    override fun markAsJoined(
+        @Positive @PathVariable gatheringId: GatheringId,
+        @CurrentMemberId memberId: MemberId,
+    ): CustomResponse<Void> {
+        gatheringCommandService.markAsJoinedEachGatheringMember(gatheringId, memberId)
+        return CustomResponse.noContent()
+    }
+}

--- a/src/main/kotlin/com/server/dpmcore/gathering/gathering/presentation/controller/GatheringController.kt
+++ b/src/main/kotlin/com/server/dpmcore/gathering/gathering/presentation/controller/GatheringController.kt
@@ -2,12 +2,11 @@ package com.server.dpmcore.gathering.gathering.presentation.controller
 
 import com.server.dpmcore.common.exception.CustomResponse
 import com.server.dpmcore.gathering.gathering.application.GatheringCommandService
-import com.server.dpmcore.gathering.gathering.domain.model.GatheringId
+import com.server.dpmcore.gathering.gathering.presentation.request.UpdateGatheringJoinsRequest
 import com.server.dpmcore.member.member.domain.model.MemberId
 import com.server.dpmcore.security.annotation.CurrentMemberId
-import jakarta.validation.constraints.Positive
 import org.springframework.web.bind.annotation.PatchMapping
-import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 
@@ -18,10 +17,10 @@ class GatheringController(
 ) : GatheringApi {
     @PatchMapping("/{gatheringId}/join")
     override fun markAsJoined(
-        @Positive @PathVariable gatheringId: GatheringId,
+        @RequestBody request: UpdateGatheringJoinsRequest,
         @CurrentMemberId memberId: MemberId,
     ): CustomResponse<Void> {
-        gatheringCommandService.markAsJoinedEachGatheringMember(gatheringId, memberId)
+        gatheringCommandService.markAsJoinedEachGatheringMember(request, memberId)
         return CustomResponse.noContent()
     }
 }

--- a/src/main/kotlin/com/server/dpmcore/gathering/gathering/presentation/request/UpdateGatheringJoinsRequest.kt
+++ b/src/main/kotlin/com/server/dpmcore/gathering/gathering/presentation/request/UpdateGatheringJoinsRequest.kt
@@ -1,0 +1,12 @@
+package com.server.dpmcore.gathering.gathering.presentation.request
+
+import com.server.dpmcore.gathering.gathering.domain.model.GatheringId
+
+data class UpdateGatheringJoinsRequest(
+    val gatheringJoins: List<EachGatheringJoin>,
+) {
+    data class EachGatheringJoin(
+        val gatheringId: GatheringId,
+        val isJoined: Boolean,
+    )
+}

--- a/src/main/kotlin/com/server/dpmcore/gathering/gatheringMember/application/GatheringMemberCommandService.kt
+++ b/src/main/kotlin/com/server/dpmcore/gathering/gatheringMember/application/GatheringMemberCommandService.kt
@@ -2,7 +2,7 @@ package com.server.dpmcore.gathering.gatheringMember.application
 
 import com.server.dpmcore.gathering.gathering.domain.model.Gathering
 import com.server.dpmcore.gathering.gatheringMember.domain.model.GatheringMember
-import com.server.dpmcore.gathering.gatheringMember.domain.port.GatheringMemberPersistencePort
+import com.server.dpmcore.gathering.gatheringMember.domain.port.outbound.GatheringMemberPersistencePort
 import com.server.dpmcore.member.member.domain.model.MemberId
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -17,5 +17,12 @@ class GatheringMemberCommandService(
         gathering: Gathering,
     ) = memberIds.map { memberId ->
         gatheringMemberPersistencePort.save(GatheringMember.create(gathering.id!!, memberId), gathering)
+    }
+
+    fun markAsChecked(gatheringMembers: List<GatheringMember>) {
+        gatheringMembers.forEach {
+            it.markAsChecked()
+            gatheringMemberPersistencePort.updateGatheringMemberById(it)
+        }
     }
 }

--- a/src/main/kotlin/com/server/dpmcore/gathering/gatheringMember/application/GatheringMemberCommandService.kt
+++ b/src/main/kotlin/com/server/dpmcore/gathering/gatheringMember/application/GatheringMemberCommandService.kt
@@ -25,4 +25,11 @@ class GatheringMemberCommandService(
             gatheringMemberPersistencePort.updateGatheringMemberById(it)
         }
     }
+
+    fun markAsJoined(gatheringMembers: List<GatheringMember>) {
+        gatheringMembers.forEach {
+            it.markAsJoined()
+            gatheringMemberPersistencePort.updateGatheringMemberById(it)
+        }
+    }
 }

--- a/src/main/kotlin/com/server/dpmcore/gathering/gatheringMember/application/GatheringMemberCommandService.kt
+++ b/src/main/kotlin/com/server/dpmcore/gathering/gatheringMember/application/GatheringMemberCommandService.kt
@@ -26,9 +26,12 @@ class GatheringMemberCommandService(
         }
     }
 
-    fun markAsJoined(gatheringMembers: List<GatheringMember>) {
+    fun markAsJoined(
+        gatheringMembers: List<GatheringMember>,
+        isJoined: Boolean,
+    ) {
         gatheringMembers.forEach {
-            it.markAsJoined()
+            it.markAsJoined(isJoined)
             gatheringMemberPersistencePort.updateGatheringMemberById(it)
         }
     }

--- a/src/main/kotlin/com/server/dpmcore/gathering/gatheringMember/application/GatheringMemberQueryService.kt
+++ b/src/main/kotlin/com/server/dpmcore/gathering/gatheringMember/application/GatheringMemberQueryService.kt
@@ -2,16 +2,22 @@ package com.server.dpmcore.gathering.gatheringMember.application
 
 import com.server.dpmcore.gathering.gathering.domain.model.GatheringId
 import com.server.dpmcore.gathering.gatheringMember.domain.model.GatheringMember
-import com.server.dpmcore.gathering.gatheringMember.domain.port.GatheringMemberQueryUseCase
-import com.server.dpmcore.gathering.gatheringMember.infrastructure.repository.GatheringMemberRepository
+import com.server.dpmcore.gathering.gatheringMember.domain.port.inbound.GatheringMemberQueryUseCase
+import com.server.dpmcore.gathering.gatheringMember.domain.port.outbound.GatheringMemberPersistencePort
+import com.server.dpmcore.member.member.domain.model.MemberId
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
 @Service
 @Transactional(readOnly = true)
 class GatheringMemberQueryService(
-    private val gatheringMemberRepository: GatheringMemberRepository,
+    private val gatheringMemberPersistencePort: GatheringMemberPersistencePort,
 ) : GatheringMemberQueryUseCase {
     override fun getGatheringMemberByGatheringId(gatheringId: GatheringId): List<GatheringMember> =
-        gatheringMemberRepository.findByGatheringId(gatheringId)
+        gatheringMemberPersistencePort.findByGatheringId(gatheringId)
+
+    fun getGatheringMembersByGatheringIdAndMemberId(
+        gatheringId: GatheringId,
+        memberId: MemberId,
+    ): List<GatheringMember> = gatheringMemberPersistencePort.findByGatheringIdAndMemberId(gatheringId, memberId)
 }

--- a/src/main/kotlin/com/server/dpmcore/gathering/gatheringMember/application/GatheringMemberQueryService.kt
+++ b/src/main/kotlin/com/server/dpmcore/gathering/gatheringMember/application/GatheringMemberQueryService.kt
@@ -1,5 +1,6 @@
 package com.server.dpmcore.gathering.gatheringMember.application
 
+import com.server.dpmcore.gathering.exception.GatheringMemberException
 import com.server.dpmcore.gathering.gathering.domain.model.GatheringId
 import com.server.dpmcore.gathering.gatheringMember.domain.model.GatheringMember
 import com.server.dpmcore.gathering.gatheringMember.domain.port.inbound.GatheringMemberQueryUseCase
@@ -19,5 +20,9 @@ class GatheringMemberQueryService(
     fun getGatheringMembersByGatheringIdAndMemberId(
         gatheringId: GatheringId,
         memberId: MemberId,
-    ): List<GatheringMember> = gatheringMemberPersistencePort.findByGatheringIdAndMemberId(gatheringId, memberId)
+    ): List<GatheringMember> =
+        gatheringMemberPersistencePort
+            .findByGatheringIdAndMemberId(gatheringId, memberId)
+            .takeIf { it.isNotEmpty() }
+            ?: throw GatheringMemberException.GatheringMemberNotFoundException()
 }

--- a/src/main/kotlin/com/server/dpmcore/gathering/gatheringMember/domain/model/GatheringMember.kt
+++ b/src/main/kotlin/com/server/dpmcore/gathering/gatheringMember/domain/model/GatheringMember.kt
@@ -43,8 +43,8 @@ class GatheringMember(
         this.updatedAt = Instant.now()
     }
 
-    fun markAsJoined() {
-        this.isJoined = true
+    fun markAsJoined(isJoined: Boolean) {
+        this.isJoined = isJoined
         this.updatedAt = Instant.now()
     }
 

--- a/src/main/kotlin/com/server/dpmcore/gathering/gatheringMember/domain/model/GatheringMember.kt
+++ b/src/main/kotlin/com/server/dpmcore/gathering/gatheringMember/domain/model/GatheringMember.kt
@@ -16,13 +16,16 @@ class GatheringMember(
     val id: GatheringMemberId? = null,
     val memberId: MemberId,
     val gatheringId: GatheringId,
-    val isChecked: Boolean = false,
+    isChecked: Boolean = false,
     val isJoined: Boolean = false,
     val createdAt: Instant? = null,
     completedAt: Instant? = null,
     updatedAt: Instant? = null,
     deletedAt: Instant? = null,
 ) {
+    var isChecked: Boolean = isChecked
+        private set
+
     var completedAt: Instant? = completedAt
         private set
 
@@ -31,6 +34,11 @@ class GatheringMember(
 
     var deletedAt: Instant? = deletedAt
         private set
+
+    fun markAsChecked() {
+        this.isChecked = true
+        this.updatedAt = Instant.now()
+    }
 
     fun isDeleted(): Boolean = deletedAt != null
 

--- a/src/main/kotlin/com/server/dpmcore/gathering/gatheringMember/domain/model/GatheringMember.kt
+++ b/src/main/kotlin/com/server/dpmcore/gathering/gatheringMember/domain/model/GatheringMember.kt
@@ -17,13 +17,16 @@ class GatheringMember(
     val memberId: MemberId,
     val gatheringId: GatheringId,
     isChecked: Boolean = false,
-    val isJoined: Boolean = false,
+    isJoined: Boolean = false,
     val createdAt: Instant? = null,
     completedAt: Instant? = null,
     updatedAt: Instant? = null,
     deletedAt: Instant? = null,
 ) {
     var isChecked: Boolean = isChecked
+        private set
+
+    var isJoined: Boolean = isJoined
         private set
 
     var completedAt: Instant? = completedAt
@@ -37,6 +40,11 @@ class GatheringMember(
 
     fun markAsChecked() {
         this.isChecked = true
+        this.updatedAt = Instant.now()
+    }
+
+    fun markAsJoined() {
+        this.isJoined = true
         this.updatedAt = Instant.now()
     }
 

--- a/src/main/kotlin/com/server/dpmcore/gathering/gatheringMember/domain/port/inbound/GatheringMemberQueryUseCase.kt
+++ b/src/main/kotlin/com/server/dpmcore/gathering/gatheringMember/domain/port/inbound/GatheringMemberQueryUseCase.kt
@@ -1,4 +1,4 @@
-package com.server.dpmcore.gathering.gatheringMember.domain.port
+package com.server.dpmcore.gathering.gatheringMember.domain.port.inbound
 
 import com.server.dpmcore.gathering.gathering.domain.model.GatheringId
 import com.server.dpmcore.gathering.gatheringMember.domain.model.GatheringMember

--- a/src/main/kotlin/com/server/dpmcore/gathering/gatheringMember/domain/port/outbound/GatheringMemberPersistencePort.kt
+++ b/src/main/kotlin/com/server/dpmcore/gathering/gatheringMember/domain/port/outbound/GatheringMemberPersistencePort.kt
@@ -1,8 +1,9 @@
-package com.server.dpmcore.gathering.gatheringMember.domain.port
+package com.server.dpmcore.gathering.gatheringMember.domain.port.outbound
 
 import com.server.dpmcore.gathering.gathering.domain.model.Gathering
 import com.server.dpmcore.gathering.gathering.domain.model.GatheringId
 import com.server.dpmcore.gathering.gatheringMember.domain.model.GatheringMember
+import com.server.dpmcore.member.member.domain.model.MemberId
 
 interface GatheringMemberPersistencePort {
     fun save(
@@ -11,4 +12,11 @@ interface GatheringMemberPersistencePort {
     )
 
     fun findByGatheringId(gatheringId: GatheringId): List<GatheringMember>
+
+    fun findByGatheringIdAndMemberId(
+        gatheringId: GatheringId,
+        memberId: MemberId,
+    ): List<GatheringMember>
+
+    fun updateGatheringMemberById(gatheringMember: GatheringMember)
 }

--- a/src/main/kotlin/com/server/dpmcore/gathering/gatheringMember/infrastructure/repository/GatheringMemberJpaRepository.kt
+++ b/src/main/kotlin/com/server/dpmcore/gathering/gatheringMember/infrastructure/repository/GatheringMemberJpaRepository.kt
@@ -2,8 +2,14 @@ package com.server.dpmcore.gathering.gatheringMember.infrastructure.repository
 
 import com.server.dpmcore.gathering.gathering.domain.model.GatheringId
 import com.server.dpmcore.gathering.gatheringMember.infrastructure.entity.GatheringMemberEntity
+import com.server.dpmcore.member.member.domain.model.MemberId
 import org.springframework.data.jpa.repository.JpaRepository
 
 interface GatheringMemberJpaRepository : JpaRepository<GatheringMemberEntity, Long> {
     fun findByGatheringId(gatheringId: GatheringId): List<GatheringMemberEntity>
+
+    fun findByGatheringIdAndMemberId(
+        gatheringId: GatheringId,
+        memberId: MemberId,
+    ): List<GatheringMemberEntity>
 }

--- a/src/main/kotlin/com/server/dpmcore/gathering/gatheringMember/infrastructure/repository/GatheringMemberRepository.kt
+++ b/src/main/kotlin/com/server/dpmcore/gathering/gatheringMember/infrastructure/repository/GatheringMemberRepository.kt
@@ -1,15 +1,20 @@
 package com.server.dpmcore.gathering.gatheringMember.infrastructure.repository
 
+import com.linecorp.kotlinjdsl.querydsl.expression.col
+import com.linecorp.kotlinjdsl.spring.data.SpringDataQueryFactory
+import com.linecorp.kotlinjdsl.spring.data.updateQuery
 import com.server.dpmcore.gathering.gathering.domain.model.Gathering
 import com.server.dpmcore.gathering.gathering.domain.model.GatheringId
 import com.server.dpmcore.gathering.gatheringMember.domain.model.GatheringMember
-import com.server.dpmcore.gathering.gatheringMember.domain.port.GatheringMemberPersistencePort
+import com.server.dpmcore.gathering.gatheringMember.domain.port.outbound.GatheringMemberPersistencePort
 import com.server.dpmcore.gathering.gatheringMember.infrastructure.entity.GatheringMemberEntity
+import com.server.dpmcore.member.member.domain.model.MemberId
 import org.springframework.stereotype.Repository
 
 @Repository
 class GatheringMemberRepository(
     private val gatheringJpaRepository: GatheringMemberJpaRepository,
+    private val queryFactory: SpringDataQueryFactory,
 ) : GatheringMemberPersistencePort {
     override fun save(
         gatheringMember: GatheringMember,
@@ -20,4 +25,24 @@ class GatheringMemberRepository(
 
     override fun findByGatheringId(gatheringId: GatheringId): List<GatheringMember> =
         gatheringJpaRepository.findByGatheringId(gatheringId).map { it.toDomain() }
+
+    override fun findByGatheringIdAndMemberId(
+        gatheringId: GatheringId,
+        memberId: MemberId,
+    ): List<GatheringMember> =
+        gatheringJpaRepository.findByGatheringIdAndMemberId(gatheringId, memberId).map { it.toDomain() }
+
+    override fun updateGatheringMemberById(gatheringMember: GatheringMember) {
+        queryFactory
+            .updateQuery<GatheringMemberEntity> {
+                where(
+                    gatheringMember.id?.let { col(GatheringMemberEntity::id).equal(it.value) },
+                )
+                set(col(GatheringMemberEntity::isChecked), gatheringMember.isChecked)
+                set(col(GatheringMemberEntity::isJoined), gatheringMember.isJoined)
+                set(col(GatheringMemberEntity::completedAt), gatheringMember.completedAt)
+                set(col(GatheringMemberEntity::updatedAt), gatheringMember.updatedAt)
+                set(col(GatheringMemberEntity::deletedAt), gatheringMember.deletedAt)
+            }.executeUpdate()
+    }
 }

--- a/src/main/kotlin/com/server/dpmcore/gathering/gatheringMember/infrastructure/repository/GatheringMemberRepository.kt
+++ b/src/main/kotlin/com/server/dpmcore/gathering/gatheringMember/infrastructure/repository/GatheringMemberRepository.kt
@@ -3,6 +3,7 @@ package com.server.dpmcore.gathering.gatheringMember.infrastructure.repository
 import com.linecorp.kotlinjdsl.querydsl.expression.col
 import com.linecorp.kotlinjdsl.spring.data.SpringDataQueryFactory
 import com.linecorp.kotlinjdsl.spring.data.updateQuery
+import com.server.dpmcore.gathering.exception.GatheringException
 import com.server.dpmcore.gathering.gathering.domain.model.Gathering
 import com.server.dpmcore.gathering.gathering.domain.model.GatheringId
 import com.server.dpmcore.gathering.gatheringMember.domain.model.GatheringMember
@@ -33,11 +34,13 @@ class GatheringMemberRepository(
         gatheringJpaRepository.findByGatheringIdAndMemberId(gatheringId, memberId).map { it.toDomain() }
 
     override fun updateGatheringMemberById(gatheringMember: GatheringMember) {
+        val id =
+            gatheringMember.id?.value
+                ?: throw GatheringException.GatheringIdRequiredException()
+
         queryFactory
             .updateQuery<GatheringMemberEntity> {
-                where(
-                    gatheringMember.id?.let { col(GatheringMemberEntity::id).equal(it.value) },
-                )
+                where(col(GatheringMemberEntity::id).equal(id))
                 set(col(GatheringMemberEntity::isChecked), gatheringMember.isChecked)
                 set(col(GatheringMemberEntity::isJoined), gatheringMember.isJoined)
                 set(col(GatheringMemberEntity::completedAt), gatheringMember.completedAt)


### PR DESCRIPTION
## Summary

>- refs #83

정산서 조회 체크 및 회식 참여 관련 API를 구현하였습니다.
<!-- 해당 PR에 대한 요약을 작성해주세요. -->

## Tasks

- 정산서 조회 체크 API 구현
- 회식 참여 체크 API 구현

## ETC

Bill 및 Gathering 도메인에서 자칫 혼동을 줄 수 있는 메서드 명을 목적이 명확이 드러나도록 수정하였습니다

<!-- 추가적인 정보나 참고 사항을 작성해주세요. -->

## Screenshot

<!-- (없을 경우 삭제) 작업한 내용에 대한 스크린샷을 첨부해주세요._ -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 청구서 참여자가 확인 여부를 표시할 수 있는 API가 추가되었습니다.
  * 회식 참여자가 개별 회식에 참여했음을 표시하는 API가 추가되었습니다.

* **버그 수정**
  * 청구서 생성 요청에 대한 유효성 검증이 강화되었습니다.

* **개선 사항**
  * 회식 및 청구서 관련 예외 메시지가 추가되어 오류 상황에 대한 안내가 향상되었습니다.
  * 참여자 상태(확인/참여) 변경 로직이 추가되어 사용자 경험이 개선되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->