### PR TITLE
feat: 멤버 승인 및 초기 데이터 주입 개발용 API 구현

### DIFF
--- a/src/main/kotlin/com/server/dpmcore/authority/application/AuthorityQueryService.kt
+++ b/src/main/kotlin/com/server/dpmcore/authority/application/AuthorityQueryService.kt
@@ -1,5 +1,8 @@
 package com.server.dpmcore.authority.application
 
+import com.server.dpmcore.authority.application.exception.AuthorityNotFoundException
+import com.server.dpmcore.authority.domain.model.AuthorityId
+import com.server.dpmcore.authority.domain.model.AuthorityType
 import com.server.dpmcore.authority.domain.port.inbound.AuthorityQueryUseCase
 import com.server.dpmcore.authority.domain.port.outbound.AuthorityPersistencePort
 import com.server.dpmcore.authority.presentation.response.AuthorityListResponse
@@ -21,4 +24,8 @@ class AuthorityQueryService(
         authorityPersistencePort
             .findAllByMemberId(memberId)
             .ifEmpty { listOf("GUEST") }
+
+    override fun getAuthorityIdByName(authorityName: AuthorityType): AuthorityId =
+        authorityPersistencePort.findAuthorityIdByName(authorityName.toString())
+            ?: throw AuthorityNotFoundException()
 }

--- a/src/main/kotlin/com/server/dpmcore/authority/application/exception/AuthorityExceptionCode.kt
+++ b/src/main/kotlin/com/server/dpmcore/authority/application/exception/AuthorityExceptionCode.kt
@@ -1,0 +1,22 @@
+package com.server.dpmcore.authority.application.exception
+
+import com.server.dpmcore.common.exception.ExceptionCode
+import org.springframework.http.HttpStatus
+
+enum class AuthorityExceptionCode(
+    @JvmField
+    val status: HttpStatus,
+    @JvmField
+    val code: String,
+    @JvmField
+    val message: String,
+) : ExceptionCode {
+    AUTHORITY_NOT_FOUND(HttpStatus.NOT_FOUND, "AUTHORITY-404-01", "권한을 찾을 수 없습니다"),
+    ;
+
+    override fun getStatus(): HttpStatus = status
+
+    override fun getCode(): String = code
+
+    override fun getMessage(): String = message
+}

--- a/src/main/kotlin/com/server/dpmcore/authority/application/exception/AuthorityNotFoundException.kt
+++ b/src/main/kotlin/com/server/dpmcore/authority/application/exception/AuthorityNotFoundException.kt
@@ -1,0 +1,8 @@
+package com.server.dpmcore.authority.application.exception
+
+import com.server.dpmcore.common.exception.BusinessException
+
+class AuthorityNotFoundException :
+    BusinessException(
+        AuthorityExceptionCode.AUTHORITY_NOT_FOUND,
+    )

--- a/src/main/kotlin/com/server/dpmcore/authority/domain/model/AuthorityType.kt
+++ b/src/main/kotlin/com/server/dpmcore/authority/domain/model/AuthorityType.kt
@@ -1,0 +1,7 @@
+package com.server.dpmcore.authority.domain.model
+
+enum class AuthorityType {
+    ORGANIZER,
+    DEEPER,
+    GUEST,
+}

--- a/src/main/kotlin/com/server/dpmcore/authority/domain/port/inbound/AuthorityQueryUseCase.kt
+++ b/src/main/kotlin/com/server/dpmcore/authority/domain/port/inbound/AuthorityQueryUseCase.kt
@@ -1,9 +1,13 @@
 package com.server.dpmcore.authority.domain.port.inbound
 
+import com.server.dpmcore.authority.domain.model.AuthorityId
+import com.server.dpmcore.authority.domain.model.AuthorityType
 import com.server.dpmcore.member.member.domain.model.MemberId
 
 interface AuthorityQueryUseCase {
     fun getAuthoritiesByExternalId(externalId: String): List<String>
 
     fun getAuthoritiesByMemberId(memberId: MemberId): List<String>
+
+    fun getAuthorityIdByName(authorityName: AuthorityType): AuthorityId
 }

--- a/src/main/kotlin/com/server/dpmcore/authority/domain/port/outbound/AuthorityPersistencePort.kt
+++ b/src/main/kotlin/com/server/dpmcore/authority/domain/port/outbound/AuthorityPersistencePort.kt
@@ -1,6 +1,7 @@
 package com.server.dpmcore.authority.domain.port.outbound
 
 import com.server.dpmcore.authority.domain.model.Authority
+import com.server.dpmcore.authority.domain.model.AuthorityId
 import com.server.dpmcore.member.member.domain.model.MemberId
 
 interface AuthorityPersistencePort {
@@ -9,4 +10,6 @@ interface AuthorityPersistencePort {
     fun findAllByMemberExternalId(externalId: String): List<String>
 
     fun findAllByMemberId(memberId: MemberId): List<String>
+
+    fun findAuthorityIdByName(authorityName: String): AuthorityId?
 }

--- a/src/main/kotlin/com/server/dpmcore/authority/infrastructure/repository/AuthorityRepository.kt
+++ b/src/main/kotlin/com/server/dpmcore/authority/infrastructure/repository/AuthorityRepository.kt
@@ -3,6 +3,7 @@ package com.server.dpmcore.authority.infrastructure.repository
 import com.linecorp.kotlinjdsl.spring.data.SpringDataQueryFactory
 import com.linecorp.kotlinjdsl.spring.data.listQuery
 import com.server.dpmcore.authority.domain.model.Authority
+import com.server.dpmcore.authority.domain.model.AuthorityId
 import com.server.dpmcore.authority.domain.port.outbound.AuthorityPersistencePort
 import com.server.dpmcore.authority.infrastructure.entity.AuthorityEntity
 import com.server.dpmcore.member.member.domain.model.MemberId
@@ -51,4 +52,17 @@ class AuthorityRepository(
             .where(MEMBERS.MEMBER_ID.eq(memberId.value).and(MEMBER_AUTHORITIES.DELETED_AT.isNull))
             .fetch(AUTHORITIES.NAME)
             .filterNotNull()
+
+    override fun findAuthorityIdByName(authorityName: String): AuthorityId? {
+        dsl
+            .select(AUTHORITIES.AUTHORITY_ID)
+            .from(AUTHORITIES)
+            .where(AUTHORITIES.NAME.eq(authorityName))
+            .fetchOne()
+            ?.get(AUTHORITIES.AUTHORITY_ID)
+            ?.let {
+                return AuthorityId(it)
+            }
+        return null
+    }
 }

--- a/src/main/kotlin/com/server/dpmcore/cohort/domain/model/Cohort.kt
+++ b/src/main/kotlin/com/server/dpmcore/cohort/domain/model/Cohort.kt
@@ -1,6 +1,6 @@
 package com.server.dpmcore.cohort.domain.model
 
-import com.server.dpmcore.member.memberCohort.domain.MemberCohortId
+import com.server.dpmcore.member.memberCohort.domain.model.MemberCohortId
 import com.server.dpmcore.team.domain.model.TeamId
 
 /**
@@ -39,8 +39,7 @@ class Cohort(
         return result
     }
 
-    override fun toString(): String {
-        return "Cohort(id=$id, value='$value', createdAt=$createdAt, updatedAt=$updatedAt, teamIds=$teamIds, " +
+    override fun toString(): String =
+        "Cohort(id=$id, value='$value', createdAt=$createdAt, updatedAt=$updatedAt, teamIds=$teamIds, " +
             "memberCohortIds=$memberCohortIds)"
-    }
 }

--- a/src/main/kotlin/com/server/dpmcore/member/member/application/MemberCommandService.kt
+++ b/src/main/kotlin/com/server/dpmcore/member/member/application/MemberCommandService.kt
@@ -1,0 +1,34 @@
+package com.server.dpmcore.member.member.application
+
+import com.server.dpmcore.authority.domain.model.AuthorityType.DEEPER
+import com.server.dpmcore.member.member.domain.port.outbound.MemberPersistencePort
+import com.server.dpmcore.member.member.presentation.request.InitMemberDataRequest
+import com.server.dpmcore.member.memberAuthority.application.MemberAuthorityService
+import com.server.dpmcore.member.memberCohort.application.MemberCohortService
+import com.server.dpmcore.member.memberTeam.application.MemberTeamService
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+@Transactional
+class MemberCommandService(
+    private val memberPersistencePort: MemberPersistencePort,
+    private val memberQueryService: MemberQueryService,
+    private val memberAuthorityService: MemberAuthorityService,
+    private val memberTeamService: MemberTeamService,
+    private val memberCohortService: MemberCohortService,
+) {
+    fun initMemberDataAndApprove(request: InitMemberDataRequest) {
+        request.members.forEach {
+            memberPersistencePort.save(
+                memberQueryService.getMemberById(it.memberId).apply {
+                    updatePart(it.memberPart)
+                    activate()
+                },
+            )
+            memberAuthorityService.setMemberAuthorityByMemberId(it.memberId, DEEPER)
+            memberTeamService.addMemberToTeam(it.memberId, request.teamId)
+            memberCohortService.addMemberToCohort(it.memberId)
+        }
+    }
+}

--- a/src/main/kotlin/com/server/dpmcore/member/member/domain/model/Member.kt
+++ b/src/main/kotlin/com/server/dpmcore/member/member/domain/model/Member.kt
@@ -1,9 +1,9 @@
 package com.server.dpmcore.member.member.domain.model
 
 import com.server.dpmcore.member.memberAuthority.domain.model.MemberAuthority
-import com.server.dpmcore.member.memberCohort.domain.MemberCohort
+import com.server.dpmcore.member.memberCohort.domain.model.MemberCohort
 import com.server.dpmcore.member.memberOAuth.domain.model.MemberOAuth
-import com.server.dpmcore.member.memberTeam.domain.MemberTeam
+import com.server.dpmcore.member.memberTeam.domain.model.MemberTeam
 import org.springframework.core.env.Environment
 import java.time.Instant
 
@@ -26,7 +26,7 @@ class Member(
     val id: MemberId? = null,
     val name: String,
     val email: String,
-    val part: MemberPart? = null,
+    part: MemberPart? = null,
     status: MemberStatus,
     createdAt: Instant? = null,
     updatedAt: Instant? = null,
@@ -36,6 +36,9 @@ class Member(
     val memberTeams: List<MemberTeam> = emptyList(),
     val memberOAuths: List<MemberOAuth> = emptyList(),
 ) {
+    var part: MemberPart? = part
+        private set
+
     var status: MemberStatus = status
         private set
 
@@ -49,6 +52,16 @@ class Member(
         private set
 
     fun isAllowed(): Boolean = status == MemberStatus.ACTIVE || status == MemberStatus.INACTIVE
+
+    fun activate() {
+        status = MemberStatus.ACTIVE
+        updatedAt = Instant.now()
+    }
+
+    fun updatePart(memberPart: MemberPart) {
+        part = memberPart
+        updatedAt = Instant.now()
+    }
 
     override fun equals(other: Any?): Boolean {
         if (this === other) return true

--- a/src/main/kotlin/com/server/dpmcore/member/member/presentation/MemberApi.kt
+++ b/src/main/kotlin/com/server/dpmcore/member/member/presentation/MemberApi.kt
@@ -2,12 +2,14 @@ package com.server.dpmcore.member.member.presentation
 
 import com.server.dpmcore.common.exception.CustomResponse
 import com.server.dpmcore.member.member.domain.model.MemberId
+import com.server.dpmcore.member.member.presentation.request.InitMemberDataRequest
 import com.server.dpmcore.member.member.presentation.response.MemberDetailsResponse
 import com.server.dpmcore.security.annotation.CurrentMemberId
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.media.Content
 import io.swagger.v3.oas.annotations.media.ExampleObject
 import io.swagger.v3.oas.annotations.media.Schema
+import io.swagger.v3.oas.annotations.parameters.RequestBody
 import io.swagger.v3.oas.annotations.responses.ApiResponse
 import io.swagger.v3.oas.annotations.tags.Tag
 import jakarta.servlet.http.HttpServletResponse
@@ -76,4 +78,49 @@ interface MemberApi {
         @CurrentMemberId memberId: MemberId,
         response: HttpServletResponse,
     ): CustomResponse<Void>
+
+    @Operation(
+        summary = "멤버 데이터 주입 및 승인 API (dev)",
+        description = "멤버의 추가적인 데이터를 주입하고, 승인 상태로 변경합니다. 관리자가 멤버 가입 시 데이터를 변경할 때 사용됩니다.",
+        requestBody =
+            RequestBody(
+                content = [
+                    Content(
+                        mediaType = APPLICATION_JSON_VALUE,
+                        schema = Schema(implementation = InitMemberDataRequest::class),
+                        examples = [
+                            ExampleObject(
+                                name = "멤버 데이터 주입 요청 예시",
+                                value = """
+                                {
+                                    "teamId": "1",
+                                    "members": [
+                                        {
+                                            "memberId": "1",
+                                            "memberPart": "SERVER"
+                                        },
+                                        {
+                                            "memberId": "2",
+                                            "memberPart": "DESIGN"
+                                        }
+                                    ]
+                                }
+                            """,
+                            ),
+                        ],
+                    ),
+                ],
+            ),
+    )
+    @ApiResponse(
+        responseCode = "204",
+        description = "멤버 데이터 주입 및 승인 성공",
+        content = [
+            Content(
+                mediaType = APPLICATION_JSON_VALUE,
+                schema = Schema(implementation = CustomResponse::class),
+            ),
+        ],
+    )
+    fun initMemberDataAndApprove(request: InitMemberDataRequest): CustomResponse<Void>
 }

--- a/src/main/kotlin/com/server/dpmcore/member/member/presentation/MemberController.kt
+++ b/src/main/kotlin/com/server/dpmcore/member/member/presentation/MemberController.kt
@@ -1,25 +1,29 @@
 package com.server.dpmcore.member.member.presentation
 
 import com.server.dpmcore.common.exception.CustomResponse
+import com.server.dpmcore.member.member.application.MemberCommandService
 import com.server.dpmcore.member.member.application.MemberQueryService
 import com.server.dpmcore.member.member.domain.model.MemberId
+import com.server.dpmcore.member.member.presentation.request.InitMemberDataRequest
 import com.server.dpmcore.member.member.presentation.response.MemberDetailsResponse
 import jakarta.servlet.http.HttpServletResponse
 import org.springframework.security.access.prepost.PreAuthorize
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PatchMapping
+import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 
 @RestController
 @RequestMapping("/v1/members")
 class MemberController(
-    private val memberService: MemberQueryService,
+    private val memberQueryService: MemberQueryService,
+    private val memberCommandService: MemberCommandService,
 ) : MemberApi {
     @PreAuthorize("!hasRole('ROLE_GUEST')")
     @GetMapping("/me")
     override fun me(memberId: MemberId): CustomResponse<MemberDetailsResponse> {
-        val response: MemberDetailsResponse = memberService.memberMe(memberId)
+        val response: MemberDetailsResponse = memberQueryService.memberMe(memberId)
         return CustomResponse.ok(response)
     }
 
@@ -28,7 +32,16 @@ class MemberController(
         memberId: MemberId,
         response: HttpServletResponse,
     ): CustomResponse<Void> {
-        memberService.withdraw(memberId, response)
+        memberQueryService.withdraw(memberId, response)
+        return CustomResponse.noContent()
+    }
+
+    @PreAuthorize("hasRole('ROLE_ORGANIZER')")
+    @PatchMapping("/init")
+    override fun initMemberDataAndApprove(
+        @RequestBody request: InitMemberDataRequest,
+    ): CustomResponse<Void> {
+        memberCommandService.initMemberDataAndApprove(request)
         return CustomResponse.noContent()
     }
 }

--- a/src/main/kotlin/com/server/dpmcore/member/member/presentation/request/InitMemberDataRequest.kt
+++ b/src/main/kotlin/com/server/dpmcore/member/member/presentation/request/InitMemberDataRequest.kt
@@ -1,0 +1,15 @@
+package com.server.dpmcore.member.member.presentation.request
+
+import com.server.dpmcore.member.member.domain.model.MemberId
+import com.server.dpmcore.member.member.domain.model.MemberPart
+import com.server.dpmcore.team.domain.model.TeamId
+
+data class InitMemberDataRequest(
+    val teamId: TeamId,
+    val members: List<MemberData>,
+) {
+    data class MemberData(
+        val memberId: MemberId,
+        val memberPart: MemberPart,
+    )
+}

--- a/src/main/kotlin/com/server/dpmcore/member/memberAuthority/application/MemberAuthorityService.kt
+++ b/src/main/kotlin/com/server/dpmcore/member/memberAuthority/application/MemberAuthorityService.kt
@@ -1,14 +1,26 @@
 package com.server.dpmcore.member.memberAuthority.application
 
+import com.server.dpmcore.authority.domain.model.AuthorityType
+import com.server.dpmcore.authority.domain.port.inbound.AuthorityQueryUseCase
 import com.server.dpmcore.member.member.domain.model.MemberId
+import com.server.dpmcore.member.memberAuthority.domain.model.MemberAuthority
 import com.server.dpmcore.member.memberAuthority.domain.port.outbound.MemberAuthorityPersistencePort
 import org.springframework.stereotype.Service
 
 @Service
 class MemberAuthorityService(
     private val memberAuthorityPersistencePort: MemberAuthorityPersistencePort,
+    private val authorityQueryUseCase: AuthorityQueryUseCase,
 ) {
     fun getAuthorityNamesByMemberId(memberId: MemberId): List<String> =
         memberAuthorityPersistencePort
             .findAuthorityNamesByMemberId(memberId.value)
+
+    fun setMemberAuthorityByMemberId(
+        memberId: MemberId,
+        authorityName: AuthorityType,
+    ) {
+        val authorityId = authorityQueryUseCase.getAuthorityIdByName(authorityName)
+        memberAuthorityPersistencePort.save(MemberAuthority.of(memberId, authorityId))
+    }
 }

--- a/src/main/kotlin/com/server/dpmcore/member/memberAuthority/domain/model/MemberAuthority.kt
+++ b/src/main/kotlin/com/server/dpmcore/member/memberAuthority/domain/model/MemberAuthority.kt
@@ -36,4 +36,16 @@ class MemberAuthority(
     override fun toString(): String =
         "MemberAuthority(id=$id, memberId=$memberId, authorityId=$authorityId, grantedAt=$grantedAt, " +
             "deletedAt=$deletedAt)"
+
+    companion object {
+        fun of(
+            memberId: MemberId,
+            authorityId: AuthorityId,
+        ): MemberAuthority =
+            MemberAuthority(
+                memberId = memberId,
+                authorityId = authorityId,
+                grantedAt = Instant.now(),
+            )
+    }
 }

--- a/src/main/kotlin/com/server/dpmcore/member/memberAuthority/domain/port/outbound/MemberAuthorityPersistencePort.kt
+++ b/src/main/kotlin/com/server/dpmcore/member/memberAuthority/domain/port/outbound/MemberAuthorityPersistencePort.kt
@@ -1,5 +1,9 @@
 package com.server.dpmcore.member.memberAuthority.domain.port.outbound
 
+import com.server.dpmcore.member.memberAuthority.domain.model.MemberAuthority
+
 interface MemberAuthorityPersistencePort {
     fun findAuthorityNamesByMemberId(memberId: Long): List<String>
+
+    fun save(memberAuthority: MemberAuthority)
 }

--- a/src/main/kotlin/com/server/dpmcore/member/memberAuthority/infrastructure/repository/MemberAuthorityRepository.kt
+++ b/src/main/kotlin/com/server/dpmcore/member/memberAuthority/infrastructure/repository/MemberAuthorityRepository.kt
@@ -1,11 +1,14 @@
 package com.server.dpmcore.member.memberAuthority.infrastructure.repository
 
 import com.linecorp.kotlinjdsl.spring.data.SpringDataQueryFactory
+import com.server.dpmcore.member.memberAuthority.domain.model.MemberAuthority
 import com.server.dpmcore.member.memberAuthority.domain.port.outbound.MemberAuthorityPersistencePort
 import org.jooq.DSLContext
 import org.jooq.generated.tables.references.AUTHORITIES
 import org.jooq.generated.tables.references.MEMBER_AUTHORITIES
 import org.springframework.stereotype.Repository
+import java.time.LocalDateTime
+import java.time.ZoneId
 
 @Repository
 class MemberAuthorityRepository(
@@ -25,4 +28,18 @@ class MemberAuthorityRepository(
                     .and(MEMBER_AUTHORITIES.DELETED_AT.isNull()),
             ).fetch(AUTHORITIES.NAME)
             .filterNotNull()
+
+    override fun save(memberAuthority: MemberAuthority) {
+        dsl
+            .insertInto(MEMBER_AUTHORITIES)
+            .set(MEMBER_AUTHORITIES.MEMBER_ID, memberAuthority.memberId.value)
+            .set(MEMBER_AUTHORITIES.AUTHORITY_ID, memberAuthority.authorityId.value)
+            .set(
+                MEMBER_AUTHORITIES.GRANTED_AT,
+                memberAuthority.grantedAt
+                    ?.atZone(ZoneId.systemDefault())
+                    ?.toLocalDateTime()
+                    ?: LocalDateTime.now(),
+            ).execute()
+    }
 }

--- a/src/main/kotlin/com/server/dpmcore/member/memberCohort/application/MemberCohortService.kt
+++ b/src/main/kotlin/com/server/dpmcore/member/memberCohort/application/MemberCohortService.kt
@@ -1,0 +1,19 @@
+package com.server.dpmcore.member.memberCohort.application
+
+import com.server.dpmcore.cohort.application.CohortQueryService
+import com.server.dpmcore.member.member.domain.model.MemberId
+import com.server.dpmcore.member.memberCohort.domain.model.MemberCohort
+import com.server.dpmcore.member.memberCohort.domain.port.outbound.MemberCohortPersistencePort
+import org.springframework.stereotype.Service
+
+@Service
+class MemberCohortService(
+    private val memberCohortPersistencePort: MemberCohortPersistencePort,
+    private val cohortQueryService: CohortQueryService,
+) {
+    fun addMemberToCohort(memberId: MemberId) {
+        memberCohortPersistencePort.save(
+            MemberCohort.of(memberId, cohortQueryService.getLatestCohortId()),
+        )
+    }
+}

--- a/src/main/kotlin/com/server/dpmcore/member/memberCohort/domain/MemberCohortId.kt
+++ b/src/main/kotlin/com/server/dpmcore/member/memberCohort/domain/MemberCohortId.kt
@@ -1,6 +1,0 @@
-package com.server.dpmcore.member.memberCohort.domain
-
-@JvmInline
-value class MemberCohortId(val value: Long) {
-    override fun toString(): String = value.toString()
-}

--- a/src/main/kotlin/com/server/dpmcore/member/memberCohort/domain/model/MemberCohort.kt
+++ b/src/main/kotlin/com/server/dpmcore/member/memberCohort/domain/model/MemberCohort.kt
@@ -1,4 +1,4 @@
-package com.server.dpmcore.member.memberCohort.domain
+package com.server.dpmcore.member.memberCohort.domain.model
 
 import com.server.dpmcore.cohort.domain.model.CohortId
 import com.server.dpmcore.member.member.domain.model.MemberId
@@ -24,7 +24,16 @@ class MemberCohort(
         return result
     }
 
-    override fun toString(): String {
-        return "MemberCohort(id=$id, memberId=$memberId, cohortId=$cohortId)"
+    override fun toString(): String = "MemberCohort(id=$id, memberId=$memberId, cohortId=$cohortId)"
+
+    companion object {
+        fun of(
+            memberId: MemberId,
+            cohortId: CohortId,
+        ): MemberCohort =
+            MemberCohort(
+                memberId = memberId,
+                cohortId = cohortId,
+            )
     }
 }

--- a/src/main/kotlin/com/server/dpmcore/member/memberCohort/domain/model/MemberCohortId.kt
+++ b/src/main/kotlin/com/server/dpmcore/member/memberCohort/domain/model/MemberCohortId.kt
@@ -1,0 +1,8 @@
+package com.server.dpmcore.member.memberCohort.domain.model
+
+@JvmInline
+value class MemberCohortId(
+    val value: Long,
+) {
+    override fun toString(): String = value.toString()
+}

--- a/src/main/kotlin/com/server/dpmcore/member/memberCohort/domain/port/outbound/MemberCohortPersistencePort.kt
+++ b/src/main/kotlin/com/server/dpmcore/member/memberCohort/domain/port/outbound/MemberCohortPersistencePort.kt
@@ -1,0 +1,7 @@
+package com.server.dpmcore.member.memberCohort.domain.port.outbound
+
+import com.server.dpmcore.member.memberCohort.domain.model.MemberCohort
+
+interface MemberCohortPersistencePort {
+    fun save(memberCohort: MemberCohort)
+}

--- a/src/main/kotlin/com/server/dpmcore/member/memberCohort/infrastructure/entity/MemberCohortEntity.kt
+++ b/src/main/kotlin/com/server/dpmcore/member/memberCohort/infrastructure/entity/MemberCohortEntity.kt
@@ -4,8 +4,8 @@ import com.server.dpmcore.cohort.domain.model.CohortId
 import com.server.dpmcore.cohort.infrastructure.entity.CohortEntity
 import com.server.dpmcore.member.member.domain.model.MemberId
 import com.server.dpmcore.member.member.infrastructure.entity.MemberEntity
-import com.server.dpmcore.member.memberCohort.domain.MemberCohort
-import com.server.dpmcore.member.memberCohort.domain.MemberCohortId
+import com.server.dpmcore.member.memberCohort.domain.model.MemberCohort
+import com.server.dpmcore.member.memberCohort.domain.model.MemberCohortId
 import jakarta.persistence.Column
 import jakarta.persistence.ConstraintMode
 import jakarta.persistence.Entity

--- a/src/main/kotlin/com/server/dpmcore/member/memberCohort/infrastructure/repository/MemberCohortRepository.kt
+++ b/src/main/kotlin/com/server/dpmcore/member/memberCohort/infrastructure/repository/MemberCohortRepository.kt
@@ -1,0 +1,20 @@
+package com.server.dpmcore.member.memberCohort.infrastructure.repository
+
+import com.server.dpmcore.member.memberCohort.domain.model.MemberCohort
+import com.server.dpmcore.member.memberCohort.domain.port.outbound.MemberCohortPersistencePort
+import org.jooq.DSLContext
+import org.jooq.generated.tables.references.MEMBER_COHORTS
+import org.springframework.stereotype.Repository
+
+@Repository
+class MemberCohortRepository(
+    private val dsl: DSLContext,
+) : MemberCohortPersistencePort {
+    override fun save(memberCohort: MemberCohort) {
+        dsl
+            .insertInto(MEMBER_COHORTS)
+            .set(MEMBER_COHORTS.MEMBER_ID, memberCohort.memberId.value)
+            .set(MEMBER_COHORTS.COHORT_ID, memberCohort.cohortId.value)
+            .execute()
+    }
+}

--- a/src/main/kotlin/com/server/dpmcore/member/memberTeam/application/MemberTeamService.kt
+++ b/src/main/kotlin/com/server/dpmcore/member/memberTeam/application/MemberTeamService.kt
@@ -1,0 +1,19 @@
+package com.server.dpmcore.member.memberTeam.application
+
+import com.server.dpmcore.member.member.domain.model.MemberId
+import com.server.dpmcore.member.memberTeam.domain.model.MemberTeam
+import com.server.dpmcore.member.memberTeam.domain.port.outbound.MemberTeamPersistencePort
+import com.server.dpmcore.team.domain.model.TeamId
+import org.springframework.stereotype.Service
+
+@Service
+class MemberTeamService(
+    private val memberTeamPersistencePort: MemberTeamPersistencePort,
+) {
+    fun addMemberToTeam(
+        memberId: MemberId,
+        teamId: TeamId,
+    ) {
+        memberTeamPersistencePort.save(MemberTeam.of(memberId, teamId))
+    }
+}

--- a/src/main/kotlin/com/server/dpmcore/member/memberTeam/domain/MemberTeamId.kt
+++ b/src/main/kotlin/com/server/dpmcore/member/memberTeam/domain/MemberTeamId.kt
@@ -1,6 +1,0 @@
-package com.server.dpmcore.member.memberTeam.domain
-
-@JvmInline
-value class MemberTeamId(val value: Long) {
-    override fun toString(): String = value.toString()
-}

--- a/src/main/kotlin/com/server/dpmcore/member/memberTeam/domain/model/MemberTeam.kt
+++ b/src/main/kotlin/com/server/dpmcore/member/memberTeam/domain/model/MemberTeam.kt
@@ -1,4 +1,4 @@
-package com.server.dpmcore.member.memberTeam.domain
+package com.server.dpmcore.member.memberTeam.domain.model
 
 import com.server.dpmcore.member.member.domain.model.MemberId
 import com.server.dpmcore.team.domain.model.TeamId
@@ -24,7 +24,16 @@ class MemberTeam(
         return result
     }
 
-    override fun toString(): String {
-        return "MemberTeam(id=$id, memberId=$memberId, teamId=$teamId)"
+    override fun toString(): String = "MemberTeam(id=$id, memberId=$memberId, teamId=$teamId)"
+
+    companion object {
+        fun of(
+            memberId: MemberId,
+            teamId: TeamId,
+        ): MemberTeam =
+            MemberTeam(
+                memberId = memberId,
+                teamId = teamId,
+            )
     }
 }

--- a/src/main/kotlin/com/server/dpmcore/member/memberTeam/domain/model/MemberTeamId.kt
+++ b/src/main/kotlin/com/server/dpmcore/member/memberTeam/domain/model/MemberTeamId.kt
@@ -1,0 +1,8 @@
+package com.server.dpmcore.member.memberTeam.domain.model
+
+@JvmInline
+value class MemberTeamId(
+    val value: Long,
+) {
+    override fun toString(): String = value.toString()
+}

--- a/src/main/kotlin/com/server/dpmcore/member/memberTeam/domain/port/outbound/MemberTeamPersistencePort.kt
+++ b/src/main/kotlin/com/server/dpmcore/member/memberTeam/domain/port/outbound/MemberTeamPersistencePort.kt
@@ -1,0 +1,7 @@
+package com.server.dpmcore.member.memberTeam.domain.port.outbound
+
+import com.server.dpmcore.member.memberTeam.domain.model.MemberTeam
+
+interface MemberTeamPersistencePort {
+    fun save(memberTeam: MemberTeam)
+}

--- a/src/main/kotlin/com/server/dpmcore/member/memberTeam/infrastructure/entity/MemberTeamEntity.kt
+++ b/src/main/kotlin/com/server/dpmcore/member/memberTeam/infrastructure/entity/MemberTeamEntity.kt
@@ -2,8 +2,8 @@ package com.server.dpmcore.member.memberTeam.infrastructure.entity
 
 import com.server.dpmcore.member.member.domain.model.MemberId
 import com.server.dpmcore.member.member.infrastructure.entity.MemberEntity
-import com.server.dpmcore.member.memberTeam.domain.MemberTeam
-import com.server.dpmcore.member.memberTeam.domain.MemberTeamId
+import com.server.dpmcore.member.memberTeam.domain.model.MemberTeam
+import com.server.dpmcore.member.memberTeam.domain.model.MemberTeamId
 import com.server.dpmcore.team.domain.model.TeamId
 import com.server.dpmcore.team.infrastructure.entity.TeamEntity
 import jakarta.persistence.Column

--- a/src/main/kotlin/com/server/dpmcore/member/memberTeam/infrastructure/repository/MemberTeamRepository.kt
+++ b/src/main/kotlin/com/server/dpmcore/member/memberTeam/infrastructure/repository/MemberTeamRepository.kt
@@ -1,0 +1,20 @@
+package com.server.dpmcore.member.memberTeam.infrastructure.repository
+
+import com.server.dpmcore.member.memberTeam.domain.model.MemberTeam
+import com.server.dpmcore.member.memberTeam.domain.port.outbound.MemberTeamPersistencePort
+import org.jooq.DSLContext
+import org.jooq.generated.tables.references.MEMBER_TEAMS
+import org.springframework.stereotype.Repository
+
+@Repository
+class MemberTeamRepository(
+    private val dsl: DSLContext,
+) : MemberTeamPersistencePort {
+    override fun save(memberTeam: MemberTeam) {
+        dsl
+            .insertInto(MEMBER_TEAMS)
+            .set(MEMBER_TEAMS.MEMBER_ID, memberTeam.memberId.value)
+            .set(MEMBER_TEAMS.TEAM_ID, memberTeam.teamId.value)
+            .execute()
+    }
+}

--- a/src/main/kotlin/com/server/dpmcore/team/domain/model/Team.kt
+++ b/src/main/kotlin/com/server/dpmcore/team/domain/model/Team.kt
@@ -1,7 +1,7 @@
 package com.server.dpmcore.team.domain.model
 
 import com.server.dpmcore.cohort.domain.model.CohortId
-import com.server.dpmcore.member.memberTeam.domain.MemberTeamId
+import com.server.dpmcore.member.memberTeam.domain.model.MemberTeamId
 
 /**
  * 팀(Team)을 표현하는 도메인 모델입니다.
@@ -42,8 +42,7 @@ class Team(
         return result
     }
 
-    override fun toString(): String {
-        return "Team(id=$id, number=$number, createdAt=$createdAt, updatedAt=$updatedAt, cohortId=$cohortId, " +
+    override fun toString(): String =
+        "Team(id=$id, number=$number, createdAt=$createdAt, updatedAt=$updatedAt, cohortId=$cohortId, " +
             "memberTeamIds=$memberTeamIds)"
-    }
 }


### PR DESCRIPTION
## Summary

>- #98 

디퍼 가입 시 멤버 승인 및 초기 데이터 주입을 위한 개발용 API를 구현합니다.

<!-- 해당 PR에 대한 요약을 작성해주세요. -->

## Tasks

- AuthorityType 을 통한 권한 타입 안정성 개선
- 멤버 승인 및 초기 데이터 주입 개발용 API 구현

<!-- 추가적인 정보나 참고 사항을 작성해주세요. -->

## Screenshot

<!-- (없을 경우 삭제) 작업한 내용에 대한 스크린샷을 첨부해주세요._ -->
