### PR TITLE
refactor: 내 정보 조회 API에서 파트 없을 경우 null로 명시

### DIFF
--- a/src/main/kotlin/com/server/dpmcore/member/member/presentation/response/MemberDetailsResponse.kt
+++ b/src/main/kotlin/com/server/dpmcore/member/member/presentation/response/MemberDetailsResponse.kt
@@ -1,10 +1,8 @@
 package com.server.dpmcore.member.member.presentation.response
 
-import com.fasterxml.jackson.annotation.JsonInclude
 import com.server.dpmcore.member.member.domain.model.Member
 import io.swagger.v3.oas.annotations.media.Schema
 
-@JsonInclude(JsonInclude.Include.NON_NULL)
 data class MemberDetailsResponse(
     @field:Schema(
         description = "이메일",
@@ -21,7 +19,7 @@ data class MemberDetailsResponse(
     @field:Schema(
         description = "파트",
         example = "WEB",
-        requiredMode = Schema.RequiredMode.NOT_REQUIRED,
+        requiredMode = Schema.RequiredMode.REQUIRED,
     )
     val part: String?,
     @field:Schema(


### PR DESCRIPTION
## Summary

>- #116 

기존 API에서 파트 정보가 없을 경우 해당 필드를 response에서 제외했습니다.
이에 따라 FE에서 파트 정보를 하드코딩하는 문제가 있어 명시적으로 null을 넘기도록 수정하였습니다

<!-- 해당 PR에 대한 요약을 작성해주세요. -->

## Tasks

- 내 정보 조회 API에서 파트 없을 경우 null로 명시

## ETC

<!-- 추가적인 정보나 참고 사항을 작성해주세요. -->

## Screenshot

<!-- (없을 경우 삭제) 작업한 내용에 대한 스크린샷을 첨부해주세요._ -->
