### PR TITLE
fix: 멤버 로그인 관련 1차 이슈 수정

### DIFF
--- a/src/main/kotlin/com/server/dpmcore/member/member/application/MemberLoginService.kt
+++ b/src/main/kotlin/com/server/dpmcore/member/member/application/MemberLoginService.kt
@@ -80,8 +80,10 @@ class MemberLoginService(
             when (requestDomain) {
                 "$CLIENT_SUFFIX.${securityProperties.cookie.domain}" ->
                     "${securityProperties.clientRedirectUrl}?$IS_ADMIN_TRUE"
+
                 "$ADMIN_SUFFIX.${securityProperties.cookie.domain}" ->
                     "${securityProperties.adminRedirectUrl}?$IS_ADMIN_TRUE"
+
                 else -> "${securityProperties.adminRedirectUrl}?$IS_ADMIN_TRUE"
             }
         }
@@ -92,7 +94,8 @@ class MemberLoginService(
             .any { it in ADMIN_AUTHORITIES }
 
     private fun handleUnregisteredMember(authAttributes: OAuthAttributes): LoginResult {
-        val member = memberPersistencePort.save(Member.create(authAttributes.getEmail(), environment))
+        val member =
+            memberPersistencePort.save(Member.create(authAttributes.getEmail(), authAttributes.getName(), environment))
         memberOAuthService.addMemberOAuthProvider(member, authAttributes)
 
         return generateLoginResult(

--- a/src/main/kotlin/com/server/dpmcore/member/member/application/MemberLoginService.kt
+++ b/src/main/kotlin/com/server/dpmcore/member/member/application/MemberLoginService.kt
@@ -74,7 +74,7 @@ class MemberLoginService(
     }
 
     private fun adminRedirectUrl(requestDomain: String): String =
-        if (environment.activeProfiles.equals("local")) {
+        if (environment.activeProfiles.contains("local")) {
             "${securityProperties.adminRedirectUrl}?$IS_ADMIN_TRUE"
         } else {
             when (requestDomain) {

--- a/src/main/kotlin/com/server/dpmcore/member/member/application/MemberLoginService.kt
+++ b/src/main/kotlin/com/server/dpmcore/member/member/application/MemberLoginService.kt
@@ -63,8 +63,8 @@ class MemberLoginService(
 
         val redirectUrl =
             when {
-                isAdmin -> securityProperties.adminRedirectUrl
-                else -> securityProperties.redirectUrl
+                isAdmin -> securityProperties.adminRedirectUrl + "?$IS_ADMIN_TRUE"
+                else -> securityProperties.redirectUrl + "?$IS_ADMIN_FALSE"
             }
 
         return generateLoginResult(member.id, redirectUrl)
@@ -82,5 +82,7 @@ class MemberLoginService(
 
     companion object {
         private val ADMIN_AUTHORITIES = setOf("ORGANIZER")
+        private const val IS_ADMIN_TRUE = "isAdmin=true"
+        private const val IS_ADMIN_FALSE = "isAdmin=false"
     }
 }

--- a/src/main/kotlin/com/server/dpmcore/member/member/application/MemberLoginService.kt
+++ b/src/main/kotlin/com/server/dpmcore/member/member/application/MemberLoginService.kt
@@ -70,7 +70,7 @@ class MemberLoginService(
         memberId: MemberId,
     ) = when {
         hasAdminRole(memberId) -> adminRedirectUrl(requestDomain)
-        else -> securityProperties.redirectUrl + "?$IS_ADMIN_FALSE"
+        else -> securityProperties.clientRedirectUrl + "?$IS_ADMIN_FALSE"
     }
 
     private fun adminRedirectUrl(requestDomain: String): String =
@@ -79,7 +79,7 @@ class MemberLoginService(
         } else {
             when (requestDomain) {
                 "$CLIENT_SUFFIX.${securityProperties.cookie.domain}" ->
-                    "${securityProperties.redirectUrl}?$IS_ADMIN_TRUE"
+                    "${securityProperties.clientRedirectUrl}?$IS_ADMIN_TRUE"
                 "$ADMIN_SUFFIX.${securityProperties.cookie.domain}" ->
                     "${securityProperties.adminRedirectUrl}?$IS_ADMIN_TRUE"
                 else -> "${securityProperties.adminRedirectUrl}?$IS_ADMIN_TRUE"

--- a/src/main/kotlin/com/server/dpmcore/member/member/domain/model/Member.kt
+++ b/src/main/kotlin/com/server/dpmcore/member/member/domain/model/Member.kt
@@ -24,7 +24,7 @@ import java.time.Instant
  */
 class Member(
     val id: MemberId? = null,
-    val name: String? = null,
+    val name: String,
     val email: String,
     val part: MemberPart? = null,
     status: MemberStatus,
@@ -76,6 +76,7 @@ class Member(
     companion object {
         fun create(
             email: String,
+            name: String,
             environment: Environment,
         ): Member {
             val profileStatusMap =
@@ -93,6 +94,7 @@ class Member(
             val now = Instant.now()
             return Member(
                 email = email,
+                name = name,
                 status = matchedStatus,
                 createdAt = now,
                 updatedAt = now,

--- a/src/main/kotlin/com/server/dpmcore/member/member/domain/port/inbound/HandleMemberLoginUseCase.kt
+++ b/src/main/kotlin/com/server/dpmcore/member/member/domain/port/inbound/HandleMemberLoginUseCase.kt
@@ -4,5 +4,8 @@ import com.server.dpmcore.security.oauth.dto.LoginResult
 import com.server.dpmcore.security.oauth.dto.OAuthAttributes
 
 interface HandleMemberLoginUseCase {
-    fun handleLoginSuccess(authAttributes: OAuthAttributes): LoginResult
+    fun handleLoginSuccess(
+        requestDomain: String,
+        authAttributes: OAuthAttributes,
+    ): LoginResult
 }

--- a/src/main/kotlin/com/server/dpmcore/member/member/infrastructure/entity/MemberEntity.kt
+++ b/src/main/kotlin/com/server/dpmcore/member/member/infrastructure/entity/MemberEntity.kt
@@ -26,8 +26,8 @@ class MemberEntity(
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "member_id", nullable = false, updatable = false)
     val id: Long,
-    @Column
-    val name: String? = null,
+    @Column(nullable = false)
+    val name: String,
     @Column(nullable = false, unique = true)
     val email: String,
     @Column

--- a/src/main/kotlin/com/server/dpmcore/security/oauth/dto/KakaoAuthAttributes.kt
+++ b/src/main/kotlin/com/server/dpmcore/security/oauth/dto/KakaoAuthAttributes.kt
@@ -12,6 +12,7 @@ import com.server.dpmcore.member.memberOAuth.domain.model.OAuthProvider
 data class KakaoAuthAttributes(
     @JvmField val externalId: String,
     @JvmField val email: String,
+    @JvmField val name: String,
     @JvmField val provider: OAuthProvider,
 ) : OAuthAttributes {
     companion object {
@@ -25,6 +26,7 @@ data class KakaoAuthAttributes(
             return KakaoAuthAttributes(
                 externalId = externalId.toString(),
                 email = email,
+                name = kakaoAccount["profile"]?.let { (it as Map<*, *>)["nickname"] as String } ?: "",
                 provider = OAuthProvider.KAKAO,
             )
         }
@@ -35,4 +37,6 @@ data class KakaoAuthAttributes(
     override fun getProvider(): OAuthProvider = this.provider
 
     override fun getEmail(): String = this.email
+
+    override fun getName(): String = this.name
 }

--- a/src/main/kotlin/com/server/dpmcore/security/oauth/dto/OAuthAttributes.kt
+++ b/src/main/kotlin/com/server/dpmcore/security/oauth/dto/OAuthAttributes.kt
@@ -10,6 +10,8 @@ interface OAuthAttributes {
 
     fun getEmail(): String
 
+    fun getName(): String
+
     companion object {
         fun of(
             providerId: String,

--- a/src/main/kotlin/com/server/dpmcore/security/oauth/handler/CustomAuthenticationFailureHandler.kt
+++ b/src/main/kotlin/com/server/dpmcore/security/oauth/handler/CustomAuthenticationFailureHandler.kt
@@ -18,7 +18,7 @@ class CustomAuthenticationFailureHandler(
         exception: AuthenticationException?,
     ) {
         response?.sendRedirect(
-            securityProperties.loginUrl + "?error=true&exception=" +
+            securityProperties.restrictedRedirectUrl + "?error=true&exception=" +
                 OAuthExceptionCode.AUTHENTICATION_FAILED,
         )
     }

--- a/src/main/kotlin/com/server/dpmcore/security/oauth/handler/CustomAuthenticationSuccessHandler.kt
+++ b/src/main/kotlin/com/server/dpmcore/security/oauth/handler/CustomAuthenticationSuccessHandler.kt
@@ -20,7 +20,7 @@ class CustomAuthenticationSuccessHandler(
         response: HttpServletResponse,
         authentication: Authentication,
     ) {
-        resolveLoginResultFromAuthentication(authentication).let { loginResult ->
+        resolveLoginResultFromAuthentication(request.serverName, authentication).let { loginResult ->
             loginResult.refreshToken?.let {
                 tokenInjector.injectRefreshToken(it, response)
             }
@@ -28,8 +28,11 @@ class CustomAuthenticationSuccessHandler(
         }
     }
 
-    private fun resolveLoginResultFromAuthentication(authentication: Authentication): LoginResult {
+    private fun resolveLoginResultFromAuthentication(
+        requestDomain: String,
+        authentication: Authentication,
+    ): LoginResult {
         val oAuth2User = authentication.principal as CustomOAuth2User
-        return handleMemberLoginUseCase.handleLoginSuccess(oAuth2User.authAttributes)
+        return handleMemberLoginUseCase.handleLoginSuccess(requestDomain, oAuth2User.authAttributes)
     }
 }

--- a/src/main/kotlin/com/server/dpmcore/security/properties/SecurityProperties.kt
+++ b/src/main/kotlin/com/server/dpmcore/security/properties/SecurityProperties.kt
@@ -5,7 +5,6 @@ import org.springframework.boot.context.properties.NestedConfigurationProperty
 
 @ConfigurationProperties(prefix = "spring.security")
 data class SecurityProperties(
-    val loginUrl: String,
     val logoutUrl: String,
     val clientRedirectUrl: String,
     val adminRedirectUrl: String,

--- a/src/main/kotlin/com/server/dpmcore/security/properties/SecurityProperties.kt
+++ b/src/main/kotlin/com/server/dpmcore/security/properties/SecurityProperties.kt
@@ -7,7 +7,7 @@ import org.springframework.boot.context.properties.NestedConfigurationProperty
 data class SecurityProperties(
     val loginUrl: String,
     val logoutUrl: String,
-    val redirectUrl: String,
+    val clientRedirectUrl: String,
     val adminRedirectUrl: String,
     val restrictedRedirectUrl: String,
     @NestedConfigurationProperty val cookie: Cookie,

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -43,6 +43,7 @@ spring:
             client-authentication-method: client_secret_post
             scope:
               - account_email
+              - profile_nickname
         provider:
           kakao:
             authorization-uri: https://kauth.kakao.com/oauth/authorize

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -21,7 +21,6 @@ spring:
         access-token: ${ACCESS_TOKEN_EXPIRATION_TIME}
         refresh-token: ${REFRESH_TOKEN_EXPIRATION_TIME}
 
-    login-url: ${LOGIN_URL:/login}
     logout-url: ${LOGOUT_URL:/logout}
     client-redirect-url: ${REDIRECT_URL:/swagger-ui/index.html}
     admin-redirect-url: ${ADMIN_REDIRECT_URL:/swagger-ui/index.html}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -23,7 +23,7 @@ spring:
 
     login-url: ${LOGIN_URL:/login}
     logout-url: ${LOGOUT_URL:/logout}
-    redirect-url: ${REDIRECT_URL:/swagger-ui/index.html}
+    client-redirect-url: ${REDIRECT_URL:/swagger-ui/index.html}
     admin-redirect-url: ${ADMIN_REDIRECT_URL:/swagger-ui/index.html}
     restricted-redirect-url: ${RESTRICTED_REDIRECT_URL:/swagger-ui/index.html}
 


### PR DESCRIPTION
## Summary

>- #95

멤버 로그인 리다이렉트 관련 이슈를 모두 수정합니다.
추가적으로 최초 가입 시 이름을 저장하도록 스코프를 수정하였습니다.

<!-- 해당 PR에 대한 요약을 작성해주세요. -->

## Tasks

- 리다이렉트 시 권한 파라미터로 제공
- 어드민이 client로 접근 시 clinet로 리다이렉트
- OAuth 이름 받아오도록 Scope 수정
- 스프링 시큐리티 기본 페이지 비활성화
- 일부 환경변수 삭제 또는 변경

## ETC

<!-- 추가적인 정보나 참고 사항을 작성해주세요. -->

## Screenshot

<!-- (없을 경우 삭제) 작업한 내용에 대한 스크린샷을 첨부해주세요._ -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 로그인 성공 시 사용자의 도메인과 역할(관리자/일반)에 따라 리다이렉트 URL이 다르게 제공되며, URL에 관리자 여부 쿼리 파라미터가 추가됩니다.
  * 회원 생성 시 이메일뿐 아니라 이름 정보도 필수로 저장됩니다.
  * 카카오 로그인 시 닉네임(이름) 정보가 추가로 수집됩니다.

* **버그 수정**
  * 인증 실패 시 리다이렉트되는 URL이 제한된 접근 URL로 변경되었습니다.

* **설정 변경**
  * 보안 설정에서 로그인 및 리다이렉트 URL 항목이 변경되고, 클라이언트 리다이렉트 URL이 추가되었습니다.
  * 카카오 OAuth2 로그인 시 닉네임 정보(scope)가 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->