### PR TITLE
refactor : 참여 멤버 조회 리팩토링(Authority 다중 처리, 팀 번호 추가)

### DIFF
--- a/src/main/kotlin/com/server/dpmcore/gathering/gathering/presentation/controller/GatheringController.kt
+++ b/src/main/kotlin/com/server/dpmcore/gathering/gathering/presentation/controller/GatheringController.kt
@@ -19,7 +19,7 @@ class GatheringController(
     private val gatheringQueryService: GatheringQueryService,
 ) : GatheringApi {
     @PreAuthorize("!hasRole('ROLE_GUEST')")
-    @GetMapping("/{gatheringId}/members")
+    @GetMapping("/{gatheringId}/participant-members")
     override fun getGatheringMemberJoinList(
         @Positive @PathVariable gatheringId: GatheringId,
     ): CustomResponse<GatheringMemberJoinListResponse> {

--- a/src/main/kotlin/com/server/dpmcore/gathering/gatheringMember/application/GatheringMemberQueryService.kt
+++ b/src/main/kotlin/com/server/dpmcore/gathering/gatheringMember/application/GatheringMemberQueryService.kt
@@ -1,5 +1,6 @@
 package com.server.dpmcore.gathering.gatheringMember.application
 
+import com.server.dpmcore.authority.domain.model.AuthorityType
 import com.server.dpmcore.gathering.exception.GatheringMemberException
 import com.server.dpmcore.gathering.gathering.domain.model.GatheringId
 import com.server.dpmcore.gathering.gatheringMember.domain.model.GatheringMember
@@ -34,8 +35,19 @@ class GatheringMemberQueryService(
     fun getQueryGatheringMemberIsJoined(gatheringId: GatheringId): List<GatheringMemberIsJoinQueryModel> {
         val memberIds = getMemberIdsByGatheringId(gatheringId)
         return memberIds.map { memberId ->
-            gatheringMemberPersistencePort
-                .findGatheringMemberWithIsJoinByGatheringIdAndMemberId(gatheringId, memberId)
+            var queryResults =
+                gatheringMemberPersistencePort
+                    .findGatheringMemberWithIsJoinByGatheringIdAndMemberId(gatheringId, memberId)
+            // TODO : 기수 정보가 추가됐을 때 기수 기준 정렬 등의 로직 추가 필요
+            if (queryResults.size > 1) {
+                queryResults =
+                    queryResults.sortedWith(
+                        compareBy {
+                            if (it.authority.equals(AuthorityType.ORGANIZER.name)) 0 else 1
+                        },
+                    )
+            }
+            queryResults.first()
         }
     }
 }

--- a/src/main/kotlin/com/server/dpmcore/gathering/gatheringMember/domain/port/inbound/query/GatheringMemberIsJoinQueryModel.kt
+++ b/src/main/kotlin/com/server/dpmcore/gathering/gatheringMember/domain/port/inbound/query/GatheringMemberIsJoinQueryModel.kt
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonInclude
 @JsonInclude(JsonInclude.Include.NON_NULL)
 data class GatheringMemberIsJoinQueryModel(
     val name: String,
+    val teamNumber: Int,
     val authority: String,
     val part: String?,
     val isJoined: Boolean,
@@ -12,11 +13,13 @@ data class GatheringMemberIsJoinQueryModel(
     companion object {
         fun of(
             name: String,
+            teamNumber: Int,
             authority: String,
             part: String?,
             isJoined: Boolean,
         ) = GatheringMemberIsJoinQueryModel(
             name = name,
+            teamNumber = teamNumber,
             authority = authority,
             part = part,
             isJoined = isJoined,

--- a/src/main/kotlin/com/server/dpmcore/gathering/gatheringMember/domain/port/inbound/query/GatheringMemberIsJoinQueryModel.kt
+++ b/src/main/kotlin/com/server/dpmcore/gathering/gatheringMember/domain/port/inbound/query/GatheringMemberIsJoinQueryModel.kt
@@ -1,13 +1,39 @@
 package com.server.dpmcore.gathering.gatheringMember.domain.port.inbound.query
 
 import com.fasterxml.jackson.annotation.JsonInclude
+import io.swagger.v3.oas.annotations.media.Schema
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
 data class GatheringMemberIsJoinQueryModel(
+    @field:Schema(
+        description = "멤버 이름",
+        example = "정준원",
+        requiredMode = Schema.RequiredMode.REQUIRED,
+    )
     val name: String,
+    @field:Schema(
+        description = "팀 번호",
+        example = "6",
+        requiredMode = Schema.RequiredMode.REQUIRED,
+    )
     val teamNumber: Int,
+    @field:Schema(
+        description = "권한 이름",
+        example = "ORGANIZER",
+        requiredMode = Schema.RequiredMode.REQUIRED,
+    )
     val authority: String,
+    @field:Schema(
+        description = "파트",
+        example = "SERVER",
+        requiredMode = Schema.RequiredMode.REQUIRED,
+    )
     val part: String?,
+    @field:Schema(
+        description = "gathering 참여 여부",
+        example = "true",
+        requiredMode = Schema.RequiredMode.REQUIRED,
+    )
     val isJoined: Boolean,
 ) {
     companion object {

--- a/src/main/kotlin/com/server/dpmcore/gathering/gatheringMember/domain/port/outbound/GatheringMemberPersistencePort.kt
+++ b/src/main/kotlin/com/server/dpmcore/gathering/gatheringMember/domain/port/outbound/GatheringMemberPersistencePort.kt
@@ -26,7 +26,7 @@ interface GatheringMemberPersistencePort {
     fun findGatheringMemberWithIsJoinByGatheringIdAndMemberId(
         gatheringId: GatheringId,
         memberId: MemberId,
-    ): GatheringMemberIsJoinQueryModel
+    ): List<GatheringMemberIsJoinQueryModel>
 
     fun markAsGatheringParticipationSubmitConfirm(gatheringMember: GatheringMember)
 }

--- a/src/main/kotlin/com/server/dpmcore/gathering/gatheringMember/infrastructure/repository/GatheringMemberRepository.kt
+++ b/src/main/kotlin/com/server/dpmcore/gathering/gatheringMember/infrastructure/repository/GatheringMemberRepository.kt
@@ -87,9 +87,9 @@ class GatheringMemberRepository(
                 .on(MEMBERS.MEMBER_ID.eq(MEMBER_AUTHORITIES.MEMBER_ID))
                 .join(AUTHORITIES)
                 .on(MEMBER_AUTHORITIES.AUTHORITY_ID.eq(AUTHORITIES.AUTHORITY_ID))
-                .join(MEMBER_TEAMS)
+                .leftJoin(MEMBER_TEAMS)
                 .on(MEMBER_TEAMS.MEMBER_ID.eq(MEMBERS.MEMBER_ID))
-                .join(TEAMS)
+                .leftJoin(TEAMS)
                 .on(MEMBER_TEAMS.TEAM_ID.eq(TEAMS.TEAM_ID))
                 .where(
                     GATHERING_MEMBERS.GATHERING_ID


### PR DESCRIPTION
## Summary

>- close #135 

<!-- 해당 PR에 대한 요약을 작성해주세요. -->

## Tasks

- Authority 다중 처리
  - 여러 기수 참여 시 최신 기수 우선
  - 운영진, 디퍼 참여 시 운영진 우선
- response
  - 팀 번호 추가

## ETC

<!-- 추가적인 정보나 참고 사항을 작성해주세요. -->

## Screenshot

<!-- (없을 경우 삭제) 작업한 내용에 대한 스크린샷을 첨부해주세요._ -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 신기능
  - 멤버 참여 여부 응답에 teamNumber 필드가 추가되었습니다.
  - 동일 멤버 중복 소속 시 주최자(Organizer) 권한이 우선되어 결과 상단에 노출됩니다.

- 리팩터링
  - 멤버 목록 조회 경로가 /{gatheringId}/members → /{gatheringId}/participant-members 로 변경되었습니다.
  - 멤버 참여 여부 조회 결과가 단일 항목에서 다중 항목 목록으로 반환되도록 변경되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->