### PR TITLE
feat : 정산 참여 멤버들 응답 제출 여부 조회 API 구현

### DIFF
--- a/src/main/kotlin/com/server/dpmcore/bill/bill/application/BillQueryService.kt
+++ b/src/main/kotlin/com/server/dpmcore/bill/bill/application/BillQueryService.kt
@@ -3,6 +3,7 @@ package com.server.dpmcore.bill.bill.application
 import com.server.dpmcore.bill.bill.domain.model.Bill
 import com.server.dpmcore.bill.bill.domain.model.BillId
 import com.server.dpmcore.bill.bill.domain.port.inbound.BillQueryUseCase
+import com.server.dpmcore.bill.bill.domain.port.inbound.query.BillMemberIsInvitationSubmittedQueryModel
 import com.server.dpmcore.bill.bill.domain.port.outbound.BillPersistencePort
 import com.server.dpmcore.bill.bill.presentation.dto.response.BillDetailResponse
 import com.server.dpmcore.bill.bill.presentation.dto.response.BillListResponse
@@ -66,4 +67,7 @@ class BillQueryService(
             }
         return SubmittedParticipantEachGatheringResponse(responses)
     }
+
+    fun getBillMemberSubmittedList(billId: BillId): List<BillMemberIsInvitationSubmittedQueryModel> =
+        gatheringQueryUseCase.getBillMemberSubmittedList(billId)
 }

--- a/src/main/kotlin/com/server/dpmcore/bill/bill/domain/port/inbound/query/BillMemberIsInvitationSubmittedQueryModel.kt
+++ b/src/main/kotlin/com/server/dpmcore/bill/bill/domain/port/inbound/query/BillMemberIsInvitationSubmittedQueryModel.kt
@@ -1,0 +1,9 @@
+package com.server.dpmcore.bill.bill.domain.port.inbound.query
+
+data class BillMemberIsInvitationSubmittedQueryModel(
+    val name: String,
+    val teamNumber: Int,
+    val authority: String,
+    val part: String?,
+    val isInvitationSubmitted: Boolean,
+)

--- a/src/main/kotlin/com/server/dpmcore/bill/bill/domain/port/inbound/query/BillMemberIsInvitationSubmittedQueryModel.kt
+++ b/src/main/kotlin/com/server/dpmcore/bill/bill/domain/port/inbound/query/BillMemberIsInvitationSubmittedQueryModel.kt
@@ -1,9 +1,38 @@
 package com.server.dpmcore.bill.bill.domain.port.inbound.query
 
+import com.fasterxml.jackson.annotation.JsonInclude
+import io.swagger.v3.oas.annotations.media.Schema
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
 data class BillMemberIsInvitationSubmittedQueryModel(
+    @field:Schema(
+        description = "멤버 이름",
+        example = "정준원",
+        requiredMode = Schema.RequiredMode.REQUIRED,
+    )
     val name: String,
+    @field:Schema(
+        description = "팀 번호",
+        example = "6",
+        requiredMode = Schema.RequiredMode.REQUIRED,
+    )
     val teamNumber: Int,
+    @field:Schema(
+        description = "권한 이름",
+        example = "ORGANIZER",
+        requiredMode = Schema.RequiredMode.REQUIRED,
+    )
     val authority: String,
+    @field:Schema(
+        description = "파트",
+        example = "SERVER",
+        requiredMode = Schema.RequiredMode.REQUIRED,
+    )
     val part: String?,
+    @field:Schema(
+        description = "bill 참여 제출 여부",
+        example = "true",
+        requiredMode = Schema.RequiredMode.REQUIRED,
+    )
     val isInvitationSubmitted: Boolean,
 )

--- a/src/main/kotlin/com/server/dpmcore/bill/bill/presentation/controller/BillQueryApi.kt
+++ b/src/main/kotlin/com/server/dpmcore/bill/bill/presentation/controller/BillQueryApi.kt
@@ -303,7 +303,7 @@ interface BillQueryApi {
                           "data": {
                             "members": [
                               {
-                                "name": "준원카카오",
+                                "name": "정준원",
                                 "teamNumber": 1,
                                 "authority": "ORGANIZER",
                                 "part": "SERVER",

--- a/src/main/kotlin/com/server/dpmcore/bill/bill/presentation/controller/BillQueryApi.kt
+++ b/src/main/kotlin/com/server/dpmcore/bill/bill/presentation/controller/BillQueryApi.kt
@@ -3,6 +3,7 @@ package com.server.dpmcore.bill.bill.presentation.controller
 import com.server.dpmcore.bill.bill.domain.model.BillId
 import com.server.dpmcore.bill.bill.presentation.dto.response.BillDetailResponse
 import com.server.dpmcore.bill.bill.presentation.dto.response.BillListResponse
+import com.server.dpmcore.bill.bill.presentation.dto.response.BillMemberSubmittedListResponse
 import com.server.dpmcore.bill.bill.presentation.dto.response.BillSummaryListByMemberResponse
 import com.server.dpmcore.bill.bill.presentation.dto.response.SubmittedParticipantEachGatheringResponse
 import com.server.dpmcore.common.exception.CustomResponse
@@ -283,4 +284,53 @@ interface BillQueryApi {
         @Positive billId: BillId,
         memberId: MemberId,
     ): CustomResponse<SubmittedParticipantEachGatheringResponse>
+
+    @ApiResponse(
+        responseCode = "200",
+        description = "정산 참여 제출 여부 조회 성공",
+        content = [
+            Content(
+                mediaType = APPLICATION_JSON_VALUE,
+                schema = Schema(implementation = CustomResponse::class),
+                examples = [
+                    ExampleObject(
+                        name = "정산 참여 제출 여부 조회 성공 응답",
+                        value = """
+                        {
+                          "status": "OK",
+                          "message": "요청에 성공했습니다",
+                          "code": "GLOBAL-200-01",
+                          "data": {
+                            "members": [
+                              {
+                                "name": "준원카카오",
+                                "teamNumber": 1,
+                                "authority": "ORGANIZER",
+                                "part": "SERVER",
+                                "isInvitationSubmitted": false
+                              },
+                              {
+                                "name": "신민철",
+                                "teamNumber": 1,
+                                "authority": "DEEPER",
+                                "part": "SERVER",
+                                "isInvitationSubmitted": false
+                              }
+                            ]
+                          }
+                        }
+                    """,
+                    ),
+                ],
+            ),
+        ],
+    )
+    @Operation(
+        summary = "정산 참여 제출 여부 조회 API",
+        description = "초대된 정산에 참여 여부를 제출한 멤버들의 목록을 조회합니다.",
+    )
+    fun getBillMemberSubmittedList(
+        @Positive billId: BillId,
+        memberId: MemberId,
+    ): CustomResponse<BillMemberSubmittedListResponse>
 }

--- a/src/main/kotlin/com/server/dpmcore/bill/bill/presentation/controller/BillQueryController.kt
+++ b/src/main/kotlin/com/server/dpmcore/bill/bill/presentation/controller/BillQueryController.kt
@@ -4,6 +4,7 @@ import com.server.dpmcore.bill.bill.application.BillQueryService
 import com.server.dpmcore.bill.bill.domain.model.BillId
 import com.server.dpmcore.bill.bill.presentation.dto.response.BillDetailResponse
 import com.server.dpmcore.bill.bill.presentation.dto.response.BillListResponse
+import com.server.dpmcore.bill.bill.presentation.dto.response.BillMemberSubmittedListResponse
 import com.server.dpmcore.bill.bill.presentation.dto.response.BillSummaryListByMemberResponse
 import com.server.dpmcore.bill.bill.presentation.dto.response.SubmittedParticipantEachGatheringResponse
 import com.server.dpmcore.common.exception.CustomResponse
@@ -58,5 +59,15 @@ class BillQueryController(
     ): CustomResponse<SubmittedParticipantEachGatheringResponse> {
         val response = billQueryService.getSubmittedParticipantEachGathering(billId, memberId)
         return CustomResponse.ok(response)
+    }
+
+    @PreAuthorize("hasRole('ROLE_ORGANIZER')")
+    @GetMapping("/{billId}/members/submitted-members")
+    override fun getBillMemberSubmittedList(
+        @Positive @PathVariable billId: BillId,
+        @CurrentMemberId memberId: MemberId,
+    ): CustomResponse<BillMemberSubmittedListResponse> {
+        val response = billQueryService.getBillMemberSubmittedList(billId)
+        return CustomResponse.ok(BillMemberSubmittedListResponse(response))
     }
 }

--- a/src/main/kotlin/com/server/dpmcore/bill/bill/presentation/dto/response/BillMemberSubmittedListResponse.kt
+++ b/src/main/kotlin/com/server/dpmcore/bill/bill/presentation/dto/response/BillMemberSubmittedListResponse.kt
@@ -1,0 +1,7 @@
+package com.server.dpmcore.bill.bill.presentation.dto.response
+
+import com.server.dpmcore.bill.bill.domain.port.inbound.query.BillMemberIsInvitationSubmittedQueryModel
+
+data class BillMemberSubmittedListResponse(
+    val members: List<BillMemberIsInvitationSubmittedQueryModel>,
+)

--- a/src/main/kotlin/com/server/dpmcore/gathering/gathering/application/GatheringQueryService.kt
+++ b/src/main/kotlin/com/server/dpmcore/gathering/gathering/application/GatheringQueryService.kt
@@ -1,6 +1,7 @@
 package com.server.dpmcore.gathering.gathering.application
 
 import com.server.dpmcore.bill.bill.domain.model.BillId
+import com.server.dpmcore.bill.bill.domain.port.inbound.query.BillMemberIsInvitationSubmittedQueryModel
 import com.server.dpmcore.gathering.gathering.domain.model.Gathering
 import com.server.dpmcore.gathering.gathering.domain.model.GatheringId
 import com.server.dpmcore.gathering.gathering.domain.model.query.SubmittedParticipantGathering
@@ -96,4 +97,9 @@ class GatheringQueryService(
         gatheringIds.sumOf { gatheringId ->
             gatheringReceiptQueryService.getSplitAmountByGatheringId(gatheringId)
         }
+
+    override fun getBillMemberSubmittedList(billId: BillId): List<BillMemberIsInvitationSubmittedQueryModel> {
+        val gatheringIds = getAllGatheringIdsByBillId(billId)
+        return gatheringMemberQueryService.getQueryGatheringMemberIsInvitationSubmitted(gatheringIds.first())
+    }
 }

--- a/src/main/kotlin/com/server/dpmcore/gathering/gathering/application/GatheringQueryService.kt
+++ b/src/main/kotlin/com/server/dpmcore/gathering/gathering/application/GatheringQueryService.kt
@@ -2,6 +2,7 @@ package com.server.dpmcore.gathering.gathering.application
 
 import com.server.dpmcore.bill.bill.domain.model.BillId
 import com.server.dpmcore.bill.bill.domain.port.inbound.query.BillMemberIsInvitationSubmittedQueryModel
+import com.server.dpmcore.gathering.exception.GatheringException
 import com.server.dpmcore.gathering.gathering.domain.model.Gathering
 import com.server.dpmcore.gathering.gathering.domain.model.GatheringId
 import com.server.dpmcore.gathering.gathering.domain.model.query.SubmittedParticipantGathering
@@ -100,6 +101,9 @@ class GatheringQueryService(
 
     override fun getBillMemberSubmittedList(billId: BillId): List<BillMemberIsInvitationSubmittedQueryModel> {
         val gatheringIds = getAllGatheringIdsByBillId(billId)
-        return gatheringMemberQueryService.getQueryGatheringMemberIsInvitationSubmitted(gatheringIds.first())
+        return gatheringMemberQueryService.getQueryGatheringMemberIsInvitationSubmitted(
+            gatheringIds.firstOrNull()
+                ?: throw GatheringException.GatheringNotFoundException(),
+        )
     }
 }

--- a/src/main/kotlin/com/server/dpmcore/gathering/gathering/domain/port/inbound/GatheringQueryUseCase.kt
+++ b/src/main/kotlin/com/server/dpmcore/gathering/gathering/domain/port/inbound/GatheringQueryUseCase.kt
@@ -1,6 +1,7 @@
 package com.server.dpmcore.gathering.gathering.domain.port.inbound
 
 import com.server.dpmcore.bill.bill.domain.model.BillId
+import com.server.dpmcore.bill.bill.domain.port.inbound.query.BillMemberIsInvitationSubmittedQueryModel
 import com.server.dpmcore.gathering.gathering.domain.model.Gathering
 import com.server.dpmcore.gathering.gathering.domain.model.GatheringId
 import com.server.dpmcore.gathering.gathering.domain.model.query.SubmittedParticipantGathering
@@ -26,4 +27,6 @@ interface GatheringQueryUseCase {
         billId: BillId,
         memberId: MemberId,
     ): List<SubmittedParticipantGathering>
+
+    fun getBillMemberSubmittedList(billId: BillId): List<BillMemberIsInvitationSubmittedQueryModel>
 }

--- a/src/main/kotlin/com/server/dpmcore/gathering/gatheringMember/application/GatheringMemberQueryService.kt
+++ b/src/main/kotlin/com/server/dpmcore/gathering/gatheringMember/application/GatheringMemberQueryService.kt
@@ -1,5 +1,7 @@
 package com.server.dpmcore.gathering.gatheringMember.application
 
+import com.server.dpmcore.authority.domain.model.AuthorityType
+import com.server.dpmcore.bill.bill.domain.port.inbound.query.BillMemberIsInvitationSubmittedQueryModel
 import com.server.dpmcore.gathering.exception.GatheringMemberException
 import com.server.dpmcore.gathering.gathering.domain.model.GatheringId
 import com.server.dpmcore.gathering.gatheringMember.domain.model.GatheringMember
@@ -36,6 +38,27 @@ class GatheringMemberQueryService(
         return memberIds.map { memberId ->
             gatheringMemberPersistencePort
                 .findGatheringMemberWithIsJoinByGatheringIdAndMemberId(gatheringId, memberId)
+        }
+    }
+
+    fun getQueryGatheringMemberIsInvitationSubmitted(
+        gatheringId: GatheringId,
+    ): List<BillMemberIsInvitationSubmittedQueryModel> {
+        val memberIds = getMemberIdsByGatheringId(gatheringId)
+        return memberIds.map { memberId ->
+            var queryResults =
+                gatheringMemberPersistencePort
+                    .findGatheringMemberWithIsInvitationSubmittedByGatheringIdAndMemberId(gatheringId, memberId)
+            // TODO : 기수 정보가 추가됐을 때 기수 기준 정렬 등의 로직 추가 필요
+            if (queryResults.size > 1) {
+                queryResults =
+                    queryResults.sortedWith(
+                        compareBy {
+                            if (it.authority.equals(AuthorityType.ORGANIZER.name)) 0 else 1
+                        },
+                    )
+            }
+            queryResults.first()
         }
     }
 }

--- a/src/main/kotlin/com/server/dpmcore/gathering/gatheringMember/application/GatheringMemberQueryService.kt
+++ b/src/main/kotlin/com/server/dpmcore/gathering/gatheringMember/application/GatheringMemberQueryService.kt
@@ -58,7 +58,7 @@ class GatheringMemberQueryService(
                         },
                     )
             }
-            queryResults.first()
+            queryResults.firstOrNull() ?: throw GatheringMemberException.GatheringMemberNotFoundException()
         }
     }
 }

--- a/src/main/kotlin/com/server/dpmcore/gathering/gatheringMember/domain/port/outbound/GatheringMemberPersistencePort.kt
+++ b/src/main/kotlin/com/server/dpmcore/gathering/gatheringMember/domain/port/outbound/GatheringMemberPersistencePort.kt
@@ -1,5 +1,6 @@
 package com.server.dpmcore.gathering.gatheringMember.domain.port.outbound
 
+import com.server.dpmcore.bill.bill.domain.port.inbound.query.BillMemberIsInvitationSubmittedQueryModel
 import com.server.dpmcore.gathering.gathering.domain.model.Gathering
 import com.server.dpmcore.gathering.gathering.domain.model.GatheringId
 import com.server.dpmcore.gathering.gatheringMember.domain.model.GatheringMember
@@ -29,4 +30,9 @@ interface GatheringMemberPersistencePort {
     ): GatheringMemberIsJoinQueryModel
 
     fun markAsGatheringParticipationSubmitConfirm(gatheringMember: GatheringMember)
+
+    fun findGatheringMemberWithIsInvitationSubmittedByGatheringIdAndMemberId(
+        gatheringId: GatheringId,
+        memberId: MemberId,
+    ): List<BillMemberIsInvitationSubmittedQueryModel>
 }

--- a/src/main/kotlin/com/server/dpmcore/gathering/gatheringMember/infrastructure/repository/GatheringMemberRepository.kt
+++ b/src/main/kotlin/com/server/dpmcore/gathering/gatheringMember/infrastructure/repository/GatheringMemberRepository.kt
@@ -142,9 +142,9 @@ class GatheringMemberRepository(
                 .on(MEMBERS.MEMBER_ID.eq(MEMBER_AUTHORITIES.MEMBER_ID))
                 .join(AUTHORITIES)
                 .on(MEMBER_AUTHORITIES.AUTHORITY_ID.eq(AUTHORITIES.AUTHORITY_ID))
-                .join(MEMBER_TEAMS)
+                .leftJoin(MEMBER_TEAMS)
                 .on(MEMBER_TEAMS.MEMBER_ID.eq(MEMBERS.MEMBER_ID))
-                .join(TEAMS)
+                .leftJoin(TEAMS)
                 .on(MEMBER_TEAMS.TEAM_ID.eq(TEAMS.TEAM_ID))
                 .where(
                     GATHERING_MEMBERS.GATHERING_ID

--- a/src/main/resources/db/schema.sql
+++ b/src/main/resources/db/schema.sql
@@ -232,6 +232,7 @@ CREATE TABLE `gathering_members`
     `deleted_at`          datetime(6) DEFAULT NULL,
     `is_checked`          bit(1) NOT NULL,
     `is_joined`           bit(1) NOT NULL,
+    `is_invitation_submitted` bit(1) NOT NULL,
     `member_id`           bigint NOT NULL,
     `updated_at`          datetime(6) NOT NULL,
     `gathering_id`        bigint NOT NULL,


### PR DESCRIPTION
## Summary

>- close #134 

<!-- 해당 PR에 대한 요약을 작성해주세요. -->

## Tasks

- 정산 참여 멤버들 응답 제출 여부 조회 API 구현

## ETC

<!-- 추가적인 정보나 참고 사항을 작성해주세요. -->

## Screenshot

<!-- (없을 경우 삭제) 작업한 내용에 대한 스크린샷을 첨부해주세요._ -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 새로운 기능
  - 주최자가 특정 청구서의 구성원별 초대장 제출 여부 목록을 조회하는 API 추가
  - 응답에 구성원 이름, 팀 번호, 권한, 파트 및 제출 여부 포함

- 문서
  - 새 API에 대한 스펙과 예시 응답 추가

- 데이터베이스
  - 구성원 초대장 제출 여부를 저장하는 필드 추가하여 조회 정확도 향상
<!-- end of auto-generated comment: release notes by coderabbit.ai -->