### PR TITLE
refactor : 정산 조회 API '정산 중' 이후 상태에서 참석자 수 추가

### DIFF
--- a/src/main/kotlin/com/server/dpmcore/bill/bill/presentation/dto/response/BillDetailResponse.kt
+++ b/src/main/kotlin/com/server/dpmcore/bill/bill/presentation/dto/response/BillDetailResponse.kt
@@ -16,8 +16,8 @@ data class BillDetailResponse(
     val billAccountId: Long,
     /** 초대된 총 멤버수 */
     val invitedMemberCount: Int,
-    /** 초대에 답변한 멤버의 수 */
-    val invitationConfirmedCount: Int,
+    /** 초대에 답변을 제출한 멤버의 수 */
+    val invitationSubmittedCount: Int,
     /** 초대를 확인한 멤버 수 */
     val invitationCheckedMemberCount: Int,
     val inviteAuthorities: List<BillDetailInviteAuthorityResponse> = BillDetailInviteAuthorityResponse.defaultInviteAuthorityResponse(),

--- a/src/main/kotlin/com/server/dpmcore/bill/bill/presentation/dto/response/BillListDetailResponse.kt
+++ b/src/main/kotlin/com/server/dpmcore/bill/bill/presentation/dto/response/BillListDetailResponse.kt
@@ -14,10 +14,11 @@ data class BillListDetailResponse(
     val billAccountId: Long,
     /** 초대된 총 멤버수 */
     val invitedMemberCount: Int,
-    /** 초대에 답변한 멤버의 수 */
-    val invitationConfirmedCount: Int,
+    /** 초대에 답변을 제출한 멤버의 수 */
+    val invitationSubmittedCount: Int,
     /** 초대를 확인한 멤버 수 */
     val invitationCheckedMemberCount: Int,
+    val participantCount: Int,
     val inviteAuthorities: List<BillListInviteAuthorityDetailResponse>? = BillListInviteAuthorityDetailResponse.defaultInviteAuthorityResponse(),
     val gatherings: List<BillListGatheringDetailResponse>,
 )

--- a/src/main/kotlin/com/server/dpmcore/bill/bill/presentation/mapper/BillMapper.kt
+++ b/src/main/kotlin/com/server/dpmcore/bill/bill/presentation/mapper/BillMapper.kt
@@ -101,7 +101,7 @@ class BillMapper(
             gatheringQueryUseCase.findGatheringMemberByGatheringId(gatheringDetail.gatheringId)
                 .filter { it.isJoined }
                 .forEach { gatheringMember ->
-                    participants.computeIfAbsent(gatheringMember.id!!.value) { mutableListOf() }
+                    participants.computeIfAbsent(gatheringMember.memberId!!.value) { mutableListOf() }
                         .add(gatheringDetail.gatheringId.value)
                 }
         }

--- a/src/main/kotlin/com/server/dpmcore/bill/bill/presentation/mapper/BillMapper.kt
+++ b/src/main/kotlin/com/server/dpmcore/bill/bill/presentation/mapper/BillMapper.kt
@@ -58,7 +58,7 @@ class BillMapper(
             billAccountId = bill.billAccount.id?.value ?: 0L,
 //            TODO : 매번 카운트 호출 좀 별로라서 고민해보면 좋을 것 같아요.
             invitedMemberCount = gatheringMembers.count(),
-            invitationConfirmedCount = gatheringMembers.count { it.isInvitationSubmitted },
+            invitationSubmittedCount = gatheringMembers.count { it.isInvitationSubmitted },
             invitationCheckedMemberCount = gatheringMembers.count { it.isChecked },
             gatherings =
                 gatherings.map { gathering ->
@@ -95,7 +95,7 @@ class BillMapper(
         val gatheringMembers =
             gatheringQueryUseCase.findGatheringMemberByGatheringId(gatheringDetails.get(0).gatheringId)
 
-        val participants : MutableMap<Long, MutableList<Long>> = mutableMapOf<Long, MutableList<Long>>()
+        val participants: MutableMap<Long, MutableList<Long>> = mutableMapOf<Long, MutableList<Long>>()
 
         gatheringDetails.forEach { gatheringDetail ->
             gatheringQueryUseCase.findGatheringMemberByGatheringId(gatheringDetail.gatheringId)
@@ -104,9 +104,8 @@ class BillMapper(
                     participants.computeIfAbsent(gatheringMember.id!!.value) { mutableListOf() }
                         .add(gatheringDetail.gatheringId.value)
                 }
-            }
+        }
         val participantCount = participants.filter { it.value.isNotEmpty() }.count()
-
 
         val billTotalAmount =
             gatheringDetails.sumOf { it.amount }
@@ -122,7 +121,7 @@ class BillMapper(
             billAccountId = bill.billAccount.id?.value ?: throw BillAccountException.BillAccountNotFoundException(),
 //            TODO : 매번 카운트 호출 좀 별로라서 고민해보면 좋을 것 같아요.
             invitedMemberCount = gatheringMembers.count(),
-            invitationConfirmedCount = gatheringMembers.count { it.isInvitationSubmitted },
+            invitationSubmittedCount = gatheringMembers.count { it.isInvitationSubmitted },
             invitationCheckedMemberCount = gatheringMembers.count { it.isChecked },
 //            inviteAuthorities = TODO(),
             participantCount = participantCount,

--- a/src/main/kotlin/com/server/dpmcore/bill/bill/presentation/mapper/BillMapper.kt
+++ b/src/main/kotlin/com/server/dpmcore/bill/bill/presentation/mapper/BillMapper.kt
@@ -95,6 +95,19 @@ class BillMapper(
         val gatheringMembers =
             gatheringQueryUseCase.findGatheringMemberByGatheringId(gatheringDetails.get(0).gatheringId)
 
+        val participants : MutableMap<Long, MutableList<Long>> = mutableMapOf<Long, MutableList<Long>>()
+
+        gatheringDetails.forEach { gatheringDetail ->
+            gatheringQueryUseCase.findGatheringMemberByGatheringId(gatheringDetail.gatheringId)
+                .filter { it.isJoined }
+                .forEach { gatheringMember ->
+                    participants.computeIfAbsent(gatheringMember.id!!.value) { mutableListOf() }
+                        .add(gatheringDetail.gatheringId.value)
+                }
+            }
+        val participantCount = participants.filter { it.value.isNotEmpty() }.count()
+
+
         val billTotalAmount =
             gatheringDetails.sumOf { it.amount }
 
@@ -112,6 +125,7 @@ class BillMapper(
             invitationConfirmedCount = gatheringMembers.count { it.isInvitationSubmitted },
             invitationCheckedMemberCount = gatheringMembers.count { it.isChecked },
 //            inviteAuthorities = TODO(),
+            participantCount = participantCount,
             gatherings = gatheringDetails,
         )
     }


### PR DESCRIPTION
## Summary

>- close #119 

<!-- 해당 PR에 대한 요약을 작성해주세요. -->

## Tasks

- 정산 목록 API 수정
  - 답변 제출 멤버 수 필드명 명확하도록 수정
  - 참여자 수 추가
- 정산 상세 조회 API 수정
  - 답변 제출 멤버 수 필드명 명확하도록 수정

## ETC

<!-- 추가적인 정보나 참고 사항을 작성해주세요. -->

## Screenshot

<!-- (없을 경우 삭제) 작업한 내용에 대한 스크린샷을 첨부해주세요._ -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 청구서 목록 상세 응답에 참여자 수(`participantCount`)가 추가되었습니다.

* **스타일**
  * 초대 응답 인원 수 관련 필드명이 보다 명확하게 변경되었습니다. (확정 → 제출)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->