### PR TITLE
refactor: 세션 및 개인 출석 리스트 조회 API 내 팀 조회 조건 추가 및 기타 수정

### DIFF
--- a/src/main/kotlin/com/server/dpmcore/attendance/application/AttendanceCommandService.kt
+++ b/src/main/kotlin/com/server/dpmcore/attendance/application/AttendanceCommandService.kt
@@ -8,7 +8,7 @@ import com.server.dpmcore.attendance.domain.port.inbound.command.AttendanceRecor
 import com.server.dpmcore.attendance.domain.port.inbound.command.AttendanceStatusUpdateCommand
 import com.server.dpmcore.attendance.domain.port.outbound.AttendancePersistencePort
 import com.server.dpmcore.cohort.application.config.CohortProperties
-import com.server.dpmcore.member.member.application.MemberServiceQuery
+import com.server.dpmcore.member.member.application.MemberQueryService
 import com.server.dpmcore.member.member.domain.exception.CohortMembersNotFoundException
 import com.server.dpmcore.session.application.SessionQueryService
 import com.server.dpmcore.session.domain.exception.CheckedAttendanceException
@@ -21,7 +21,7 @@ import org.springframework.transaction.annotation.Transactional
 class AttendanceCommandService(
     private val attendancePersistencePort: AttendancePersistencePort,
     private val sessionQueryService: SessionQueryService,
-    private val memberService: MemberServiceQuery,
+    private val memberService: MemberQueryService,
     private val cohortProperties: CohortProperties,
 ) {
     fun attendSession(command: AttendanceRecordCommand): AttendanceStatus {

--- a/src/main/kotlin/com/server/dpmcore/attendance/application/AttendanceQueryService.kt
+++ b/src/main/kotlin/com/server/dpmcore/attendance/application/AttendanceQueryService.kt
@@ -15,7 +15,7 @@ import com.server.dpmcore.attendance.presentation.dto.response.MyDetailAttendanc
 import com.server.dpmcore.attendance.presentation.dto.response.SessionAttendancesResponse
 import com.server.dpmcore.attendance.presentation.mapper.AttendanceMapper
 import com.server.dpmcore.common.util.paginate
-import com.server.dpmcore.member.member.application.MemberService
+import com.server.dpmcore.member.member.application.MemberQueryService
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
@@ -24,14 +24,14 @@ private const val PAGE_SIZE = 20
 @Service
 @Transactional(readOnly = true)
 class AttendanceQueryService(
-    private val memberService: MemberService,
+    private val memberQueryService: MemberQueryService,
     private val attendancePersistencePort: AttendancePersistencePort,
     private val attendanceGraduationEvaluator: AttendanceGraduationEvaluator,
 ) {
     fun getAttendancesBySession(query: GetAttendancesBySessionWeekQuery): SessionAttendancesResponse {
         val myTeamNumber =
             query.onlyMyTeam
-                ?.let { memberService.getMemberTeamNumber(query.memberId) }
+                ?.let { memberQueryService.getMemberTeamNumber(query.memberId) }
 
         val queryResult =
             attendancePersistencePort
@@ -49,7 +49,7 @@ class AttendanceQueryService(
     fun getMemberAttendances(query: GetMemberAttendancesQuery): MemberAttendancesResponse {
         val myTeamNumber =
             query.onlyMyTeam
-                ?.let { memberService.getMemberTeamNumber(query.memberId) }
+                ?.let { memberQueryService.getMemberTeamNumber(query.memberId) }
 
         val queryResult =
             attendancePersistencePort

--- a/src/main/kotlin/com/server/dpmcore/attendance/application/AttendanceQueryService.kt
+++ b/src/main/kotlin/com/server/dpmcore/attendance/application/AttendanceQueryService.kt
@@ -15,6 +15,7 @@ import com.server.dpmcore.attendance.presentation.dto.response.MyDetailAttendanc
 import com.server.dpmcore.attendance.presentation.dto.response.SessionAttendancesResponse
 import com.server.dpmcore.attendance.presentation.mapper.AttendanceMapper
 import com.server.dpmcore.common.util.paginate
+import com.server.dpmcore.member.member.application.MemberService
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
@@ -23,6 +24,7 @@ private const val PAGE_SIZE = 20
 @Service
 @Transactional(readOnly = true)
 class AttendanceQueryService(
+    private val memberService: MemberService,
     private val attendancePersistencePort: AttendancePersistencePort,
     private val attendanceGraduationEvaluator: AttendanceGraduationEvaluator,
 ) {
@@ -41,9 +43,16 @@ class AttendanceQueryService(
     }
 
     fun getMemberAttendances(query: GetMemberAttendancesQuery): MemberAttendancesResponse {
+        println("멤버 아이디 : " + query.memberId.value)
+        val myTeamNumber =
+            query.onlyMyTeam
+                ?.let { memberService.getMemberTeamNumber(query.memberId) }
+
+        println("현재 팀 번호 : " + myTeamNumber)
+
         val queryResult =
             attendancePersistencePort
-                .findMemberAttendancesByQuery(query)
+                .findMemberAttendancesByQuery(query, myTeamNumber)
                 .sortedBy { it.teamNumber }
         val paginatedResult = queryResult.paginate { it.id }
 

--- a/src/main/kotlin/com/server/dpmcore/attendance/application/AttendanceQueryService.kt
+++ b/src/main/kotlin/com/server/dpmcore/attendance/application/AttendanceQueryService.kt
@@ -29,9 +29,13 @@ class AttendanceQueryService(
     private val attendanceGraduationEvaluator: AttendanceGraduationEvaluator,
 ) {
     fun getAttendancesBySession(query: GetAttendancesBySessionWeekQuery): SessionAttendancesResponse {
+        val myTeamNumber =
+            query.onlyMyTeam
+                ?.let { memberService.getMemberTeamNumber(query.memberId) }
+
         val queryResult =
             attendancePersistencePort
-                .findSessionAttendancesByQuery(query)
+                .findSessionAttendancesByQuery(query, myTeamNumber)
                 .sortedBy { it.teamNumber }
         val paginatedResult = queryResult.paginate { it.id }
 
@@ -43,12 +47,9 @@ class AttendanceQueryService(
     }
 
     fun getMemberAttendances(query: GetMemberAttendancesQuery): MemberAttendancesResponse {
-        println("멤버 아이디 : " + query.memberId.value)
         val myTeamNumber =
             query.onlyMyTeam
                 ?.let { memberService.getMemberTeamNumber(query.memberId) }
-
-        println("현재 팀 번호 : " + myTeamNumber)
 
         val queryResult =
             attendancePersistencePort

--- a/src/main/kotlin/com/server/dpmcore/attendance/domain/exception/AttendanceExceptionCode.kt
+++ b/src/main/kotlin/com/server/dpmcore/attendance/domain/exception/AttendanceExceptionCode.kt
@@ -8,14 +8,8 @@ enum class AttendanceExceptionCode(
     @JvmField val code: String,
     @JvmField val message: String,
 ) : ExceptionCode {
-    ATTENDANCE_NOT_FOUND(HttpStatus.NOT_FOUND, "A404", "출석을 찾을 수 없습니다"),
-    ATTENDANCE_ALREADY_EXISTS(HttpStatus.CONFLICT, "A409", "이미 존재하는 출석입니다"),
-    INVALID_ATTENDANCE_ID(HttpStatus.BAD_REQUEST, "A400", "유효하지 않은 출석 ID입니다"),
-    INVALID_ATTENDANCE_STATE(HttpStatus.BAD_REQUEST, "A400", "유효하지 않은 출석 상태입니다"),
-    INVALID_ATTENDANCE_CODE(HttpStatus.BAD_REQUEST, "A400", "출석코드가 일치하지 않습니다"),
-    TOO_EARLY_ATTENDANCE(HttpStatus.BAD_REQUEST, "A400", "출석하기에는 너무 이른 시간입니다"),
-    ALREADY_CHECKED_ATTENDANCE(HttpStatus.BAD_REQUEST, "A400", "이미 출석을 체크했습니다"),
-    ATTENDANCE_START_TIME_DATE_MISMATCH(HttpStatus.BAD_REQUEST, "A400", "출석 시작 시간의 날짜가 세션의 날짜와 일치하지 않습니다"),
+    INVALID_ATTENDANCE_ID(HttpStatus.BAD_REQUEST, "ATTENDANCE-400-01", "유효하지 않은 출석 아이디입니다"),
+    ATTENDANCE_NOT_FOUND(HttpStatus.NOT_FOUND, "ATTENDANCE-404-01", "출석을 찾을 수 없습니다"),
     ;
 
     override fun getStatus(): HttpStatus = this.status

--- a/src/main/kotlin/com/server/dpmcore/attendance/domain/port/inbound/query/GetAttendancesBySessionWeekQuery.kt
+++ b/src/main/kotlin/com/server/dpmcore/attendance/domain/port/inbound/query/GetAttendancesBySessionWeekQuery.kt
@@ -1,12 +1,15 @@
 package com.server.dpmcore.attendance.domain.port.inbound.query
 
 import com.server.dpmcore.attendance.domain.model.AttendanceStatus
+import com.server.dpmcore.member.member.domain.model.MemberId
 import com.server.dpmcore.session.domain.model.SessionId
 
 data class GetAttendancesBySessionWeekQuery(
     val sessionId: SessionId,
+    val memberId: MemberId,
     val statuses: List<AttendanceStatus>?,
     val teams: List<Int>?,
     val name: String?,
+    val onlyMyTeam: Boolean?,
     val cursorId: Long?,
 )

--- a/src/main/kotlin/com/server/dpmcore/attendance/domain/port/inbound/query/GetMemberAttendancesQuery.kt
+++ b/src/main/kotlin/com/server/dpmcore/attendance/domain/port/inbound/query/GetMemberAttendancesQuery.kt
@@ -1,10 +1,13 @@
 package com.server.dpmcore.attendance.domain.port.inbound.query
 
 import com.server.dpmcore.attendance.domain.model.AttendanceStatus
+import com.server.dpmcore.member.member.domain.model.MemberId
 
 data class GetMemberAttendancesQuery(
+    val memberId: MemberId,
     val statuses: List<AttendanceStatus>?,
     val teams: List<Int>?,
     val name: String?,
+    val onlyMyTeam: Boolean?,
     val cursorId: Long?,
 )

--- a/src/main/kotlin/com/server/dpmcore/attendance/domain/port/outbound/AttendancePersistencePort.kt
+++ b/src/main/kotlin/com/server/dpmcore/attendance/domain/port/outbound/AttendancePersistencePort.kt
@@ -25,7 +25,10 @@ interface AttendancePersistencePort {
 
     fun findSessionAttendancesByQuery(query: GetAttendancesBySessionWeekQuery): List<SessionAttendanceQueryModel>
 
-    fun findMemberAttendancesByQuery(query: GetMemberAttendancesQuery): List<MemberAttendanceQueryModel>
+    fun findMemberAttendancesByQuery(
+        query: GetMemberAttendancesQuery,
+        myTeamNumber: Int?,
+    ): List<MemberAttendanceQueryModel>
 
     fun findDetailAttendanceBySession(query: GetDetailAttendanceBySessionQuery): SessionDetailAttendanceQueryModel?
 

--- a/src/main/kotlin/com/server/dpmcore/attendance/domain/port/outbound/AttendancePersistencePort.kt
+++ b/src/main/kotlin/com/server/dpmcore/attendance/domain/port/outbound/AttendancePersistencePort.kt
@@ -23,7 +23,10 @@ interface AttendancePersistencePort {
 
     fun save(attendance: Attendance)
 
-    fun findSessionAttendancesByQuery(query: GetAttendancesBySessionWeekQuery): List<SessionAttendanceQueryModel>
+    fun findSessionAttendancesByQuery(
+        query: GetAttendancesBySessionWeekQuery,
+        myTeamNumber: Int?,
+    ): List<SessionAttendanceQueryModel>
 
     fun findMemberAttendancesByQuery(
         query: GetMemberAttendancesQuery,

--- a/src/main/kotlin/com/server/dpmcore/attendance/infrastructure/repository/AttendanceRepository.kt
+++ b/src/main/kotlin/com/server/dpmcore/attendance/infrastructure/repository/AttendanceRepository.kt
@@ -90,7 +90,10 @@ class AttendanceRepository(
                 )
             }
 
-    override fun findMemberAttendancesByQuery(query: GetMemberAttendancesQuery): List<MemberAttendanceQueryModel> =
+    override fun findMemberAttendancesByQuery(
+        query: GetMemberAttendancesQuery,
+        myTeamNumber: Int?,
+    ): List<MemberAttendanceQueryModel> =
         dsl
             .select(
                 ATTENDANCES.MEMBER_ID,
@@ -123,7 +126,7 @@ class AttendanceRepository(
             .join(TEAMS)
             .on(MEMBER_TEAMS.TEAM_ID.eq(TEAMS.TEAM_ID))
             .where(
-                query.toCondition(),
+                query.toCondition(myTeamNumber),
             ).groupBy(
                 ATTENDANCES.MEMBER_ID,
                 MEMBERS.NAME,

--- a/src/main/kotlin/com/server/dpmcore/attendance/infrastructure/repository/AttendanceRepository.kt
+++ b/src/main/kotlin/com/server/dpmcore/attendance/infrastructure/repository/AttendanceRepository.kt
@@ -59,6 +59,7 @@ class AttendanceRepository(
 
     override fun findSessionAttendancesByQuery(
         query: GetAttendancesBySessionWeekQuery,
+        myTeamNumber: Int?,
     ): List<SessionAttendanceQueryModel> =
         dsl
             .select(
@@ -77,7 +78,7 @@ class AttendanceRepository(
             .join(TEAMS)
             .on(MEMBER_TEAMS.TEAM_ID.eq(TEAMS.TEAM_ID))
             .where(
-                query.toCondition(),
+                query.toCondition(myTeamNumber),
             ).orderBy(ATTENDANCES.MEMBER_ID.asc(), TEAMS.NUMBER.asc())
             .limit(PAGE_SIZE + 1)
             .fetch { record ->

--- a/src/main/kotlin/com/server/dpmcore/attendance/infrastructure/repository/QueryConditionExtensions.kt
+++ b/src/main/kotlin/com/server/dpmcore/attendance/infrastructure/repository/QueryConditionExtensions.kt
@@ -35,15 +35,19 @@ fun GetAttendancesBySessionWeekQuery.toCondition(): List<Condition> {
     return conditions
 }
 
-fun GetMemberAttendancesQuery.toCondition(): List<Condition> {
+fun GetMemberAttendancesQuery.toCondition(myTeamNumber: Int?): List<Condition> {
     val conditions = mutableListOf<Condition>()
 
     this.statuses?.takeIf { it.isNotEmpty() }?.let {
         conditions += ATTENDANCES.STATUS.`in`(it)
     }
 
-    this.teams?.takeIf { it.isNotEmpty() }?.let {
-        conditions += TEAMS.NUMBER.`in`(it)
+    when {
+        onlyMyTeam == true ->
+            conditions += TEAMS.NUMBER.eq(myTeamNumber ?: 0)
+
+        teams?.isNotEmpty() == true ->
+            conditions += TEAMS.NUMBER.`in`(teams)
     }
 
     this.name?.takeIf { it.isNotBlank() }?.let {

--- a/src/main/kotlin/com/server/dpmcore/attendance/infrastructure/repository/QueryConditionExtensions.kt
+++ b/src/main/kotlin/com/server/dpmcore/attendance/infrastructure/repository/QueryConditionExtensions.kt
@@ -11,7 +11,7 @@ import org.jooq.generated.tables.references.MEMBERS
 import org.jooq.generated.tables.references.SESSIONS
 import org.jooq.generated.tables.references.TEAMS
 
-fun GetAttendancesBySessionWeekQuery.toCondition(): List<Condition> {
+fun GetAttendancesBySessionWeekQuery.toCondition(myTeamNumber: Int?): List<Condition> {
     val conditions = mutableListOf<Condition>()
 
     conditions += SESSIONS.SESSION_ID.eq(this.sessionId.value)
@@ -20,8 +20,12 @@ fun GetAttendancesBySessionWeekQuery.toCondition(): List<Condition> {
         conditions += ATTENDANCES.STATUS.`in`(it)
     }
 
-    this.teams?.takeIf { it.isNotEmpty() }?.let {
-        conditions += TEAMS.NUMBER.`in`(it)
+    when {
+        this.onlyMyTeam == true ->
+            conditions += TEAMS.NUMBER.eq(myTeamNumber ?: 0)
+
+        this.teams?.isNotEmpty() == true ->
+            conditions += TEAMS.NUMBER.`in`(this.teams)
     }
 
     this.name?.takeIf { it.isNotBlank() }?.let {
@@ -43,10 +47,10 @@ fun GetMemberAttendancesQuery.toCondition(myTeamNumber: Int?): List<Condition> {
     }
 
     when {
-        onlyMyTeam == true ->
+        this.onlyMyTeam == true ->
             conditions += TEAMS.NUMBER.eq(myTeamNumber ?: 0)
 
-        teams?.isNotEmpty() == true ->
+        this.teams?.isNotEmpty() == true ->
             conditions += TEAMS.NUMBER.`in`(teams)
     }
 

--- a/src/main/kotlin/com/server/dpmcore/attendance/presentation/AttendanceApi.kt
+++ b/src/main/kotlin/com/server/dpmcore/attendance/presentation/AttendanceApi.kt
@@ -136,9 +136,11 @@ interface AttendanceApi {
     )
     fun getAttendancesBySessionId(
         sessionId: SessionId,
+        memberId: MemberId,
         statuses: List<AttendanceStatus>?,
         teams: List<Int>?,
         name: String?,
+        onlyMyTeam: Boolean?,
         cursorId: Long?,
     ): CustomResponse<SessionAttendancesResponse>
 

--- a/src/main/kotlin/com/server/dpmcore/attendance/presentation/AttendanceApi.kt
+++ b/src/main/kotlin/com/server/dpmcore/attendance/presentation/AttendanceApi.kt
@@ -193,9 +193,11 @@ interface AttendanceApi {
         ],
     )
     fun getMemberAttendances(
+        memberId: MemberId,
         statuses: List<AttendanceStatus>?,
         teams: List<Int>?,
         name: String?,
+        onlyMyTeam: Boolean?,
         cursorId: Long?,
     ): CustomResponse<MemberAttendancesResponse>
 

--- a/src/main/kotlin/com/server/dpmcore/attendance/presentation/AttendanceController.kt
+++ b/src/main/kotlin/com/server/dpmcore/attendance/presentation/AttendanceController.kt
@@ -60,18 +60,22 @@ class AttendanceController(
     @GetMapping("/v1/sessions/{sessionId}/attendances")
     override fun getAttendancesBySessionId(
         @PathVariable sessionId: SessionId,
+        @CurrentMemberId memberId: MemberId,
         @RequestParam(name = "statuses", required = false) statuses: List<AttendanceStatus>?,
         @RequestParam(name = "teams", required = false) teams: List<Int>?,
         @RequestParam(name = "name", required = false) name: String?,
+        @RequestParam(name = "onlyMyTeam", required = false) onlyMyTeam: Boolean?,
         @RequestParam(name = "cursorId", required = false) cursorId: Long?,
     ): CustomResponse<SessionAttendancesResponse> {
         val response =
             attendanceQueryService.getAttendancesBySession(
                 GetAttendancesBySessionWeekQuery(
                     sessionId = sessionId,
+                    memberId = memberId,
                     statuses = statuses,
                     teams = teams,
                     name = name,
+                    onlyMyTeam = onlyMyTeam,
                     cursorId = cursorId,
                 ),
             )

--- a/src/main/kotlin/com/server/dpmcore/attendance/presentation/AttendanceController.kt
+++ b/src/main/kotlin/com/server/dpmcore/attendance/presentation/AttendanceController.kt
@@ -81,17 +81,21 @@ class AttendanceController(
 
     @GetMapping("/v1/members/attendances")
     override fun getMemberAttendances(
+        @CurrentMemberId memberId: MemberId,
         @RequestParam(name = "statuses", required = false) statuses: List<AttendanceStatus>?,
         @RequestParam(name = "teams", required = false) teams: List<Int>?,
         @RequestParam(name = "name", required = false) name: String?,
+        @RequestParam(name = "onlyMyTeam", required = false) onlyMyTeam: Boolean?,
         @RequestParam(name = "cursorId", required = false) cursorId: Long?,
     ): CustomResponse<MemberAttendancesResponse> {
         val response =
             attendanceQueryService.getMemberAttendances(
                 GetMemberAttendancesQuery(
+                    memberId = memberId,
                     statuses = statuses,
                     teams = teams,
                     name = name,
+                    onlyMyTeam = onlyMyTeam,
                     cursorId = cursorId,
                 ),
             )

--- a/src/main/kotlin/com/server/dpmcore/cohort/domain/exception/CohortNotFoundException.kt
+++ b/src/main/kotlin/com/server/dpmcore/cohort/domain/exception/CohortNotFoundException.kt
@@ -4,11 +4,5 @@ import com.server.dpmcore.common.exception.BusinessException
 import com.server.dpmcore.common.exception.ExceptionCode
 
 class CohortNotFoundException(
-    code: ExceptionCode,
-) : BusinessException(code) {
-    constructor() : this(CohortExceptionCode.COHORT_NOT_FOUND)
-
-    companion object {
-        val COHORT_NOT_FOUND = CohortExceptionCode.COHORT_NOT_FOUND
-    }
-}
+    code: ExceptionCode = CohortExceptionCode.COHORT_NOT_FOUND,
+) : BusinessException(code)

--- a/src/main/kotlin/com/server/dpmcore/member/member/application/MemberQueryService.kt
+++ b/src/main/kotlin/com/server/dpmcore/member/member/application/MemberQueryService.kt
@@ -2,6 +2,7 @@ package com.server.dpmcore.member.member.application
 
 import com.server.dpmcore.authority.domain.model.AuthorityId
 import com.server.dpmcore.member.member.application.exception.MemberNotFoundException
+import com.server.dpmcore.member.member.domain.exception.MemberTeamNotFoundException
 import com.server.dpmcore.member.member.domain.model.MemberId
 import com.server.dpmcore.member.member.domain.port.inbound.MemberQueryByAuthorityUseCase
 import com.server.dpmcore.member.member.domain.port.inbound.MemberQueryUseCase
@@ -16,7 +17,7 @@ import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
 @Service
-class MemberServiceQuery(
+class MemberQueryService(
     private val memberPersistencePort: MemberPersistencePort,
     private val tokenInjector: JwtTokenInjector,
     private val refreshTokenInvalidator: RefreshTokenInvalidator,

--- a/src/main/kotlin/com/server/dpmcore/member/member/application/MemberService.kt
+++ b/src/main/kotlin/com/server/dpmcore/member/member/application/MemberService.kt
@@ -2,6 +2,7 @@ package com.server.dpmcore.member.member.application
 
 import com.server.dpmcore.authority.domain.model.AuthorityId
 import com.server.dpmcore.member.member.application.exception.MemberNotFoundException
+import com.server.dpmcore.member.member.domain.exception.MemberTeamNotFoundException
 import com.server.dpmcore.member.member.domain.model.MemberId
 import com.server.dpmcore.member.member.domain.port.inbound.QueryMemberByAuthorityUseCase
 import com.server.dpmcore.member.member.domain.port.outbound.MemberPersistencePort
@@ -48,4 +49,8 @@ class MemberService(
     fun getMembersByCohort(value: String): List<MemberId> =
         memberPersistencePort
             .findAllByCohort(value)
+
+    fun getMemberTeamNumber(memberId: MemberId): Int =
+        memberPersistencePort.findMemberTeamByMemberId(memberId)
+            ?: throw MemberTeamNotFoundException()
 }

--- a/src/main/kotlin/com/server/dpmcore/member/member/application/exception/MemberExceptionCode.kt
+++ b/src/main/kotlin/com/server/dpmcore/member/member/application/exception/MemberExceptionCode.kt
@@ -11,10 +11,11 @@ enum class MemberExceptionCode(
     @JvmField
     val message: String,
 ) : ExceptionCode {
-    MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "MEMBER-404-1", "멤버를 찾을 수 없습니다"),
-    INVALID_MEMBER_ID(HttpStatus.BAD_REQUEST, "MEMBER-400-1", "유효하지 않은 멤버 ID입니다"),
-    COHORT_MEMBERS_NOT_FOUND(HttpStatus.NOT_FOUND, "MEMBER-404-2", "기수에 속한 멤버를 찾을 수 없습니다"),
-    MEMBER_ID_CAN_NOT_BE_NULL(HttpStatus.BAD_REQUEST, "MEMBER-400-2", "멤버 ID는 null일 수 없습니다"),
+    MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "MEMBER-404-01", "멤버를 찾을 수 없습니다"),
+    MEMBER_ID_CAN_NOT_BE_NULL(HttpStatus.BAD_REQUEST, "MEMBER-400-02", "멤버 ID는 null일 수 없습니다"),
+    INVALID_MEMBER_ID(HttpStatus.BAD_REQUEST, "MEMBER-400-01", "유효하지 않은 멤버 ID입니다"),
+    COHORT_MEMBERS_NOT_FOUND(HttpStatus.NOT_FOUND, "MEMBER-404-02", "기수에 속한 멤버를 찾을 수 없습니다"),
+    MEMBER_TEAM_NOT_FOUND(HttpStatus.NOT_FOUND, "MEMBER-404-03", "멤버의 팀을 찾을 수 없습니다"),
     ;
 
     override fun getStatus(): HttpStatus = status

--- a/src/main/kotlin/com/server/dpmcore/member/member/domain/exception/MemberTeamNotFoundException.kt
+++ b/src/main/kotlin/com/server/dpmcore/member/member/domain/exception/MemberTeamNotFoundException.kt
@@ -1,0 +1,9 @@
+package com.server.dpmcore.member.member.domain.exception
+
+import com.server.dpmcore.common.exception.BusinessException
+import com.server.dpmcore.common.exception.ExceptionCode
+import com.server.dpmcore.member.member.application.exception.MemberExceptionCode
+
+class MemberTeamNotFoundException(
+    code: ExceptionCode = MemberExceptionCode.MEMBER_TEAM_NOT_FOUND,
+) : BusinessException(code)

--- a/src/main/kotlin/com/server/dpmcore/member/member/domain/port/outbound/MemberPersistencePort.kt
+++ b/src/main/kotlin/com/server/dpmcore/member/member/domain/port/outbound/MemberPersistencePort.kt
@@ -20,4 +20,6 @@ interface MemberPersistencePort {
     fun findAllMemberIdByAuthorityIds(authorityIds: List<AuthorityId>): List<MemberId>
 
     fun findAllByCohort(value: String): List<MemberId>
+
+    fun findMemberTeamByMemberId(memberId: MemberId): Int?
 }

--- a/src/main/kotlin/com/server/dpmcore/member/member/infrastructure/repository/MemberRepository.kt
+++ b/src/main/kotlin/com/server/dpmcore/member/member/infrastructure/repository/MemberRepository.kt
@@ -14,6 +14,8 @@ import org.jooq.generated.tables.references.COHORTS
 import org.jooq.generated.tables.references.MEMBERS
 import org.jooq.generated.tables.references.MEMBER_AUTHORITIES
 import org.jooq.generated.tables.references.MEMBER_COHORTS
+import org.jooq.generated.tables.references.MEMBER_TEAMS
+import org.jooq.generated.tables.references.TEAMS
 import org.springframework.stereotype.Repository
 import java.time.Instant
 
@@ -95,4 +97,15 @@ class MemberRepository(
             .map {
                 MemberId(it)
             }
+
+    override fun findMemberTeamByMemberId(memberId: MemberId): Int? =
+        dsl
+            .select(TEAMS.NUMBER)
+            .from(MEMBER_TEAMS)
+            .join(MEMBERS)
+            .on(MEMBER_TEAMS.MEMBER_ID.eq(MEMBERS.MEMBER_ID))
+            .join(TEAMS)
+            .on(MEMBER_TEAMS.TEAM_ID.eq(TEAMS.TEAM_ID))
+            .where(MEMBER_TEAMS.MEMBER_ID.eq(memberId.value))
+            .fetchOne(TEAMS.NUMBER)
 }

--- a/src/main/kotlin/com/server/dpmcore/member/member/presentation/MemberController.kt
+++ b/src/main/kotlin/com/server/dpmcore/member/member/presentation/MemberController.kt
@@ -1,7 +1,7 @@
 package com.server.dpmcore.member.member.presentation
 
 import com.server.dpmcore.common.exception.CustomResponse
-import com.server.dpmcore.member.member.application.MemberServiceQuery
+import com.server.dpmcore.member.member.application.MemberQueryService
 import com.server.dpmcore.member.member.domain.model.MemberId
 import com.server.dpmcore.member.member.presentation.response.MemberDetailsResponse
 import jakarta.servlet.http.HttpServletResponse
@@ -13,7 +13,7 @@ import org.springframework.web.bind.annotation.RestController
 @RestController
 @RequestMapping("/v1/members")
 class MemberController(
-    private val memberService: MemberServiceQuery,
+    private val memberService: MemberQueryService,
 ) : MemberApi {
     @GetMapping("/me")
     override fun me(memberId: MemberId): CustomResponse<MemberDetailsResponse> {

--- a/src/main/kotlin/com/server/dpmcore/session/application/SessionQueryService.kt
+++ b/src/main/kotlin/com/server/dpmcore/session/application/SessionQueryService.kt
@@ -9,6 +9,8 @@ import com.server.dpmcore.session.domain.port.outbound.SessionPersistencePort
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.time.Instant
+import java.time.LocalDate
+import java.time.ZoneId
 
 @Service
 @Transactional(readOnly = true)
@@ -17,9 +19,11 @@ class SessionQueryService(
     private val sessionPersistencePort: SessionPersistencePort,
 ) {
     fun getNextSession(): Session? {
-        val currentTime = Instant.now()
+        val koreaZone = ZoneId.of("Asia/Seoul")
+        val today = LocalDate.ofInstant(Instant.now(), koreaZone)
+        val startOfToday = today.atStartOfDay(koreaZone).toInstant()
 
-        return sessionPersistencePort.findNextSessionBy(currentTime)
+        return sessionPersistencePort.findNextSessionBy(startOfToday)
     }
 
     fun getAllSessions(): List<Session> {

--- a/src/main/kotlin/com/server/dpmcore/session/domain/exception/SessionExceptionCode.kt
+++ b/src/main/kotlin/com/server/dpmcore/session/domain/exception/SessionExceptionCode.kt
@@ -8,14 +8,12 @@ enum class SessionExceptionCode(
     @JvmField val code: String,
     @JvmField val message: String,
 ) : ExceptionCode {
-    SESSION_NOT_FOUND(HttpStatus.NOT_FOUND, "S404", "세션을 찾을 수 없습니다"),
-    SESSION_ALREADY_EXISTS(HttpStatus.CONFLICT, "S409", "이미 존재하는 세션입니다"),
-    INVALID_SESSION_STATE(HttpStatus.BAD_REQUEST, "S400", "유효하지 않은 세션 상태입니다"),
-    INVALID_SESSION_ID(HttpStatus.BAD_REQUEST, "S400", "유효하지 않은 세션 ID입니다"),
-    INVALID_ATTENDANCE_CODE(HttpStatus.BAD_REQUEST, "S400", "출석코드가 일치하지 않습니다"),
-    TOO_EARLY_ATTENDANCE(HttpStatus.BAD_REQUEST, "S400", "출석하기에는 너무 이른 시간입니다"),
-    ALREADY_CHECKED_ATTENDANCE(HttpStatus.BAD_REQUEST, "S400", "이미 출석을 체크했습니다"),
-    ATTENDANCE_START_TIME_DATE_MISMATCH(HttpStatus.BAD_REQUEST, "S400", "출석 시작 시간의 날짜가 세션의 날짜와 일치하지 않습니다"),
+    INVALID_SESSION_ID(HttpStatus.BAD_REQUEST, "SESSION-400-01", "유효하지 않은 세션 ID입니다"),
+    INVALID_ATTENDANCE_CODE(HttpStatus.BAD_REQUEST, "SESSION-400-02", "출석코드가 일치하지 않습니다"),
+    TOO_EARLY_ATTENDANCE(HttpStatus.BAD_REQUEST, "SESSION-400-03", "출석하기에는 너무 이른 시간입니다"),
+    ALREADY_CHECKED_ATTENDANCE(HttpStatus.BAD_REQUEST, "SESSION-400-04", "이미 출석을 체크했습니다"),
+    ATTENDANCE_START_TIME_DATE_MISMATCH(HttpStatus.BAD_REQUEST, "SESSION-400-05", "출석 시작 시간의 날짜가 세션의 날짜와 일치하지 않습니다"),
+    SESSION_NOT_FOUND(HttpStatus.NOT_FOUND, "SESSION-404-01", "세션을 찾을 수 없습니다"),
     ;
 
     override fun getStatus(): HttpStatus = status

--- a/src/main/kotlin/com/server/dpmcore/session/domain/port/outbound/SessionPersistencePort.kt
+++ b/src/main/kotlin/com/server/dpmcore/session/domain/port/outbound/SessionPersistencePort.kt
@@ -6,7 +6,7 @@ import com.server.dpmcore.session.domain.model.SessionId
 import java.time.Instant
 
 interface SessionPersistencePort {
-    fun findNextSessionBy(currentTime: Instant): Session?
+    fun findNextSessionBy(startOfToday: Instant): Session?
 
     fun findAllSessions(cohortId: CohortId): List<Session>
 

--- a/src/main/kotlin/com/server/dpmcore/session/infrastructure/repository/SessionRepository.kt
+++ b/src/main/kotlin/com/server/dpmcore/session/infrastructure/repository/SessionRepository.kt
@@ -17,13 +17,13 @@ class SessionRepository(
     private val sessionJpaRepository: SessionJpaRepository,
     private val queryFactory: SpringDataQueryFactory,
 ) : SessionPersistencePort {
-    override fun findNextSessionBy(currentTime: Instant): Session? =
+    override fun findNextSessionBy(startOfToday: Instant): Session? =
         queryFactory
             .singleQueryOrNull<SessionEntity> {
                 select(entity(SessionEntity::class))
                 from(entity(SessionEntity::class))
                 where(
-                    col(SessionEntity::date).greaterThan(currentTime),
+                    col(SessionEntity::date).greaterThan(startOfToday),
                 )
                 orderBy(col(SessionEntity::date).asc())
                 limit(1)


### PR DESCRIPTION
## Summary

>- close #89 

<!-- 해당 PR에 대한 요약을 작성해주세요. -->

## Tasks

- 다음 세션 조회 시 같은 날이면 계속 조회되도록 조건을 변경하였습니다.
- 세션 및 개인 출석 리스트 조회 API에 `onlyMyTeam`  조건을 추가합니다.
- 예외 코드를 일관화하였습니다.
