### PR TITLE
Feat : 정산 참여 응답 상태 업데이트 구현, 정산 참여 API 리팩토링

### DIFF
--- a/src/main/kotlin/com/server/dpmcore/bill/bill/application/BillCommandService.kt
+++ b/src/main/kotlin/com/server/dpmcore/bill/bill/application/BillCommandService.kt
@@ -5,6 +5,7 @@ import com.server.dpmcore.bill.bill.domain.model.Bill
 import com.server.dpmcore.bill.bill.domain.model.BillId
 import com.server.dpmcore.bill.bill.domain.port.outbound.BillPersistencePort
 import com.server.dpmcore.bill.bill.presentation.dto.request.CreateBillRequest
+import com.server.dpmcore.bill.bill.presentation.dto.request.SubmitBillParticipationConfirmRequest
 import com.server.dpmcore.bill.billAccount.application.BillAccountQueryService
 import com.server.dpmcore.bill.billAccount.domain.model.BillAccountId
 import com.server.dpmcore.bill.exception.BillException
@@ -96,4 +97,10 @@ class BillCommandService(
         val gatheringIds = gatheringQueryUseCase.getAllGatheringIdsByBillId(billId)
         gatheringCommandUseCase.markAsCheckedEachGatheringMember(gatheringIds, memberId)
     }
+
+    fun submitBillParticipationConfirm(
+        billId: BillId,
+        memberId: MemberId,
+        request: SubmitBillParticipationConfirmRequest,
+    ) = gatheringCommandUseCase.submitBillParticipationEachGathering(billId, memberId, request.gatheringIds)
 }

--- a/src/main/kotlin/com/server/dpmcore/bill/bill/application/BillCommandService.kt
+++ b/src/main/kotlin/com/server/dpmcore/bill/bill/application/BillCommandService.kt
@@ -5,6 +5,7 @@ import com.server.dpmcore.bill.bill.domain.model.Bill
 import com.server.dpmcore.bill.bill.domain.model.BillId
 import com.server.dpmcore.bill.bill.domain.port.outbound.BillPersistencePort
 import com.server.dpmcore.bill.bill.presentation.dto.request.CreateBillRequest
+import com.server.dpmcore.bill.bill.presentation.dto.request.UpdateGatheringJoinsRequest
 import com.server.dpmcore.bill.billAccount.application.BillAccountQueryService
 import com.server.dpmcore.bill.billAccount.domain.model.BillAccountId
 import com.server.dpmcore.bill.exception.BillException
@@ -101,4 +102,9 @@ class BillCommandService(
         billId: BillId,
         memberId: MemberId,
     ) = gatheringCommandUseCase.submitBillParticipationConfirmEachGathering(billId, memberId)
+
+    fun markAsJoinedEachGathering(
+        request: UpdateGatheringJoinsRequest,
+        memberId: MemberId,
+    ) = gatheringCommandUseCase.markAsJoinedEachGatheringMember(request, memberId)
 }

--- a/src/main/kotlin/com/server/dpmcore/bill/bill/application/BillCommandService.kt
+++ b/src/main/kotlin/com/server/dpmcore/bill/bill/application/BillCommandService.kt
@@ -104,7 +104,8 @@ class BillCommandService(
     ) = gatheringCommandUseCase.submitBillParticipationConfirmEachGathering(billId, memberId)
 
     fun markAsJoinedEachGathering(
+        billId: BillId,
         request: UpdateGatheringJoinsRequest,
         memberId: MemberId,
-    ) = gatheringCommandUseCase.markAsJoinedEachGatheringMember(request, memberId)
+    ) = gatheringCommandUseCase.markAsJoinedEachGatheringMember(billId, request, memberId)
 }

--- a/src/main/kotlin/com/server/dpmcore/bill/bill/application/BillCommandService.kt
+++ b/src/main/kotlin/com/server/dpmcore/bill/bill/application/BillCommandService.kt
@@ -5,7 +5,6 @@ import com.server.dpmcore.bill.bill.domain.model.Bill
 import com.server.dpmcore.bill.bill.domain.model.BillId
 import com.server.dpmcore.bill.bill.domain.port.outbound.BillPersistencePort
 import com.server.dpmcore.bill.bill.presentation.dto.request.CreateBillRequest
-import com.server.dpmcore.bill.bill.presentation.dto.request.SubmitBillParticipationConfirmRequest
 import com.server.dpmcore.bill.billAccount.application.BillAccountQueryService
 import com.server.dpmcore.bill.billAccount.domain.model.BillAccountId
 import com.server.dpmcore.bill.exception.BillException
@@ -101,6 +100,5 @@ class BillCommandService(
     fun submitBillParticipationConfirm(
         billId: BillId,
         memberId: MemberId,
-        request: SubmitBillParticipationConfirmRequest,
-    ) = gatheringCommandUseCase.submitBillParticipationEachGathering(billId, memberId, request.gatheringIds)
+    ) = gatheringCommandUseCase.submitBillParticipationConfirmEachGathering(billId, memberId)
 }

--- a/src/main/kotlin/com/server/dpmcore/bill/bill/presentation/controller/BillCommandApi.kt
+++ b/src/main/kotlin/com/server/dpmcore/bill/bill/presentation/controller/BillCommandApi.kt
@@ -2,7 +2,6 @@ package com.server.dpmcore.bill.bill.presentation.controller
 
 import com.server.dpmcore.bill.bill.domain.model.BillId
 import com.server.dpmcore.bill.bill.presentation.dto.request.CreateBillRequest
-import com.server.dpmcore.bill.bill.presentation.dto.request.SubmitBillParticipationConfirmRequest
 import com.server.dpmcore.bill.bill.presentation.dto.response.BillPersistenceResponse
 import com.server.dpmcore.common.exception.CustomResponse
 import com.server.dpmcore.member.member.domain.model.MemberId
@@ -153,51 +152,13 @@ interface BillCommandApi {
     ): CustomResponse<Void>
 
     @Operation(
-        summary = "정산서 생성 또는 추가",
+        summary = "정산 참여 응답 제출 처리",
         description =
-            "정산을 추가합니다. 각 차수의 회식과 정산서, 참여 멤버 등을 함께 추가해야 합니다. \n" +
-                "추후에는 영수증 사진이 추가될 수 있습니다.",
-        requestBody =
-            RequestBody(
-                description = "정산 생성 요청",
-                required = true,
-                content = [
-                    Content(
-                        mediaType = APPLICATION_JSON_VALUE,
-                        schema = Schema(implementation = CreateBillRequest::class),
-                        examples = [
-                            ExampleObject(
-                                name = "정산 생성 요청 예시",
-                                value = """
-                                {
-                                  "title": "17기 OT세션 공식 회식",
-                                  "description": "OT 이후 첫 공식 회식 자리입니다. 운영진 및 디퍼 전체가 초대됩니다.",
-                                  "billAccountId": 1,
-                                  "invitedAuthorityIds": [
-                                    1, 2
-                                  ],
-                                  "gatherings": [
-                                    {
-                                      "title": "1차 회식 - 고깃집",
-                                      "description": "가까운 삼겹살 집에서 진행",
-                                      "roundNumber": 1,
-                                      "heldAt": "2025-07-22T05:55:34.606Z",
-                                      "receipt": {
-                                        "amount": 820000
-                                      }
-                                    }
-                                  ]
-                                }
-                            """,
-                            ),
-                        ],
-                    ),
-                ],
-            ),
+            "정산 초대에 대해 응답했음을 처리합니다. 초대에 대한 응답 제출 시 '참여'로 체크한 회식의 일련번호 리스트를 제출합니다.",
     )
     @ApiResponse(
         responseCode = "204",
-        description = "정산 참여 응답 처리",
+        description = "정산 참여 응답 제출 응답 처리",
         content = [
             Content(
                 mediaType = APPLICATION_JSON_VALUE,
@@ -206,8 +167,7 @@ interface BillCommandApi {
         ],
     )
     fun submitBillParticipationConfirm(
-        billId: BillId,
+        @Positive billId: BillId,
         memberId: MemberId,
-        submitBillParticipationConfirmRequest: SubmitBillParticipationConfirmRequest,
     ): CustomResponse<Void>
 }

--- a/src/main/kotlin/com/server/dpmcore/bill/bill/presentation/controller/BillCommandApi.kt
+++ b/src/main/kotlin/com/server/dpmcore/bill/bill/presentation/controller/BillCommandApi.kt
@@ -2,6 +2,7 @@ package com.server.dpmcore.bill.bill.presentation.controller
 
 import com.server.dpmcore.bill.bill.domain.model.BillId
 import com.server.dpmcore.bill.bill.presentation.dto.request.CreateBillRequest
+import com.server.dpmcore.bill.bill.presentation.dto.request.UpdateGatheringJoinsRequest
 import com.server.dpmcore.bill.bill.presentation.dto.response.BillPersistenceResponse
 import com.server.dpmcore.common.exception.CustomResponse
 import com.server.dpmcore.member.member.domain.model.MemberId
@@ -168,6 +169,25 @@ interface BillCommandApi {
     )
     fun submitBillParticipationConfirm(
         @Positive billId: BillId,
+        memberId: MemberId,
+    ): CustomResponse<Void>
+
+    @ApiResponse(
+        responseCode = "204",
+        description = "정산(각 회식) 참여",
+        content = [
+            Content(
+                mediaType = APPLICATION_JSON_VALUE,
+                schema = Schema(implementation = CustomResponse::class),
+            ),
+        ],
+    )
+    @Operation(
+        summary = "정산의 각 회식에 대해 참여 표시",
+        description = "정산 내의 각 회식에 대한 참여 여부를 표시합니다. '정산 참여 응답 제출 처리' API와 함께 호출됩니다.",
+    )
+    fun markAsGatheringJoined(
+        request: UpdateGatheringJoinsRequest,
         memberId: MemberId,
     ): CustomResponse<Void>
 }

--- a/src/main/kotlin/com/server/dpmcore/bill/bill/presentation/controller/BillCommandApi.kt
+++ b/src/main/kotlin/com/server/dpmcore/bill/bill/presentation/controller/BillCommandApi.kt
@@ -179,11 +179,30 @@ interface BillCommandApi {
             Content(
                 mediaType = APPLICATION_JSON_VALUE,
                 schema = Schema(implementation = CustomResponse::class),
+                examples = [
+                    ExampleObject(
+                        name = "정산(각 회식) 참여 여부 저장",
+                        value = """
+                                {
+                                  "gatheringJoins": [
+                                    {
+                                      "gatheringId": 1,
+                                      "isJoined": true
+                                    },
+                                    {
+                                      "gatheringId": 2,
+                                      "isJoined": false
+                                    }
+                                  ]
+                                }
+                            """,
+                    ),
+                ],
             ),
         ],
     )
     @Operation(
-        summary = "정산의 각 회식에 대해 참여 표시",
+        summary = "정산의 각 회식에 대해 참여 저장",
         description = "정산 내의 각 회식에 대한 참여 여부를 표시합니다. '정산 참여 응답 제출 처리' API와 함께 호출됩니다.",
     )
     fun markAsGatheringJoined(

--- a/src/main/kotlin/com/server/dpmcore/bill/bill/presentation/controller/BillCommandApi.kt
+++ b/src/main/kotlin/com/server/dpmcore/bill/bill/presentation/controller/BillCommandApi.kt
@@ -187,6 +187,7 @@ interface BillCommandApi {
         description = "정산 내의 각 회식에 대한 참여 여부를 표시합니다. '정산 참여 응답 제출 처리' API와 함께 호출됩니다.",
     )
     fun markAsGatheringJoined(
+        @Positive billId: BillId,
         request: UpdateGatheringJoinsRequest,
         memberId: MemberId,
     ): CustomResponse<Void>

--- a/src/main/kotlin/com/server/dpmcore/bill/bill/presentation/controller/BillCommandApi.kt
+++ b/src/main/kotlin/com/server/dpmcore/bill/bill/presentation/controller/BillCommandApi.kt
@@ -155,7 +155,7 @@ interface BillCommandApi {
     @Operation(
         summary = "정산 참여 응답 제출 처리",
         description =
-            "정산 초대에 대해 응답했음을 처리합니다. 초대에 대한 응답 제출 시 '참여'로 체크한 회식의 일련번호 리스트를 제출합니다.",
+            "정산 초대에 대해 응답했음을 처리합니다.",
     )
     @ApiResponse(
         responseCode = "204",

--- a/src/main/kotlin/com/server/dpmcore/bill/bill/presentation/controller/BillCommandApi.kt
+++ b/src/main/kotlin/com/server/dpmcore/bill/bill/presentation/controller/BillCommandApi.kt
@@ -2,6 +2,7 @@ package com.server.dpmcore.bill.bill.presentation.controller
 
 import com.server.dpmcore.bill.bill.domain.model.BillId
 import com.server.dpmcore.bill.bill.presentation.dto.request.CreateBillRequest
+import com.server.dpmcore.bill.bill.presentation.dto.request.SubmitBillParticipationConfirmRequest
 import com.server.dpmcore.bill.bill.presentation.dto.response.BillPersistenceResponse
 import com.server.dpmcore.common.exception.CustomResponse
 import com.server.dpmcore.member.member.domain.model.MemberId
@@ -149,5 +150,64 @@ interface BillCommandApi {
     fun markBillAsChecked(
         @Positive billId: BillId,
         memberId: MemberId,
+    ): CustomResponse<Void>
+
+    @Operation(
+        summary = "정산서 생성 또는 추가",
+        description =
+            "정산을 추가합니다. 각 차수의 회식과 정산서, 참여 멤버 등을 함께 추가해야 합니다. \n" +
+                "추후에는 영수증 사진이 추가될 수 있습니다.",
+        requestBody =
+            RequestBody(
+                description = "정산 생성 요청",
+                required = true,
+                content = [
+                    Content(
+                        mediaType = APPLICATION_JSON_VALUE,
+                        schema = Schema(implementation = CreateBillRequest::class),
+                        examples = [
+                            ExampleObject(
+                                name = "정산 생성 요청 예시",
+                                value = """
+                                {
+                                  "title": "17기 OT세션 공식 회식",
+                                  "description": "OT 이후 첫 공식 회식 자리입니다. 운영진 및 디퍼 전체가 초대됩니다.",
+                                  "billAccountId": 1,
+                                  "invitedAuthorityIds": [
+                                    1, 2
+                                  ],
+                                  "gatherings": [
+                                    {
+                                      "title": "1차 회식 - 고깃집",
+                                      "description": "가까운 삼겹살 집에서 진행",
+                                      "roundNumber": 1,
+                                      "heldAt": "2025-07-22T05:55:34.606Z",
+                                      "receipt": {
+                                        "amount": 820000
+                                      }
+                                    }
+                                  ]
+                                }
+                            """,
+                            ),
+                        ],
+                    ),
+                ],
+            ),
+    )
+    @ApiResponse(
+        responseCode = "204",
+        description = "정산 참여 응답 처리",
+        content = [
+            Content(
+                mediaType = APPLICATION_JSON_VALUE,
+                schema = Schema(implementation = CustomResponse::class),
+            ),
+        ],
+    )
+    fun submitBillParticipationConfirm(
+        billId: BillId,
+        memberId: MemberId,
+        submitBillParticipationConfirmRequest: SubmitBillParticipationConfirmRequest,
     ): CustomResponse<Void>
 }

--- a/src/main/kotlin/com/server/dpmcore/bill/bill/presentation/controller/BillCommandController.kt
+++ b/src/main/kotlin/com/server/dpmcore/bill/bill/presentation/controller/BillCommandController.kt
@@ -56,6 +56,7 @@ class BillCommandController(
         return CustomResponse.noContent()
     }
 
+    @PreAuthorize("hasRole('ROLE_ORGANIZER')")
     @PatchMapping("/{billId}/participation-confirm")
     override fun submitBillParticipationConfirm(
         @Positive @PathVariable billId: BillId,
@@ -68,6 +69,7 @@ class BillCommandController(
         return CustomResponse.noContent()
     }
 
+    @PreAuthorize("!hasRole('ROLE_GUEST')")
     @PatchMapping("/{billId}/join")
     override fun markAsGatheringJoined(
         @Positive @PathVariable billId: BillId,

--- a/src/main/kotlin/com/server/dpmcore/bill/bill/presentation/controller/BillCommandController.kt
+++ b/src/main/kotlin/com/server/dpmcore/bill/bill/presentation/controller/BillCommandController.kt
@@ -66,10 +66,11 @@ class BillCommandController(
 
     @PatchMapping("/{billId}/join")
     override fun markAsGatheringJoined(
+        @Positive @PathVariable billId: BillId,
         @RequestBody request: UpdateGatheringJoinsRequest,
         @CurrentMemberId memberId: MemberId,
     ): CustomResponse<Void> {
-        billCommandService.markAsJoinedEachGathering(request, memberId)
+        billCommandService.markAsJoinedEachGathering(billId, request, memberId)
         return CustomResponse.noContent()
     }
 }

--- a/src/main/kotlin/com/server/dpmcore/bill/bill/presentation/controller/BillCommandController.kt
+++ b/src/main/kotlin/com/server/dpmcore/bill/bill/presentation/controller/BillCommandController.kt
@@ -3,6 +3,7 @@ package com.server.dpmcore.bill.bill.presentation.controller
 import com.server.dpmcore.bill.bill.application.BillCommandService
 import com.server.dpmcore.bill.bill.domain.model.BillId
 import com.server.dpmcore.bill.bill.presentation.dto.request.CreateBillRequest
+import com.server.dpmcore.bill.bill.presentation.dto.request.UpdateGatheringJoinsRequest
 import com.server.dpmcore.bill.bill.presentation.dto.response.BillPersistenceResponse
 import com.server.dpmcore.common.exception.CustomResponse
 import com.server.dpmcore.gathering.gathering.application.GatheringQueryService
@@ -60,6 +61,15 @@ class BillCommandController(
             billId,
             memberId,
         )
+        return CustomResponse.noContent()
+    }
+
+    @PatchMapping("/{billId}/join")
+    override fun markAsGatheringJoined(
+        @RequestBody request: UpdateGatheringJoinsRequest,
+        @CurrentMemberId memberId: MemberId,
+    ): CustomResponse<Void> {
+        billCommandService.markAsJoinedEachGathering(request, memberId)
         return CustomResponse.noContent()
     }
 }

--- a/src/main/kotlin/com/server/dpmcore/bill/bill/presentation/controller/BillCommandController.kt
+++ b/src/main/kotlin/com/server/dpmcore/bill/bill/presentation/controller/BillCommandController.kt
@@ -3,7 +3,6 @@ package com.server.dpmcore.bill.bill.presentation.controller
 import com.server.dpmcore.bill.bill.application.BillCommandService
 import com.server.dpmcore.bill.bill.domain.model.BillId
 import com.server.dpmcore.bill.bill.presentation.dto.request.CreateBillRequest
-import com.server.dpmcore.bill.bill.presentation.dto.request.SubmitBillParticipationConfirmRequest
 import com.server.dpmcore.bill.bill.presentation.dto.response.BillPersistenceResponse
 import com.server.dpmcore.common.exception.CustomResponse
 import com.server.dpmcore.gathering.gathering.application.GatheringQueryService
@@ -56,12 +55,10 @@ class BillCommandController(
     override fun submitBillParticipationConfirm(
         @Positive @PathVariable billId: BillId,
         @CurrentMemberId memberId: MemberId,
-        @RequestBody submitBillParticipationConfirmRequest: SubmitBillParticipationConfirmRequest,
     ): CustomResponse<Void> {
         billCommandService.submitBillParticipationConfirm(
             billId,
             memberId,
-            submitBillParticipationConfirmRequest,
         )
         return CustomResponse.noContent()
     }

--- a/src/main/kotlin/com/server/dpmcore/bill/bill/presentation/controller/BillCommandController.kt
+++ b/src/main/kotlin/com/server/dpmcore/bill/bill/presentation/controller/BillCommandController.kt
@@ -3,6 +3,7 @@ package com.server.dpmcore.bill.bill.presentation.controller
 import com.server.dpmcore.bill.bill.application.BillCommandService
 import com.server.dpmcore.bill.bill.domain.model.BillId
 import com.server.dpmcore.bill.bill.presentation.dto.request.CreateBillRequest
+import com.server.dpmcore.bill.bill.presentation.dto.request.SubmitBillParticipationConfirmRequest
 import com.server.dpmcore.bill.bill.presentation.dto.response.BillPersistenceResponse
 import com.server.dpmcore.common.exception.CustomResponse
 import com.server.dpmcore.gathering.gathering.application.GatheringQueryService
@@ -48,6 +49,20 @@ class BillCommandController(
         @CurrentMemberId memberId: MemberId,
     ): CustomResponse<Void> {
         billCommandService.markBillAsChecked(billId, memberId)
+        return CustomResponse.noContent()
+    }
+
+    @PatchMapping("/{billId}/participation-confirm")
+    override fun submitBillParticipationConfirm(
+        @Positive @PathVariable billId: BillId,
+        @CurrentMemberId memberId: MemberId,
+        @RequestBody submitBillParticipationConfirmRequest: SubmitBillParticipationConfirmRequest,
+    ): CustomResponse<Void> {
+        billCommandService.submitBillParticipationConfirm(
+            billId,
+            memberId,
+            submitBillParticipationConfirmRequest,
+        )
         return CustomResponse.noContent()
     }
 }

--- a/src/main/kotlin/com/server/dpmcore/bill/bill/presentation/dto/request/SubmitBillParticipationConfirmRequest.kt
+++ b/src/main/kotlin/com/server/dpmcore/bill/bill/presentation/dto/request/SubmitBillParticipationConfirmRequest.kt
@@ -1,0 +1,7 @@
+package com.server.dpmcore.bill.bill.presentation.dto.request
+
+import com.server.dpmcore.gathering.gathering.domain.model.GatheringId
+
+data class SubmitBillParticipationConfirmRequest(
+    val gatheringIds: List<GatheringId>,
+)

--- a/src/main/kotlin/com/server/dpmcore/bill/bill/presentation/dto/request/UpdateGatheringJoinsRequest.kt
+++ b/src/main/kotlin/com/server/dpmcore/bill/bill/presentation/dto/request/UpdateGatheringJoinsRequest.kt
@@ -1,4 +1,4 @@
-package com.server.dpmcore.gathering.gathering.presentation.request
+package com.server.dpmcore.bill.bill.presentation.dto.request
 
 import com.server.dpmcore.gathering.gathering.domain.model.GatheringId
 

--- a/src/main/kotlin/com/server/dpmcore/bill/bill/presentation/mapper/BillMapper.kt
+++ b/src/main/kotlin/com/server/dpmcore/bill/bill/presentation/mapper/BillMapper.kt
@@ -58,7 +58,7 @@ class BillMapper(
             billAccountId = bill.billAccount.id?.value ?: 0L,
 //            TODO : 매번 카운트 호출 좀 별로라서 고민해보면 좋을 것 같아요.
             invitedMemberCount = gatheringMembers.count(),
-            invitationConfirmedCount = gatheringMembers.count { it.isInvitationConfirmed },
+            invitationConfirmedCount = gatheringMembers.count { it.isInvitationSubmitted },
             invitationCheckedMemberCount = gatheringMembers.count { it.isChecked },
             gatherings =
                 gatherings.map { gathering ->
@@ -109,7 +109,7 @@ class BillMapper(
             billAccountId = bill.billAccount.id?.value ?: throw BillAccountException.BillAccountNotFoundException(),
 //            TODO : 매번 카운트 호출 좀 별로라서 고민해보면 좋을 것 같아요.
             invitedMemberCount = gatheringMembers.count(),
-            invitationConfirmedCount = gatheringMembers.count { it.isInvitationConfirmed },
+            invitationConfirmedCount = gatheringMembers.count { it.isInvitationSubmitted },
             invitationCheckedMemberCount = gatheringMembers.count { it.isChecked },
 //            inviteAuthorities = TODO(),
             gatherings = gatheringDetails,

--- a/src/main/kotlin/com/server/dpmcore/gathering/exception/GatheringException.kt
+++ b/src/main/kotlin/com/server/dpmcore/gathering/exception/GatheringException.kt
@@ -12,4 +12,8 @@ open class GatheringException(
     class GatheringNotFoundException : GatheringException(GatheringExceptionCode.GATHERING_NOT_FOUND)
 
     class GatheringIdRequiredException : GatheringException(GatheringExceptionCode.GATHERING_ID_REQUIRED)
+
+    class GatheringNotIncludedInBillException : GatheringException(
+        GatheringExceptionCode.GATHERING_NOT_INCLUDED_IN_BILL,
+    )
 }

--- a/src/main/kotlin/com/server/dpmcore/gathering/exception/GatheringExceptionCode.kt
+++ b/src/main/kotlin/com/server/dpmcore/gathering/exception/GatheringExceptionCode.kt
@@ -16,6 +16,7 @@ enum class GatheringExceptionCode(
     GATHERING_NOT_FOUND(HttpStatus.BAD_REQUEST, "GATHERING-404-01", "존재하지 않는 회식입니다."),
     GATHERING_REQUIRED(HttpStatus.BAD_REQUEST, "GATHERING-404-02", "회식은 필수로 존재해야합니다."),
     GATHERING_ID_REQUIRED(HttpStatus.BAD_REQUEST, "GATHERING-404-03", "회식 ID는 필수로 존재해야합니다."),
+    GATHERING_NOT_INCLUDED_IN_BILL(HttpStatus.BAD_REQUEST, "GATHERING-400-02", "해당 정산에 포함되지 않은 회식입니다."),
     ;
 
     override fun getStatus(): HttpStatus = status

--- a/src/main/kotlin/com/server/dpmcore/gathering/exception/GatheringMemberException.kt
+++ b/src/main/kotlin/com/server/dpmcore/gathering/exception/GatheringMemberException.kt
@@ -22,4 +22,8 @@ open class GatheringMemberException(
     class GatheringMemberIdRequiredException : GatheringMemberException(
         GatheringMemberExceptionCode.GATHERING_MEMBER_ID_REQUIRED,
     )
+
+    class AleadySubmittedInvitationException : GatheringMemberException(
+        GatheringMemberExceptionCode.ALREADY_SUBMITTED_INVITATION,
+    )
 }

--- a/src/main/kotlin/com/server/dpmcore/gathering/exception/GatheringMemberException.kt
+++ b/src/main/kotlin/com/server/dpmcore/gathering/exception/GatheringMemberException.kt
@@ -23,7 +23,7 @@ open class GatheringMemberException(
         GatheringMemberExceptionCode.GATHERING_MEMBER_ID_REQUIRED,
     )
 
-    class AleadySubmittedInvitationException : GatheringMemberException(
+    class AlreadySubmittedInvitationException : GatheringMemberException(
         GatheringMemberExceptionCode.ALREADY_SUBMITTED_INVITATION,
     )
 }

--- a/src/main/kotlin/com/server/dpmcore/gathering/exception/GatheringMemberExceptionCode.kt
+++ b/src/main/kotlin/com/server/dpmcore/gathering/exception/GatheringMemberExceptionCode.kt
@@ -17,6 +17,7 @@ enum class GatheringMemberExceptionCode(
     GATHERING_MEMBER_REQUIRED(HttpStatus.BAD_REQUEST, "GATHERING_MEMBER-404-02", "회식 참여 멤버는 필수로 존재해야합니다."),
     ALREADY_CONFIRMED_MEMBER(HttpStatus.BAD_REQUEST, "GATHERING_MEMBER-400-02", "이미 정산 참여가 확정된 멤버는 참여 여부를 변경할 수 없습니다."),
     GATHERING_MEMBER_ID_REQUIRED(HttpStatus.BAD_REQUEST, "GATHERING_MEMBER-400-03", "회식 참여 멤버 ID는 필수로 존재해야합니다."),
+    ALREADY_SUBMITTED_INVITATION(HttpStatus.BAD_REQUEST, "GATHERING_MEMBER-400-04", "이미 초대 답변이 제출된 회식 참여 멤버입니다."),
     ;
 
     override fun getStatus(): HttpStatus = status

--- a/src/main/kotlin/com/server/dpmcore/gathering/gathering/application/GatheringCommandService.kt
+++ b/src/main/kotlin/com/server/dpmcore/gathering/gathering/application/GatheringCommandService.kt
@@ -90,18 +90,18 @@ class GatheringCommandService(
         }
     }
 
-    override fun submitBillParticipationEachGathering(
+    override fun submitBillParticipationConfirmEachGathering(
         billId: BillId,
         memberId: MemberId,
-        gatheringIds: List<GatheringId>,
     ) {
+        val gatheringIds = gatheringPersistencePort.findAllGatheringIdsByBillId(billId)
         gatheringIds.map { gatheringId ->
             val gatheringMembers =
                 gatheringMemberQueryService.getGatheringMembersByGatheringIdAndMemberId(
                     gatheringId,
                     memberId,
                 )
-            gatheringMemberCommandService.gatheringParticipationConfirm(gatheringMembers)
+            gatheringMemberCommandService.markAsGatheringParticipationSubmmitConfirm(gatheringMembers)
         }
     }
 }

--- a/src/main/kotlin/com/server/dpmcore/gathering/gathering/application/GatheringCommandService.kt
+++ b/src/main/kotlin/com/server/dpmcore/gathering/gathering/application/GatheringCommandService.kt
@@ -74,8 +74,8 @@ class GatheringCommandService(
         memberId: MemberId,
     ) {
         gatheringIds.forEach {
-            val gatheringMembers = gatheringMemberQueryService.getGatheringMembersByGatheringIdAndMemberId(it, memberId)
-            gatheringMemberCommandService.markAsChecked(gatheringMembers)
+            val gatheringMember = gatheringMemberQueryService.getGatheringMembersByGatheringIdAndMemberId(it, memberId)
+            gatheringMemberCommandService.markAsChecked(gatheringMember)
         }
     }
 
@@ -84,9 +84,9 @@ class GatheringCommandService(
         memberId: MemberId,
     ) {
         request.gatheringJoins.forEach {
-            val gatheringMembers =
+            val gatheringMember =
                 gatheringMemberQueryService.getGatheringMembersByGatheringIdAndMemberId(it.gatheringId, memberId)
-            gatheringMemberCommandService.markAsJoined(gatheringMembers, it.isJoined)
+            gatheringMemberCommandService.markAsJoined(gatheringMember, it.isJoined)
         }
     }
 }

--- a/src/main/kotlin/com/server/dpmcore/gathering/gathering/application/GatheringCommandService.kt
+++ b/src/main/kotlin/com/server/dpmcore/gathering/gathering/application/GatheringCommandService.kt
@@ -4,12 +4,12 @@ import com.server.dpmcore.authority.domain.model.AuthorityId
 import com.server.dpmcore.bill.bill.domain.model.Bill
 import com.server.dpmcore.bill.bill.domain.model.BillId
 import com.server.dpmcore.bill.bill.domain.port.inbound.BillQueryUseCase
+import com.server.dpmcore.bill.bill.presentation.dto.request.UpdateGatheringJoinsRequest
 import com.server.dpmcore.gathering.gathering.domain.model.Gathering
 import com.server.dpmcore.gathering.gathering.domain.model.GatheringId
 import com.server.dpmcore.gathering.gathering.domain.port.inbound.GatheringCommandUseCase
 import com.server.dpmcore.gathering.gathering.domain.port.inbound.command.GatheringCreateCommand
 import com.server.dpmcore.gathering.gathering.domain.port.outbound.GatheringPersistencePort
-import com.server.dpmcore.gathering.gathering.presentation.request.UpdateGatheringJoinsRequest
 import com.server.dpmcore.gathering.gatheringMember.application.GatheringMemberCommandService
 import com.server.dpmcore.gathering.gatheringMember.application.GatheringMemberQueryService
 import com.server.dpmcore.gathering.gatheringReceipt.application.GatheringReceiptCommandService
@@ -79,7 +79,7 @@ class GatheringCommandService(
         }
     }
 
-    fun markAsJoinedEachGatheringMember(
+    override fun markAsJoinedEachGatheringMember(
         request: UpdateGatheringJoinsRequest,
         memberId: MemberId,
     ) {

--- a/src/main/kotlin/com/server/dpmcore/gathering/gathering/application/GatheringCommandService.kt
+++ b/src/main/kotlin/com/server/dpmcore/gathering/gathering/application/GatheringCommandService.kt
@@ -101,7 +101,7 @@ class GatheringCommandService(
                     gatheringId,
                     memberId,
                 )
-            gatheringMemberCommandService.markAsGatheringParticipationSubmmitConfirm(gatheringMembers)
+            gatheringMemberCommandService.markAsGatheringParticipationSubmitConfirm(gatheringMembers)
         }
     }
 }

--- a/src/main/kotlin/com/server/dpmcore/gathering/gathering/application/GatheringCommandService.kt
+++ b/src/main/kotlin/com/server/dpmcore/gathering/gathering/application/GatheringCommandService.kt
@@ -5,6 +5,7 @@ import com.server.dpmcore.bill.bill.domain.model.Bill
 import com.server.dpmcore.bill.bill.domain.model.BillId
 import com.server.dpmcore.bill.bill.domain.port.inbound.BillQueryUseCase
 import com.server.dpmcore.bill.bill.presentation.dto.request.UpdateGatheringJoinsRequest
+import com.server.dpmcore.gathering.exception.GatheringException
 import com.server.dpmcore.gathering.gathering.domain.model.Gathering
 import com.server.dpmcore.gathering.gathering.domain.model.GatheringId
 import com.server.dpmcore.gathering.gathering.domain.port.inbound.GatheringCommandUseCase
@@ -80,9 +81,14 @@ class GatheringCommandService(
     }
 
     override fun markAsJoinedEachGatheringMember(
+        billId: BillId,
         request: UpdateGatheringJoinsRequest,
         memberId: MemberId,
     ) {
+        val gatheringIds = gatheringPersistencePort.findAllGatheringIdsByBillId(billId)
+        val filteredGatheringIds = request.gatheringJoins.filter { it.gatheringId !in gatheringIds }
+        if (filteredGatheringIds.isNotEmpty()) throw GatheringException.GatheringNotIncludedInBillException()
+
         request.gatheringJoins.forEach {
             val gatheringMember =
                 gatheringMemberQueryService.getGatheringMembersByGatheringIdAndMemberId(it.gatheringId, memberId)

--- a/src/main/kotlin/com/server/dpmcore/gathering/gathering/application/GatheringCommandService.kt
+++ b/src/main/kotlin/com/server/dpmcore/gathering/gathering/application/GatheringCommandService.kt
@@ -75,7 +75,7 @@ class GatheringCommandService(
         memberId: MemberId,
     ) {
         gatheringIds.forEach {
-            val gatheringMember = gatheringMemberQueryService.getGatheringMembersByGatheringIdAndMemberId(it, memberId)
+            val gatheringMember = gatheringMemberQueryService.getGatheringMemberByGatheringIdAndMemberId(it, memberId)
             gatheringMemberCommandService.markAsChecked(gatheringMember)
         }
     }
@@ -91,7 +91,7 @@ class GatheringCommandService(
 
         request.gatheringJoins.forEach {
             val gatheringMember =
-                gatheringMemberQueryService.getGatheringMembersByGatheringIdAndMemberId(it.gatheringId, memberId)
+                gatheringMemberQueryService.getGatheringMemberByGatheringIdAndMemberId(it.gatheringId, memberId)
             gatheringMemberCommandService.markAsJoined(gatheringMember, it.isJoined)
         }
     }
@@ -102,12 +102,12 @@ class GatheringCommandService(
     ) {
         val gatheringIds = gatheringPersistencePort.findAllGatheringIdsByBillId(billId)
         gatheringIds.map { gatheringId ->
-            val gatheringMembers =
-                gatheringMemberQueryService.getGatheringMembersByGatheringIdAndMemberId(
+            val gatheringMember =
+                gatheringMemberQueryService.getGatheringMemberByGatheringIdAndMemberId(
                     gatheringId,
                     memberId,
                 )
-            gatheringMemberCommandService.markAsGatheringParticipationSubmitConfirm(gatheringMembers)
+            gatheringMemberCommandService.markAsGatheringParticipationSubmitConfirm(gatheringMember)
         }
     }
 }

--- a/src/main/kotlin/com/server/dpmcore/gathering/gathering/application/GatheringCommandService.kt
+++ b/src/main/kotlin/com/server/dpmcore/gathering/gathering/application/GatheringCommandService.kt
@@ -89,4 +89,19 @@ class GatheringCommandService(
             gatheringMemberCommandService.markAsJoined(gatheringMember, it.isJoined)
         }
     }
+
+    override fun submitBillParticipationEachGathering(
+        billId: BillId,
+        memberId: MemberId,
+        gatheringIds: List<GatheringId>,
+    ) {
+        gatheringIds.map { gatheringId ->
+            val gatheringMembers =
+                gatheringMemberQueryService.getGatheringMembersByGatheringIdAndMemberId(
+                    gatheringId,
+                    memberId,
+                )
+            gatheringMemberCommandService.gatheringParticipationConfirm(gatheringMembers)
+        }
+    }
 }

--- a/src/main/kotlin/com/server/dpmcore/gathering/gathering/domain/port/inbound/GatheringCommandUseCase.kt
+++ b/src/main/kotlin/com/server/dpmcore/gathering/gathering/domain/port/inbound/GatheringCommandUseCase.kt
@@ -20,4 +20,10 @@ interface GatheringCommandUseCase {
         gatheringIds: List<GatheringId>,
         memberId: MemberId,
     )
+
+    fun submitBillParticipationEachGathering(
+        billId: BillId,
+        memberId: MemberId,
+        gatheringIds: List<GatheringId>,
+    )
 }

--- a/src/main/kotlin/com/server/dpmcore/gathering/gathering/domain/port/inbound/GatheringCommandUseCase.kt
+++ b/src/main/kotlin/com/server/dpmcore/gathering/gathering/domain/port/inbound/GatheringCommandUseCase.kt
@@ -21,9 +21,8 @@ interface GatheringCommandUseCase {
         memberId: MemberId,
     )
 
-    fun submitBillParticipationEachGathering(
+    fun submitBillParticipationConfirmEachGathering(
         billId: BillId,
         memberId: MemberId,
-        gatheringIds: List<GatheringId>,
     )
 }

--- a/src/main/kotlin/com/server/dpmcore/gathering/gathering/domain/port/inbound/GatheringCommandUseCase.kt
+++ b/src/main/kotlin/com/server/dpmcore/gathering/gathering/domain/port/inbound/GatheringCommandUseCase.kt
@@ -23,6 +23,7 @@ interface GatheringCommandUseCase {
     )
 
     fun markAsJoinedEachGatheringMember(
+        billId: BillId,
         request: UpdateGatheringJoinsRequest,
         memberId: MemberId,
     )

--- a/src/main/kotlin/com/server/dpmcore/gathering/gathering/domain/port/inbound/GatheringCommandUseCase.kt
+++ b/src/main/kotlin/com/server/dpmcore/gathering/gathering/domain/port/inbound/GatheringCommandUseCase.kt
@@ -2,6 +2,7 @@ package com.server.dpmcore.gathering.gathering.domain.port.inbound
 
 import com.server.dpmcore.authority.domain.model.AuthorityId
 import com.server.dpmcore.bill.bill.domain.model.BillId
+import com.server.dpmcore.bill.bill.presentation.dto.request.UpdateGatheringJoinsRequest
 import com.server.dpmcore.gathering.gathering.domain.model.GatheringId
 import com.server.dpmcore.gathering.gathering.domain.port.inbound.command.GatheringCreateCommand
 import com.server.dpmcore.gathering.gatheringReceipt.domain.model.GatheringReceipt
@@ -18,6 +19,11 @@ interface GatheringCommandUseCase {
 
     fun markAsCheckedEachGatheringMember(
         gatheringIds: List<GatheringId>,
+        memberId: MemberId,
+    )
+
+    fun markAsJoinedEachGatheringMember(
+        request: UpdateGatheringJoinsRequest,
         memberId: MemberId,
     )
 

--- a/src/main/kotlin/com/server/dpmcore/gathering/gathering/domain/port/inbound/command/GatheringCreateCommand.kt
+++ b/src/main/kotlin/com/server/dpmcore/gathering/gathering/domain/port/inbound/command/GatheringCreateCommand.kt
@@ -21,3 +21,9 @@ data class ReceiptPhotoCommand(
     val receiptId: Long,
     val photoUrl: String?,
 )
+
+data class GatheringParticipantCommand(
+    val gatheringId: Long,
+    val isParticipated: Boolean,
+    val isConfirmed: Boolean,
+)

--- a/src/main/kotlin/com/server/dpmcore/gathering/gathering/presentation/controller/GatheringApi.kt
+++ b/src/main/kotlin/com/server/dpmcore/gathering/gathering/presentation/controller/GatheringApi.kt
@@ -2,9 +2,7 @@ package com.server.dpmcore.gathering.gathering.presentation.controller
 
 import com.server.dpmcore.common.exception.CustomResponse
 import com.server.dpmcore.gathering.gathering.domain.model.GatheringId
-import com.server.dpmcore.gathering.gathering.presentation.request.UpdateGatheringJoinsRequest
 import com.server.dpmcore.gathering.gathering.presentation.response.GatheringMemberJoinListResponse
-import com.server.dpmcore.member.member.domain.model.MemberId
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.media.Content
 import io.swagger.v3.oas.annotations.media.ExampleObject
@@ -16,25 +14,6 @@ import org.springframework.http.MediaType.APPLICATION_JSON_VALUE
 
 @Tag(name = "Gathering", description = "회식 API")
 interface GatheringApi {
-    @ApiResponse(
-        responseCode = "204",
-        description = "각 회식 참여 추가",
-        content = [
-            Content(
-                mediaType = APPLICATION_JSON_VALUE,
-                schema = Schema(implementation = CustomResponse::class),
-            ),
-        ],
-    )
-    @Operation(
-        summary = "각 회식 참여 추가",
-        description = "여러 회식의 참여 여부를 표시합니다.",
-    )
-    fun markAsJoined(
-        request: UpdateGatheringJoinsRequest,
-        memberId: MemberId,
-    ): CustomResponse<Void>
-
     @ApiResponse(
         responseCode = "200",
         description = "회식별 멤버 참여 여부 조회 성공",

--- a/src/main/kotlin/com/server/dpmcore/gathering/gathering/presentation/controller/GatheringApi.kt
+++ b/src/main/kotlin/com/server/dpmcore/gathering/gathering/presentation/controller/GatheringApi.kt
@@ -2,9 +2,7 @@ package com.server.dpmcore.gathering.gathering.presentation.controller
 
 import com.server.dpmcore.common.exception.CustomResponse
 import com.server.dpmcore.gathering.gathering.domain.model.GatheringId
-import com.server.dpmcore.gathering.gathering.presentation.request.UpdateGatheringJoinsRequest
 import com.server.dpmcore.gathering.gathering.presentation.response.GatheringMemberJoinListResponse
-import com.server.dpmcore.member.member.domain.model.MemberId
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.media.Content
 import io.swagger.v3.oas.annotations.media.ExampleObject
@@ -16,44 +14,6 @@ import org.springframework.http.MediaType.APPLICATION_JSON_VALUE
 
 @Tag(name = "Gathering", description = "회식 API")
 interface GatheringApi {
-    @ApiResponse(
-        responseCode = "204",
-        description = "각 회식 참여 여부 저장",
-        content = [
-            Content(
-                mediaType = APPLICATION_JSON_VALUE,
-                schema = Schema(implementation = CustomResponse::class),
-                examples = [
-                    ExampleObject(
-                        name = "각 회식 참여 여부 저장",
-                        value = """
-                                {
-                                  "gatheringJoins": [
-                                    {
-                                      "gatheringId": 1,
-                                      "isJoined": true
-                                    },
-                                    {
-                                      "gatheringId": 2,
-                                      "isJoined": false
-                                    }
-                                  ]
-                                }
-                            """,
-                    ),
-                ],
-            ),
-        ],
-    )
-    @Operation(
-        summary = "각 회식 참여 여부 저장",
-        description = "여러 회식의 참여 여부를 표시합니다.",
-    )
-    fun markAsJoined(
-        request: UpdateGatheringJoinsRequest,
-        memberId: MemberId,
-    ): CustomResponse<Void>
-
     @ApiResponse(
         responseCode = "200",
         description = "회식별 멤버 참여 여부 조회 성공",

--- a/src/main/kotlin/com/server/dpmcore/gathering/gathering/presentation/controller/GatheringController.kt
+++ b/src/main/kotlin/com/server/dpmcore/gathering/gathering/presentation/controller/GatheringController.kt
@@ -4,16 +4,11 @@ import com.server.dpmcore.common.exception.CustomResponse
 import com.server.dpmcore.gathering.gathering.application.GatheringCommandService
 import com.server.dpmcore.gathering.gathering.application.GatheringQueryService
 import com.server.dpmcore.gathering.gathering.domain.model.GatheringId
-import com.server.dpmcore.gathering.gathering.presentation.request.UpdateGatheringJoinsRequest
 import com.server.dpmcore.gathering.gathering.presentation.response.GatheringMemberJoinListResponse
-import com.server.dpmcore.member.member.domain.model.MemberId
-import com.server.dpmcore.security.annotation.CurrentMemberId
 import jakarta.validation.constraints.Positive
 import org.springframework.security.access.prepost.PreAuthorize
 import org.springframework.web.bind.annotation.GetMapping
-import org.springframework.web.bind.annotation.PatchMapping
 import org.springframework.web.bind.annotation.PathVariable
-import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 
@@ -23,16 +18,6 @@ class GatheringController(
     private val gatheringCommandService: GatheringCommandService,
     private val gatheringQueryService: GatheringQueryService,
 ) : GatheringApi {
-    @PreAuthorize("!hasRole('ROLE_GUEST')")
-    @PatchMapping("/join")
-    override fun markAsJoined(
-        @RequestBody request: UpdateGatheringJoinsRequest,
-        @CurrentMemberId memberId: MemberId,
-    ): CustomResponse<Void> {
-        gatheringCommandService.markAsJoinedEachGatheringMember(request, memberId)
-        return CustomResponse.noContent()
-    }
-
     @PreAuthorize("!hasRole('ROLE_GUEST')")
     @GetMapping("/{gatheringId}/members")
     override fun getGatheringMemberJoinList(

--- a/src/main/kotlin/com/server/dpmcore/gathering/gathering/presentation/controller/GatheringController.kt
+++ b/src/main/kotlin/com/server/dpmcore/gathering/gathering/presentation/controller/GatheringController.kt
@@ -1,36 +1,20 @@
 package com.server.dpmcore.gathering.gathering.presentation.controller
 
 import com.server.dpmcore.common.exception.CustomResponse
-import com.server.dpmcore.gathering.gathering.application.GatheringCommandService
 import com.server.dpmcore.gathering.gathering.application.GatheringQueryService
 import com.server.dpmcore.gathering.gathering.domain.model.GatheringId
-import com.server.dpmcore.gathering.gathering.presentation.request.UpdateGatheringJoinsRequest
 import com.server.dpmcore.gathering.gathering.presentation.response.GatheringMemberJoinListResponse
-import com.server.dpmcore.member.member.domain.model.MemberId
-import com.server.dpmcore.security.annotation.CurrentMemberId
 import jakarta.validation.constraints.Positive
 import org.springframework.web.bind.annotation.GetMapping
-import org.springframework.web.bind.annotation.PatchMapping
 import org.springframework.web.bind.annotation.PathVariable
-import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 
 @RestController
 @RequestMapping("/v1/gatherings")
 class GatheringController(
-    private val gatheringCommandService: GatheringCommandService,
     private val gatheringQueryService: GatheringQueryService,
 ) : GatheringApi {
-    @PatchMapping("/{gatheringId}/join")
-    override fun markAsJoined(
-        @RequestBody request: UpdateGatheringJoinsRequest,
-        @CurrentMemberId memberId: MemberId,
-    ): CustomResponse<Void> {
-        gatheringCommandService.markAsJoinedEachGatheringMember(request, memberId)
-        return CustomResponse.noContent()
-    }
-
     @GetMapping("/{gatheringId}")
     override fun getGatheringMemberJoinList(
         @Positive @PathVariable gatheringId: GatheringId,

--- a/src/main/kotlin/com/server/dpmcore/gathering/gatheringMember/application/GatheringMemberCommandService.kt
+++ b/src/main/kotlin/com/server/dpmcore/gathering/gatheringMember/application/GatheringMemberCommandService.kt
@@ -19,20 +19,16 @@ class GatheringMemberCommandService(
         gatheringMemberPersistencePort.save(GatheringMember.create(gathering.id!!, memberId), gathering)
     }
 
-    fun markAsChecked(gatheringMembers: List<GatheringMember>) {
-        gatheringMembers.forEach {
-            it.markAsChecked()
-            gatheringMemberPersistencePort.updateGatheringMemberById(it)
-        }
+    fun markAsChecked(gatheringMember: GatheringMember) {
+        gatheringMember.markAsChecked()
+        gatheringMemberPersistencePort.updateGatheringMemberById(gatheringMember)
     }
 
     fun markAsJoined(
-        gatheringMembers: List<GatheringMember>,
+        gatheringMember: GatheringMember,
         isJoined: Boolean,
     ) {
-        gatheringMembers.forEach {
-            it.markAsJoined(isJoined)
-            gatheringMemberPersistencePort.updateGatheringMemberById(it)
-        }
+        gatheringMember.markAsJoined(isJoined)
+        gatheringMemberPersistencePort.updateGatheringMemberById(gatheringMember)
     }
 }

--- a/src/main/kotlin/com/server/dpmcore/gathering/gatheringMember/application/GatheringMemberCommandService.kt
+++ b/src/main/kotlin/com/server/dpmcore/gathering/gatheringMember/application/GatheringMemberCommandService.kt
@@ -32,8 +32,8 @@ class GatheringMemberCommandService(
         gatheringMemberPersistencePort.updateGatheringMemberById(gatheringMember)
     }
 
-    fun markAsGatheringParticipationSubmmitConfirm(gatheringMember: GatheringMember) {
+    fun markAsGatheringParticipationSubmitConfirm(gatheringMember: GatheringMember) {
         gatheringMember.gatheringParticipationSubmittedConfirm()
-        gatheringMemberPersistencePort.markAsGatheringParticipationSubmmitConfirm(gatheringMember)
+        gatheringMemberPersistencePort.markAsGatheringParticipationSubmitConfirm(gatheringMember)
     }
 }

--- a/src/main/kotlin/com/server/dpmcore/gathering/gatheringMember/application/GatheringMemberCommandService.kt
+++ b/src/main/kotlin/com/server/dpmcore/gathering/gatheringMember/application/GatheringMemberCommandService.kt
@@ -32,8 +32,8 @@ class GatheringMemberCommandService(
         gatheringMemberPersistencePort.updateGatheringMemberById(gatheringMember)
     }
 
-    fun gatheringParticipationConfirm(gatheringMember: GatheringMember) {
-        gatheringMember.gatheringParticipationConfirm()
-        gatheringMemberPersistencePort.gatheringParticipationConfirm(gatheringMember)
+    fun markAsGatheringParticipationSubmmitConfirm(gatheringMember: GatheringMember) {
+        gatheringMember.gatheringParticipationSubmittedConfirm()
+        gatheringMemberPersistencePort.markAsGatheringParticipationSubmmitConfirm(gatheringMember)
     }
 }

--- a/src/main/kotlin/com/server/dpmcore/gathering/gatheringMember/application/GatheringMemberCommandService.kt
+++ b/src/main/kotlin/com/server/dpmcore/gathering/gatheringMember/application/GatheringMemberCommandService.kt
@@ -31,4 +31,9 @@ class GatheringMemberCommandService(
         gatheringMember.markAsJoined(isJoined)
         gatheringMemberPersistencePort.updateGatheringMemberById(gatheringMember)
     }
+
+    fun gatheringParticipationConfirm(gatheringMember: GatheringMember) {
+        gatheringMember.gatheringParticipationConfirm()
+        gatheringMemberPersistencePort.gatheringParticipationConfirm(gatheringMember)
+    }
 }

--- a/src/main/kotlin/com/server/dpmcore/gathering/gatheringMember/application/GatheringMemberQueryService.kt
+++ b/src/main/kotlin/com/server/dpmcore/gathering/gatheringMember/application/GatheringMemberQueryService.kt
@@ -21,11 +21,9 @@ class GatheringMemberQueryService(
     fun getGatheringMembersByGatheringIdAndMemberId(
         gatheringId: GatheringId,
         memberId: MemberId,
-    ): List<GatheringMember> =
+    ): GatheringMember =
         gatheringMemberPersistencePort
             .findByGatheringIdAndMemberId(gatheringId, memberId)
-            .takeIf { it.isNotEmpty() }
-            ?: throw GatheringMemberException.GatheringMemberNotFoundException()
 
     fun getMemberIdsByGatheringId(gatheringId: GatheringId): List<MemberId> =
         gatheringMemberPersistencePort

--- a/src/main/kotlin/com/server/dpmcore/gathering/gatheringMember/application/GatheringMemberQueryService.kt
+++ b/src/main/kotlin/com/server/dpmcore/gathering/gatheringMember/application/GatheringMemberQueryService.kt
@@ -18,7 +18,7 @@ class GatheringMemberQueryService(
     override fun getGatheringMemberByGatheringId(gatheringId: GatheringId): List<GatheringMember> =
         gatheringMemberPersistencePort.findByGatheringId(gatheringId)
 
-    fun getGatheringMembersByGatheringIdAndMemberId(
+    fun getGatheringMemberByGatheringIdAndMemberId(
         gatheringId: GatheringId,
         memberId: MemberId,
     ): GatheringMember =

--- a/src/main/kotlin/com/server/dpmcore/gathering/gatheringMember/domain/model/GatheringMember.kt
+++ b/src/main/kotlin/com/server/dpmcore/gathering/gatheringMember/domain/model/GatheringMember.kt
@@ -55,7 +55,7 @@ class GatheringMember(
     fun gatheringParticipationSubmittedConfirm() {
 //        TODO : 논의 필요, 이 로직 자체가 사용자에게는 응답이 필요하지 않아서 Exception을 발생시키는 것이 맞는지
         if (isInvitationSubmitted) {
-            throw GatheringMemberException.AlreadyConfirmedMemberException()
+            throw GatheringMemberException.AleadySubmittedInvitationException()
         }
 
         this.isInvitationSubmitted = true

--- a/src/main/kotlin/com/server/dpmcore/gathering/gatheringMember/domain/model/GatheringMember.kt
+++ b/src/main/kotlin/com/server/dpmcore/gathering/gatheringMember/domain/model/GatheringMember.kt
@@ -55,7 +55,7 @@ class GatheringMember(
     fun gatheringParticipationSubmittedConfirm() {
 //        TODO : 논의 필요, 이 로직 자체가 사용자에게는 응답이 필요하지 않아서 Exception을 발생시키는 것이 맞는지
         if (isInvitationSubmitted) {
-            throw GatheringMemberException.AleadySubmittedInvitationException()
+            throw GatheringMemberException.AlreadySubmittedInvitationException()
         }
 
         this.isInvitationSubmitted = true

--- a/src/main/kotlin/com/server/dpmcore/gathering/gatheringMember/domain/model/GatheringMember.kt
+++ b/src/main/kotlin/com/server/dpmcore/gathering/gatheringMember/domain/model/GatheringMember.kt
@@ -18,7 +18,7 @@ class GatheringMember(
     val gatheringId: GatheringId,
     isChecked: Boolean = false,
     isJoined: Boolean = false,
-    isInvitationConfirmed: Boolean = false,
+    isInvitationSubmitted: Boolean = false,
     val createdAt: Instant? = null,
     completedAt: Instant? = null,
     updatedAt: Instant? = null,
@@ -30,7 +30,7 @@ class GatheringMember(
     var isJoined: Boolean = isJoined
         private set
 
-    var isInvitationConfirmed: Boolean = isInvitationConfirmed
+    var isInvitationSubmitted: Boolean = isInvitationSubmitted
         private set
 
     var completedAt: Instant? = completedAt
@@ -52,12 +52,13 @@ class GatheringMember(
         this.updatedAt = Instant.now()
     }
 
-    fun gatheringParticipationConfirm() {
-        if (isConfirmed()) {
+    fun gatheringParticipationSubmittedConfirm() {
+//        TODO : 논의 필요, 이 로직 자체가 사용자에게는 응답이 필요하지 않아서 Exception을 발생시키는 것이 맞는지
+        if (isInvitationSubmitted) {
             throw GatheringMemberException.AlreadyConfirmedMemberException()
         }
 
-        this.isInvitationConfirmed = true
+        this.isInvitationSubmitted = true
         this.updatedAt = Instant.now()
     }
 

--- a/src/main/kotlin/com/server/dpmcore/gathering/gatheringMember/domain/model/GatheringMember.kt
+++ b/src/main/kotlin/com/server/dpmcore/gathering/gatheringMember/domain/model/GatheringMember.kt
@@ -52,6 +52,15 @@ class GatheringMember(
         this.updatedAt = Instant.now()
     }
 
+    fun gatheringParticipationConfirm() {
+        if (isConfirmed()) {
+            throw GatheringMemberException.AlreadyConfirmedMemberException()
+        }
+
+        this.isInvitationConfirmed = true
+        this.updatedAt = Instant.now()
+    }
+
     fun isDeleted(): Boolean = deletedAt != null
 
     fun isConfirmed(): Boolean = completedAt != null

--- a/src/main/kotlin/com/server/dpmcore/gathering/gatheringMember/domain/model/GatheringMember.kt
+++ b/src/main/kotlin/com/server/dpmcore/gathering/gatheringMember/domain/model/GatheringMember.kt
@@ -57,6 +57,7 @@ class GatheringMember(
         if (isInvitationSubmitted) {
             throw GatheringMemberException.AlreadySubmittedInvitationException()
         }
+        id ?: throw GatheringMemberException.GatheringMemberIdRequiredException()
 
         this.isInvitationSubmitted = true
         this.updatedAt = Instant.now()

--- a/src/main/kotlin/com/server/dpmcore/gathering/gatheringMember/domain/port/outbound/GatheringMemberPersistencePort.kt
+++ b/src/main/kotlin/com/server/dpmcore/gathering/gatheringMember/domain/port/outbound/GatheringMemberPersistencePort.kt
@@ -27,4 +27,6 @@ interface GatheringMemberPersistencePort {
         gatheringId: GatheringId,
         memberId: MemberId,
     ): GatheringMemberIsJoinQueryModel
+
+    fun gatheringParticipationConfirm(gatheringMember: GatheringMember)
 }

--- a/src/main/kotlin/com/server/dpmcore/gathering/gatheringMember/domain/port/outbound/GatheringMemberPersistencePort.kt
+++ b/src/main/kotlin/com/server/dpmcore/gathering/gatheringMember/domain/port/outbound/GatheringMemberPersistencePort.kt
@@ -28,5 +28,5 @@ interface GatheringMemberPersistencePort {
         memberId: MemberId,
     ): GatheringMemberIsJoinQueryModel
 
-    fun markAsGatheringParticipationSubmmitConfirm(gatheringMember: GatheringMember)
+    fun markAsGatheringParticipationSubmitConfirm(gatheringMember: GatheringMember)
 }

--- a/src/main/kotlin/com/server/dpmcore/gathering/gatheringMember/domain/port/outbound/GatheringMemberPersistencePort.kt
+++ b/src/main/kotlin/com/server/dpmcore/gathering/gatheringMember/domain/port/outbound/GatheringMemberPersistencePort.kt
@@ -28,5 +28,5 @@ interface GatheringMemberPersistencePort {
         memberId: MemberId,
     ): GatheringMemberIsJoinQueryModel
 
-    fun gatheringParticipationConfirm(gatheringMember: GatheringMember)
+    fun markAsGatheringParticipationSubmmitConfirm(gatheringMember: GatheringMember)
 }

--- a/src/main/kotlin/com/server/dpmcore/gathering/gatheringMember/domain/port/outbound/GatheringMemberPersistencePort.kt
+++ b/src/main/kotlin/com/server/dpmcore/gathering/gatheringMember/domain/port/outbound/GatheringMemberPersistencePort.kt
@@ -17,7 +17,7 @@ interface GatheringMemberPersistencePort {
     fun findByGatheringIdAndMemberId(
         gatheringId: GatheringId,
         memberId: MemberId,
-    ): List<GatheringMember>
+    ): GatheringMember
 
     fun updateGatheringMemberById(gatheringMember: GatheringMember)
 

--- a/src/main/kotlin/com/server/dpmcore/gathering/gatheringMember/infrastructure/entity/GatheringMemberEntity.kt
+++ b/src/main/kotlin/com/server/dpmcore/gathering/gatheringMember/infrastructure/entity/GatheringMemberEntity.kt
@@ -33,8 +33,8 @@ class GatheringMemberEntity(
     val isChecked: Boolean = false,
     @Column(name = "is_joined", nullable = false)
     val isJoined: Boolean = false,
-    @Column(name = "is_invitation_confirmed", nullable = false)
-    val isInvitationConfirmed: Boolean = false,
+    @Column(name = "is_invitation_submitted", nullable = false)
+    val isInvitationSubmitted: Boolean = false,
     @Column(name = "completed_at")
     val completedAt: Instant? = null,
     @Column(name = "created_at", nullable = false, updatable = false)
@@ -69,7 +69,7 @@ class GatheringMemberEntity(
             memberId = MemberId(memberId),
             isChecked = isChecked,
             isJoined = isJoined,
-            isInvitationConfirmed = isInvitationConfirmed,
+            isInvitationSubmitted = isInvitationSubmitted,
             completedAt = completedAt,
             createdAt = createdAt,
             updatedAt = updatedAt,

--- a/src/main/kotlin/com/server/dpmcore/gathering/gatheringMember/infrastructure/repository/GatheringMemberJpaRepository.kt
+++ b/src/main/kotlin/com/server/dpmcore/gathering/gatheringMember/infrastructure/repository/GatheringMemberJpaRepository.kt
@@ -11,5 +11,5 @@ interface GatheringMemberJpaRepository : JpaRepository<GatheringMemberEntity, Lo
     fun findByGatheringIdAndMemberId(
         gatheringId: GatheringId,
         memberId: MemberId,
-    ): List<GatheringMemberEntity>
+    ): GatheringMemberEntity?
 }

--- a/src/main/kotlin/com/server/dpmcore/gathering/gatheringMember/infrastructure/repository/GatheringMemberRepository.kt
+++ b/src/main/kotlin/com/server/dpmcore/gathering/gatheringMember/infrastructure/repository/GatheringMemberRepository.kt
@@ -38,8 +38,9 @@ class GatheringMemberRepository(
     override fun findByGatheringIdAndMemberId(
         gatheringId: GatheringId,
         memberId: MemberId,
-    ): List<GatheringMember> =
-        gatheringJpaRepository.findByGatheringIdAndMemberId(gatheringId, memberId).map { it.toDomain() }
+    ): GatheringMember =
+        gatheringJpaRepository.findByGatheringIdAndMemberId(gatheringId, memberId)?.toDomain()
+            ?: throw GatheringMemberException.GatheringMemberNotFoundException()
 
     override fun updateGatheringMemberById(gatheringMember: GatheringMember) {
         val id =

--- a/src/main/kotlin/com/server/dpmcore/gathering/gatheringMember/infrastructure/repository/GatheringMemberRepository.kt
+++ b/src/main/kotlin/com/server/dpmcore/gathering/gatheringMember/infrastructure/repository/GatheringMemberRepository.kt
@@ -106,4 +106,18 @@ class GatheringMemberRepository(
             isJoined = isJoined,
         )
     }
+
+    override fun gatheringParticipationConfirm(gatheringMember: GatheringMember) {
+        val id =
+            gatheringMember.id?.value
+                ?: throw GatheringException.GatheringIdRequiredException()
+
+        queryFactory
+            .updateQuery<GatheringMemberEntity> {
+                where(col(GatheringMemberEntity::id).equal(id))
+                set(col(GatheringMemberEntity::isInvitationConfirmed), gatheringMember.isInvitationConfirmed)
+                set(col(GatheringMemberEntity::isJoined), gatheringMember.isJoined)
+                set(col(GatheringMemberEntity::updatedAt), gatheringMember.updatedAt)
+            }.executeUpdate()
+    }
 }

--- a/src/main/kotlin/com/server/dpmcore/gathering/gatheringMember/infrastructure/repository/GatheringMemberRepository.kt
+++ b/src/main/kotlin/com/server/dpmcore/gathering/gatheringMember/infrastructure/repository/GatheringMemberRepository.kt
@@ -107,7 +107,7 @@ class GatheringMemberRepository(
         )
     }
 
-    override fun gatheringParticipationConfirm(gatheringMember: GatheringMember) {
+    override fun markAsGatheringParticipationSubmmitConfirm(gatheringMember: GatheringMember) {
         val id =
             gatheringMember.id?.value
                 ?: throw GatheringException.GatheringIdRequiredException()
@@ -115,7 +115,7 @@ class GatheringMemberRepository(
         queryFactory
             .updateQuery<GatheringMemberEntity> {
                 where(col(GatheringMemberEntity::id).equal(id))
-                set(col(GatheringMemberEntity::isInvitationConfirmed), gatheringMember.isInvitationConfirmed)
+                set(col(GatheringMemberEntity::isInvitationSubmitted), gatheringMember.isInvitationSubmitted)
                 set(col(GatheringMemberEntity::isJoined), gatheringMember.isJoined)
                 set(col(GatheringMemberEntity::updatedAt), gatheringMember.updatedAt)
             }.executeUpdate()

--- a/src/main/kotlin/com/server/dpmcore/gathering/gatheringMember/infrastructure/repository/GatheringMemberRepository.kt
+++ b/src/main/kotlin/com/server/dpmcore/gathering/gatheringMember/infrastructure/repository/GatheringMemberRepository.kt
@@ -109,8 +109,7 @@ class GatheringMemberRepository(
 
     override fun markAsGatheringParticipationSubmitConfirm(gatheringMember: GatheringMember) {
         val id =
-            gatheringMember.id?.value
-                ?: throw GatheringException.GatheringIdRequiredException()
+            gatheringMember.id?.value ?: 0L
 
         queryFactory
             .updateQuery<GatheringMemberEntity> {

--- a/src/main/kotlin/com/server/dpmcore/gathering/gatheringMember/infrastructure/repository/GatheringMemberRepository.kt
+++ b/src/main/kotlin/com/server/dpmcore/gathering/gatheringMember/infrastructure/repository/GatheringMemberRepository.kt
@@ -107,7 +107,7 @@ class GatheringMemberRepository(
         )
     }
 
-    override fun markAsGatheringParticipationSubmmitConfirm(gatheringMember: GatheringMember) {
+    override fun markAsGatheringParticipationSubmitConfirm(gatheringMember: GatheringMember) {
         val id =
             gatheringMember.id?.value
                 ?: throw GatheringException.GatheringIdRequiredException()


### PR DESCRIPTION
## Summary

>- close #93 

<!-- 해당 PR에 대한 요약을 작성해주세요. -->

## Tasks

- 정산 참여 응답 제출 API
  - 정산 참여 응답을 제출할 경우 해당 상태를 업데이트합니다.
  - 제출한 사람들을 체크하기 위해 사용됩니다.
- findByGatheringIdAndMemberId 단일 멤버로 수정
  - 기존에 List로 반한되던 멤버를 단일 멤버로 수정했습니다.
    - 하나의 회식에는 동일한 멤버가 존재할 수 없기 때문입니다.
- 정산 참여 API 수정
  - Gathering에 존재하던 정산 참여를 Bill로 변경했습니다.
    - 각 회식에 대해 체크하는 것은 맞지만, Bill 단위로 이루어지기 때문입니다.

## ETC

<!-- 추가적인 정보나 참고 사항을 작성해주세요. -->

## Screenshot

<!-- (없을 경우 삭제) 작업한 내용에 대한 스크린샷을 첨부해주세요._ -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 청구서 참여 확인 제출 및 각 모임별 참여 상태를 업데이트할 수 있는 API가 추가되었습니다.
  * 여러 모임에 대한 참여 상태를 한 번에 제출하거나 개별적으로 참여 여부를 표시할 수 있습니다.

* **버그 수정**
  * 초대 응답이 이미 제출된 경우에 대한 예외 처리가 추가되었습니다.

* **리팩터**
  * 초대 응답 상태 필드명이 일관성 있게 변경되었습니다.
  * 일부 API 및 내부 메서드의 반환 타입이 단일 객체로 변경되어 조회 방식이 개선되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->