### PR TITLE
fix: 어드민이 core 접근 시 admin 도메인으로 리다이렉트 되는 문제 수정

### DIFF
--- a/src/main/kotlin/com/server/dpmcore/member/member/application/MemberLoginService.kt
+++ b/src/main/kotlin/com/server/dpmcore/member/member/application/MemberLoginService.kt
@@ -74,11 +74,11 @@ class MemberLoginService(
     }
 
     private fun adminRedirectUrl(requestDomain: String): String {
-        if (environment.activeProfiles.contains("local")) {
+        if (environment.activeProfiles.contains(PROFILE_LOCAL)) {
             return "${securityProperties.adminRedirectUrl}?$IS_ADMIN_TRUE"
         }
 
-        val coreSuffix = if (environment.activeProfiles.contains("dev")) CLIENT_SUFFIX else CORE_SUFFIX
+        val coreSuffix = if (environment.activeProfiles.contains(PROFILE_DEV)) CLIENT_SUFFIX else CORE_SUFFIX
 
         val redirectUrl =
             when (requestDomain) {
@@ -121,5 +121,7 @@ class MemberLoginService(
         private const val ADMIN_SUFFIX = "admin"
         private const val CORE_SUFFIX = "core"
         private const val CLIENT_SUFFIX = "client"
+        private const val PROFILE_DEV = "dev"
+        private const val PROFILE_LOCAL = "local"
     }
 }

--- a/src/main/kotlin/com/server/dpmcore/member/member/application/MemberLoginService.kt
+++ b/src/main/kotlin/com/server/dpmcore/member/member/application/MemberLoginService.kt
@@ -13,7 +13,6 @@ import com.server.dpmcore.security.oauth.dto.LoginResult
 import com.server.dpmcore.security.oauth.dto.OAuthAttributes
 import com.server.dpmcore.security.oauth.token.JwtTokenProvider
 import com.server.dpmcore.security.properties.SecurityProperties
-import io.github.oshai.kotlinlogging.KotlinLogging
 import org.springframework.core.env.Environment
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -28,8 +27,6 @@ class MemberLoginService(
     private val tokenProvider: JwtTokenProvider,
     private val environment: Environment,
 ) : HandleMemberLoginUseCase {
-    private val logger = KotlinLogging.logger { MemberLoginService::class.java }
-
     @Transactional
     override fun handleLoginSuccess(
         requestDomain: String,
@@ -77,27 +74,23 @@ class MemberLoginService(
     }
 
     private fun adminRedirectUrl(requestDomain: String): String {
-        logger.info { "adminRedirectUrl 호출됨 - requestDomain: $requestDomain" }
-
         if (environment.activeProfiles.contains("local")) {
-            logger.info { "로컬 환경입니다. adminRedirectUrl 사용: ${securityProperties.adminRedirectUrl}" }
             return "${securityProperties.adminRedirectUrl}?$IS_ADMIN_TRUE"
         }
 
+        val coreSuffix = if (environment.activeProfiles.contains("dev")) CLIENT_SUFFIX else CORE_SUFFIX
+
         val redirectUrl =
             when (requestDomain) {
-                "$CORE_SUFFIX.${securityProperties.cookie.domain}" -> {
-                    logger.info { "CORE 도메인 접근 - ${securityProperties.coreRedirectUrl}" }
+                "$coreSuffix.${securityProperties.cookie.domain}" -> {
                     "${securityProperties.coreRedirectUrl}?$IS_ADMIN_TRUE"
                 }
 
                 "$ADMIN_SUFFIX.${securityProperties.cookie.domain}" -> {
-                    logger.info { "ADMIN 도메인 접근 - ${securityProperties.adminRedirectUrl}" }
                     "${securityProperties.adminRedirectUrl}?$IS_ADMIN_TRUE"
                 }
 
                 else -> {
-                    logger.warn { "알 수 없는 도메인 접근 - 기본 adminRedirectUrl 사용" }
                     "${securityProperties.adminRedirectUrl}?$IS_ADMIN_TRUE"
                 }
             }
@@ -127,5 +120,6 @@ class MemberLoginService(
         private const val IS_ADMIN_FALSE = "isAdmin=false"
         private const val ADMIN_SUFFIX = "admin"
         private const val CORE_SUFFIX = "core"
+        private const val CLIENT_SUFFIX = "client"
     }
 }

--- a/src/main/kotlin/com/server/dpmcore/member/member/presentation/MemberLoginController.kt
+++ b/src/main/kotlin/com/server/dpmcore/member/member/presentation/MemberLoginController.kt
@@ -1,5 +1,6 @@
 package com.server.dpmcore.member.member.presentation
 
+import io.github.oshai.kotlinlogging.KotlinLogging
 import jakarta.servlet.http.Cookie
 import jakarta.servlet.http.HttpServletRequest
 import jakarta.servlet.http.HttpServletResponse
@@ -10,9 +11,13 @@ import java.net.URI
 @Controller
 class MemberLoginController {
     companion object {
-        const val KAKAO_REDIRECT_URL = "redirect:/oauth2/authorization/kakao"
-        const val REQUEST_DOMAIN = "REQUEST_DOMAIN"
+        private const val KAKAO_REDIRECT_URL = "redirect:/oauth2/authorization/kakao"
+        private const val REQUEST_DOMAIN = "REQUEST_DOMAIN"
+        private const val ORIGIN = "Origin"
+        private const val REFERER = "Referer"
     }
+
+    private val logger = KotlinLogging.logger { MemberLoginController::class.java }
 
     @GetMapping("/login/kakao")
     fun login(
@@ -21,7 +26,7 @@ class MemberLoginController {
     ): String {
         try {
             val requestDomain =
-                URI(request.getHeader("Origin") ?: request.getHeader("Referer") ?: request.requestURL.toString()).host
+                URI(request.getHeader(ORIGIN) ?: request.getHeader(REFERER) ?: request.requestURL.toString()).host
 
             Cookie(REQUEST_DOMAIN, requestDomain).apply {
                 path = "/"
@@ -31,7 +36,7 @@ class MemberLoginController {
                 response.addCookie(this)
             }
         } catch (e: Exception) {
-            throw IllegalArgumentException("Cannot extract host from request source")
+            logger.warn(e) { "Failed to set REQUEST_DOMAIN cookie : ${e.message}" }
         }
         return KAKAO_REDIRECT_URL
     }

--- a/src/main/kotlin/com/server/dpmcore/member/member/presentation/MemberLoginController.kt
+++ b/src/main/kotlin/com/server/dpmcore/member/member/presentation/MemberLoginController.kt
@@ -1,14 +1,38 @@
 package com.server.dpmcore.member.member.presentation
 
+import jakarta.servlet.http.Cookie
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
 import org.springframework.stereotype.Controller
 import org.springframework.web.bind.annotation.GetMapping
+import java.net.URI
 
 @Controller
 class MemberLoginController {
     companion object {
         const val KAKAO_REDIRECT_URL = "redirect:/oauth2/authorization/kakao"
+        const val REQUEST_DOMAIN = "REQUEST_DOMAIN"
     }
 
     @GetMapping("/login/kakao")
-    fun login(): String = KAKAO_REDIRECT_URL
+    fun login(
+        request: HttpServletRequest,
+        response: HttpServletResponse,
+    ): String {
+        try {
+            val requestDomain =
+                URI(request.getHeader("Origin") ?: request.getHeader("Referer") ?: request.requestURL.toString()).host
+
+            Cookie(REQUEST_DOMAIN, requestDomain).apply {
+                path = "/"
+                maxAge = 60
+                isHttpOnly = true
+                secure = true
+                response.addCookie(this)
+            }
+        } catch (e: Exception) {
+            throw IllegalArgumentException("Cannot extract host from request source")
+        }
+        return KAKAO_REDIRECT_URL
+    }
 }

--- a/src/main/kotlin/com/server/dpmcore/security/oauth/handler/CustomAuthenticationSuccessHandler.kt
+++ b/src/main/kotlin/com/server/dpmcore/security/oauth/handler/CustomAuthenticationSuccessHandler.kt
@@ -4,12 +4,14 @@ import com.server.dpmcore.member.member.domain.port.inbound.HandleMemberLoginUse
 import com.server.dpmcore.security.oauth.domain.CustomOAuth2User
 import com.server.dpmcore.security.oauth.dto.LoginResult
 import com.server.dpmcore.security.oauth.token.JwtTokenInjector
+import jakarta.servlet.http.Cookie
 import jakarta.servlet.http.HttpServletRequest
 import jakarta.servlet.http.HttpServletResponse
 import org.springframework.security.core.Authentication
 import org.springframework.security.web.authentication.AuthenticationSuccessHandler
 import org.springframework.stereotype.Component
-import java.net.URI
+
+private const val REQUEST_DOMAIN = "REQUEST_DOMAIN"
 
 @Component
 class CustomAuthenticationSuccessHandler(
@@ -22,28 +24,20 @@ class CustomAuthenticationSuccessHandler(
         authentication: Authentication,
     ) {
         resolveLoginResultFromAuthentication(
-            getRequestDomain(request),
+            request.cookies?.firstOrNull { it.name == REQUEST_DOMAIN }?.value ?: request.serverName,
             authentication,
         ).let { loginResult ->
-            println(getRequestDomain(request))
+            println("요청 도메인: ${request.cookies?.firstOrNull { it.name == REQUEST_DOMAIN }?.value}")
             loginResult.refreshToken?.let {
                 tokenInjector.injectRefreshToken(it, response)
             }
+            Cookie(REQUEST_DOMAIN, request.serverName)
+                .apply {
+                    path = "/"
+                    maxAge = 0
+                }.also { response.addCookie(it) }
             response.sendRedirect(loginResult.redirectUrl)
         }
-    }
-
-    private fun getRequestDomain(request: HttpServletRequest): String {
-        val raw =
-            request.getHeader("Origin")
-                ?: request.getHeader("Referer")
-                ?: request.requestURL.toString()
-
-        return try {
-            URI(raw).host
-        } catch (e: Exception) {
-            null
-        } ?: throw IllegalArgumentException("Cannot extract host from request source: $raw")
     }
 
     private fun resolveLoginResultFromAuthentication(

--- a/src/main/kotlin/com/server/dpmcore/security/oauth/handler/CustomAuthenticationSuccessHandler.kt
+++ b/src/main/kotlin/com/server/dpmcore/security/oauth/handler/CustomAuthenticationSuccessHandler.kt
@@ -27,7 +27,6 @@ class CustomAuthenticationSuccessHandler(
             request.cookies?.firstOrNull { it.name == REQUEST_DOMAIN }?.value ?: request.serverName,
             authentication,
         ).let { loginResult ->
-            println("요청 도메인: ${request.cookies?.firstOrNull { it.name == REQUEST_DOMAIN }?.value}")
             loginResult.refreshToken?.let {
                 tokenInjector.injectRefreshToken(it, response)
             }


### PR DESCRIPTION
## Summary

>- #113 

<!-- 해당 PR에 대한 요약을 작성해주세요. -->

## Tasks

- Origin과 Referer 기반으로 도메인 추출
- 추출한 도메인을 쿠키에 저장
- 디버깅용 로그 제거

## ETC

<!-- 추가적인 정보나 참고 사항을 작성해주세요. -->

## Screenshot

<!-- (없을 경우 삭제) 작업한 내용에 대한 스크린샷을 첨부해주세요._ -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **버그 수정**
  * 인증 성공 시 도메인 추출 로직이 개선되어 "Origin" 또는 "Referer" 헤더를 우선적으로 사용하도록 변경되었습니다.
  * 로그인 리다이렉트 URL의 도메인 접미사가 개발 환경에 따라 동적으로 조정됩니다.
* **기능 개선**
  * 로그인 시 도메인 정보를 쿠키에 저장하여 보안 및 세션 관리가 강화되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->