### PR TITLE
refactor : 정산, 정산 상세 조회 API 스펙 변경

### DIFF
--- a/src/main/kotlin/com/server/dpmcore/bill/bill/application/BillQueryService.kt
+++ b/src/main/kotlin/com/server/dpmcore/bill/bill/application/BillQueryService.kt
@@ -26,14 +26,17 @@ class BillQueryService(
         billPersistencePort.findById(billId)
             ?: throw BillException.BillNotFoundException()
 
-    fun getBillDetails(billId: BillId): BillDetailResponse = billMapper.toBillDetailResponse(getById(billId))
+    fun getBillDetails(
+        billId: BillId,
+        memberId: MemberId,
+    ): BillDetailResponse = billMapper.toBillDetailResponse(getById(billId), memberId)
 
     // TODO: 현재 17기 멤버만 존재하여 getAllBills()로 처리. 향후 다른 기수 추가 시 memberId 기반 필터링 구현 필요
-    override fun getBillByMemberId(memberId: MemberId): BillListResponse = getAllBills()
+    override fun getBillByMemberId(memberId: MemberId): BillListResponse = getAllBills(memberId)
 
-    fun getAllBills(): BillListResponse {
+    fun getAllBills(memberId: MemberId): BillListResponse {
         val bills = billPersistencePort.findAllBills()
-        return billMapper.toBillListResponse(bills)
+        return billMapper.toBillListResponse(bills, memberId)
     }
 
     fun getMemberBillSummaries(billId: BillId): BillSummaryListByMemberResponse {

--- a/src/main/kotlin/com/server/dpmcore/bill/bill/domain/model/Bill.kt
+++ b/src/main/kotlin/com/server/dpmcore/bill/bill/domain/model/Bill.kt
@@ -120,6 +120,34 @@ class Bill(
     fun getIsBillInvitationSubmitted(gatheringMembers: List<GatheringMember>): Boolean =
         gatheringMembers.any { it.isInvitationSubmitted }
 
+    fun getBillInvitedMemberCount(allBillGatheringMembers: List<GatheringMember>): Int {
+        val invitedGatheringMemberSet = mutableSetOf<MemberId>()
+        allBillGatheringMembers.forEach { gatheringMember ->
+            invitedGatheringMemberSet.add(gatheringMember.memberId)
+        }
+        return invitedGatheringMemberSet.size
+    }
+
+    fun getBillInvitationSubmittedCount(allBillGatheringMembers: List<GatheringMember>): Int {
+        val invitationSubmittedSet = mutableSetOf<MemberId>()
+        allBillGatheringMembers.forEach { gatheringMember ->
+            if (gatheringMember.isInvitationSubmitted) {
+                invitationSubmittedSet.add(gatheringMember.memberId)
+            }
+        }
+        return invitationSubmittedSet.size
+    }
+
+    fun getBillInvitationCheckedMemberCount(allBillGatheringMembers: List<GatheringMember>): Int {
+        val invitationCheckedMemberSet = mutableSetOf<MemberId>()
+        allBillGatheringMembers.forEach { gatheringMember ->
+            if (gatheringMember.isChecked) {
+                invitationCheckedMemberSet.add(gatheringMember.memberId)
+            }
+        }
+        return invitationCheckedMemberSet.size
+    }
+
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
         if (other !is Bill) return false

--- a/src/main/kotlin/com/server/dpmcore/bill/bill/domain/model/Bill.kt
+++ b/src/main/kotlin/com/server/dpmcore/bill/bill/domain/model/Bill.kt
@@ -75,6 +75,13 @@ class Bill(
         }
     }
 
+    fun getIsBillViewed(gatheringMembers: List<GatheringMember>): Boolean = gatheringMembers.any { it.isChecked }
+
+    fun getIsBillJoined(gatheringMembers: List<GatheringMember>): Boolean = gatheringMembers.any { it.isJoined }
+
+    fun getIsBillInvitationSubmitted(gatheringMembers: List<GatheringMember>): Boolean =
+        gatheringMembers.any { it.isInvitationSubmitted }
+
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
         if (other !is Bill) return false

--- a/src/main/kotlin/com/server/dpmcore/bill/bill/domain/model/Bill.kt
+++ b/src/main/kotlin/com/server/dpmcore/bill/bill/domain/model/Bill.kt
@@ -79,75 +79,6 @@ class Bill(
         }
     }
 
-    fun getMemberBillSplitAmount(
-        memberId: MemberId,
-        gatheringMembers: List<GatheringMember>,
-        gatheringReceipts: List<GatheringReceipt>,
-    ): Int {
-        if (gatheringMembers.isEmpty()) throw GatheringMemberException.GatheringMemberNotFoundException()
-        if (gatheringReceipts.isEmpty()) throw GatheringReceiptException.GatheringReceiptNotFoundException()
-        gatheringMembers.forEach { gatheringMember ->
-            if (gatheringMember.id == null) throw GatheringMemberException.GatheringMemberNotFoundException()
-        }
-        gatheringReceipts.forEach { receipt ->
-            if (receipt.id == null) throw GatheringReceiptException.GatheringReceiptNotFoundException()
-        }
-
-        val retrieveGatheringMembers = gatheringMembers.filter { it.memberId == memberId }
-
-        val gatheringMemberPairReceipts =
-            retrieveGatheringMembers.map { gatheringMember ->
-                val receipt =
-                    gatheringReceipts.find { it.gatheringId == gatheringMember.gatheringId }
-                        ?: throw GatheringReceiptException.GatheringReceiptNotFoundException()
-                Pair(gatheringMember, receipt)
-            }
-        return gatheringMemberPairReceipts.filter { it.first.isJoined }.sumOf { it.second.splitAmount ?: 0 }
-    }
-
-    fun getBillTotalAmount(gatheringReceipts: List<GatheringReceipt>): Int {
-        if (gatheringReceipts.isEmpty()) throw GatheringReceiptException.GatheringReceiptNotFoundException()
-        gatheringReceipts.forEach { receipt ->
-            if (receipt.id == null) throw GatheringReceiptException.GatheringReceiptNotFoundException()
-        }
-        return gatheringReceipts.sumOf { it.amount }
-    }
-
-    fun getIsBillViewed(gatheringMembers: List<GatheringMember>): Boolean = gatheringMembers.any { it.isChecked }
-
-    fun getIsBillJoined(gatheringMembers: List<GatheringMember>): Boolean = gatheringMembers.any { it.isJoined }
-
-    fun getIsBillInvitationSubmitted(gatheringMembers: List<GatheringMember>): Boolean =
-        gatheringMembers.any { it.isInvitationSubmitted }
-
-    fun getBillInvitedMemberCount(allBillGatheringMembers: List<GatheringMember>): Int {
-        val invitedGatheringMemberSet = mutableSetOf<MemberId>()
-        allBillGatheringMembers.forEach { gatheringMember ->
-            invitedGatheringMemberSet.add(gatheringMember.memberId)
-        }
-        return invitedGatheringMemberSet.size
-    }
-
-    fun getBillInvitationSubmittedCount(allBillGatheringMembers: List<GatheringMember>): Int {
-        val invitationSubmittedSet = mutableSetOf<MemberId>()
-        allBillGatheringMembers.forEach { gatheringMember ->
-            if (gatheringMember.isInvitationSubmitted) {
-                invitationSubmittedSet.add(gatheringMember.memberId)
-            }
-        }
-        return invitationSubmittedSet.size
-    }
-
-    fun getBillInvitationCheckedMemberCount(allBillGatheringMembers: List<GatheringMember>): Int {
-        val invitationCheckedMemberSet = mutableSetOf<MemberId>()
-        allBillGatheringMembers.forEach { gatheringMember ->
-            if (gatheringMember.isChecked) {
-                invitationCheckedMemberSet.add(gatheringMember.memberId)
-            }
-        }
-        return invitationCheckedMemberSet.size
-    }
-
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
         if (other !is Bill) return false
@@ -171,6 +102,75 @@ class Bill(
                 createdAt = Instant.now(),
                 updatedAt = Instant.now(),
             )
+
+        fun getMemberBillSplitAmount(
+            memberId: MemberId,
+            gatheringMembers: List<GatheringMember>,
+            gatheringReceipts: List<GatheringReceipt>,
+        ): Int {
+            if (gatheringMembers.isEmpty()) throw GatheringMemberException.GatheringMemberNotFoundException()
+            if (gatheringReceipts.isEmpty()) throw GatheringReceiptException.GatheringReceiptNotFoundException()
+            gatheringMembers.forEach { gatheringMember ->
+                if (gatheringMember.id == null) throw GatheringMemberException.GatheringMemberNotFoundException()
+            }
+            gatheringReceipts.forEach { receipt ->
+                if (receipt.id == null) throw GatheringReceiptException.GatheringReceiptNotFoundException()
+            }
+
+            val retrieveGatheringMembers = gatheringMembers.filter { it.memberId == memberId }
+
+            val gatheringMemberPairReceipts =
+                retrieveGatheringMembers.map { gatheringMember ->
+                    val receipt =
+                        gatheringReceipts.find { it.gatheringId == gatheringMember.gatheringId }
+                            ?: throw GatheringReceiptException.GatheringReceiptNotFoundException()
+                    Pair(gatheringMember, receipt)
+                }
+            return gatheringMemberPairReceipts.filter { it.first.isJoined }.sumOf { it.second.splitAmount ?: 0 }
+        }
+
+        fun getBillTotalAmount(gatheringReceipts: List<GatheringReceipt>): Int {
+            if (gatheringReceipts.isEmpty()) throw GatheringReceiptException.GatheringReceiptNotFoundException()
+            gatheringReceipts.forEach { receipt ->
+                if (receipt.id == null) throw GatheringReceiptException.GatheringReceiptNotFoundException()
+            }
+            return gatheringReceipts.sumOf { it.amount }
+        }
+
+        fun getIsBillViewed(gatheringMembers: List<GatheringMember>): Boolean = gatheringMembers.any { it.isChecked }
+
+        fun getIsBillJoined(gatheringMembers: List<GatheringMember>): Boolean = gatheringMembers.any { it.isJoined }
+
+        fun getIsBillInvitationSubmitted(gatheringMembers: List<GatheringMember>): Boolean =
+            gatheringMembers.any { it.isInvitationSubmitted }
+
+        fun getBillInvitedMemberCount(allBillGatheringMembers: List<GatheringMember>): Int {
+            val invitedGatheringMemberSet = mutableSetOf<MemberId>()
+            allBillGatheringMembers.forEach { gatheringMember ->
+                invitedGatheringMemberSet.add(gatheringMember.memberId)
+            }
+            return invitedGatheringMemberSet.size
+        }
+
+        fun getBillInvitationSubmittedCount(allBillGatheringMembers: List<GatheringMember>): Int {
+            val invitationSubmittedSet = mutableSetOf<MemberId>()
+            allBillGatheringMembers.forEach { gatheringMember ->
+                if (gatheringMember.isInvitationSubmitted) {
+                    invitationSubmittedSet.add(gatheringMember.memberId)
+                }
+            }
+            return invitationSubmittedSet.size
+        }
+
+        fun getBillInvitationCheckedMemberCount(allBillGatheringMembers: List<GatheringMember>): Int {
+            val invitationCheckedMemberSet = mutableSetOf<MemberId>()
+            allBillGatheringMembers.forEach { gatheringMember ->
+                if (gatheringMember.isChecked) {
+                    invitationCheckedMemberSet.add(gatheringMember.memberId)
+                }
+            }
+            return invitationCheckedMemberSet.size
+        }
     }
 
     override fun toString(): String =

--- a/src/main/kotlin/com/server/dpmcore/bill/bill/domain/model/Bill.kt
+++ b/src/main/kotlin/com/server/dpmcore/bill/bill/domain/model/Bill.kt
@@ -80,6 +80,7 @@ class Bill(
     }
 
     fun getMemberBillSplitAmount(
+        memberId: MemberId,
         gatheringMembers: List<GatheringMember>,
         gatheringReceipts: List<GatheringReceipt>,
     ): Int {
@@ -92,8 +93,10 @@ class Bill(
             if (receipt.id == null) throw GatheringReceiptException.GatheringReceiptNotFoundException()
         }
 
+        val retrieveGatheringMembers = gatheringMembers.filter { it.memberId == memberId }
+
         val gatheringMemberPairReceipts =
-            gatheringMembers.map { gatheringMember ->
+            retrieveGatheringMembers.map { gatheringMember ->
                 val receipt =
                     gatheringReceipts.find { it.gatheringId == gatheringMember.gatheringId }
                         ?: throw GatheringReceiptException.GatheringReceiptNotFoundException()

--- a/src/main/kotlin/com/server/dpmcore/bill/bill/domain/model/Bill.kt
+++ b/src/main/kotlin/com/server/dpmcore/bill/bill/domain/model/Bill.kt
@@ -2,7 +2,6 @@ package com.server.dpmcore.bill.bill.domain.model
 
 import com.server.dpmcore.bill.billAccount.domain.model.BillAccount
 import com.server.dpmcore.bill.exception.BillException
-import com.server.dpmcore.gathering.exception.GatheringMemberException
 import com.server.dpmcore.gathering.exception.GatheringReceiptException
 import com.server.dpmcore.gathering.gathering.domain.model.GatheringId
 import com.server.dpmcore.gathering.gatheringMember.domain.model.GatheringMember
@@ -108,15 +107,6 @@ class Bill(
             gatheringMembers: List<GatheringMember>,
             gatheringReceipts: List<GatheringReceipt>,
         ): Int {
-            if (gatheringMembers.isEmpty()) throw GatheringMemberException.GatheringMemberNotFoundException()
-            if (gatheringReceipts.isEmpty()) throw GatheringReceiptException.GatheringReceiptNotFoundException()
-            gatheringMembers.forEach { gatheringMember ->
-                if (gatheringMember.id == null) throw GatheringMemberException.GatheringMemberNotFoundException()
-            }
-            gatheringReceipts.forEach { receipt ->
-                if (receipt.id == null) throw GatheringReceiptException.GatheringReceiptNotFoundException()
-            }
-
             val retrieveGatheringMembers = gatheringMembers.filter { it.memberId == memberId }
 
             val gatheringMemberPairReceipts =
@@ -129,13 +119,7 @@ class Bill(
             return gatheringMemberPairReceipts.filter { it.first.isJoined }.sumOf { it.second.splitAmount ?: 0 }
         }
 
-        fun getBillTotalAmount(gatheringReceipts: List<GatheringReceipt>): Int {
-            if (gatheringReceipts.isEmpty()) throw GatheringReceiptException.GatheringReceiptNotFoundException()
-            gatheringReceipts.forEach { receipt ->
-                if (receipt.id == null) throw GatheringReceiptException.GatheringReceiptNotFoundException()
-            }
-            return gatheringReceipts.sumOf { it.amount }
-        }
+        fun getBillTotalAmount(gatheringReceipts: List<GatheringReceipt>): Int = gatheringReceipts.sumOf { it.amount }
 
         fun getIsBillViewed(gatheringMembers: List<GatheringMember>): Boolean = gatheringMembers.any { it.isChecked }
 

--- a/src/main/kotlin/com/server/dpmcore/bill/bill/presentation/controller/BillQueryApi.kt
+++ b/src/main/kotlin/com/server/dpmcore/bill/bill/presentation/controller/BillQueryApi.kt
@@ -102,6 +102,7 @@ interface BillQueryApi {
     )
     fun getBillDetails(
         @Positive billId: BillId,
+        memberId: MemberId,
     ): CustomResponse<BillDetailResponse>
 
     @ApiResponses(

--- a/src/main/kotlin/com/server/dpmcore/bill/bill/presentation/controller/BillQueryController.kt
+++ b/src/main/kotlin/com/server/dpmcore/bill/bill/presentation/controller/BillQueryController.kt
@@ -26,8 +26,9 @@ class BillQueryController(
     @GetMapping("/{billId}")
     override fun getBillDetails(
         @Positive @PathVariable billId: BillId,
+        @CurrentMemberId memberId: MemberId,
     ): CustomResponse<BillDetailResponse> {
-        val response = billQueryService.getBillDetails(billId)
+        val response = billQueryService.getBillDetails(billId, memberId)
         return CustomResponse.ok(response)
     }
 

--- a/src/main/kotlin/com/server/dpmcore/bill/bill/presentation/dto/response/BillDetailResponse.kt
+++ b/src/main/kotlin/com/server/dpmcore/bill/bill/presentation/dto/response/BillDetailResponse.kt
@@ -79,6 +79,24 @@ data class BillDetailResponse(
         requiredMode = Schema.RequiredMode.REQUIRED,
     )
     val invitationCheckedMemberCount: Int,
+    @field:Schema(
+        description = "초대를 확인(열람)한 여부",
+        example = "true",
+        requiredMode = Schema.RequiredMode.REQUIRED,
+    )
+    val isViewed: Boolean,
+    @field:Schema(
+        description = "정산 참여 여부",
+        example = "true",
+        requiredMode = Schema.RequiredMode.REQUIRED,
+    )
+    val isJoined: Boolean,
+    @field:Schema(
+        description = "정산 참여 제출 여부",
+        example = "true",
+        requiredMode = Schema.RequiredMode.REQUIRED,
+    )
+    val isInvitationSubmitted: Boolean,
     val inviteAuthorities: List<BillDetailInviteAuthorityResponse> =
         BillDetailInviteAuthorityResponse.defaultInviteAuthorityResponse(),
     val gatherings: List<BillDetailGatheringResponse>,

--- a/src/main/kotlin/com/server/dpmcore/bill/bill/presentation/dto/response/BillListDetailResponse.kt
+++ b/src/main/kotlin/com/server/dpmcore/bill/bill/presentation/dto/response/BillListDetailResponse.kt
@@ -73,6 +73,24 @@ data class BillListDetailResponse(
         requiredMode = Schema.RequiredMode.REQUIRED,
     )
     val participantCount: Int,
+    @field:Schema(
+        description = "초대를 확인(열람)한 여부",
+        example = "true",
+        requiredMode = Schema.RequiredMode.REQUIRED,
+    )
+    val isViewed: Boolean,
+    @field:Schema(
+        description = "정산 참여 여부",
+        example = "true",
+        requiredMode = Schema.RequiredMode.REQUIRED,
+    )
+    val isJoined: Boolean,
+    @field:Schema(
+        description = "정산 참여 제출 여부",
+        example = "true",
+        requiredMode = Schema.RequiredMode.REQUIRED,
+    )
+    val isInvitationSubmitted: Boolean,
     val inviteAuthorities: List<BillListInviteAuthorityDetailResponse>? =
         BillListInviteAuthorityDetailResponse
             .defaultInviteAuthorityResponse(),

--- a/src/main/kotlin/com/server/dpmcore/bill/bill/presentation/mapper/BillMapper.kt
+++ b/src/main/kotlin/com/server/dpmcore/bill/bill/presentation/mapper/BillMapper.kt
@@ -64,9 +64,9 @@ class BillMapper(
                 ),
             billAccountId = bill.billAccount.id?.value ?: 0L,
 //            TODO : 매번 카운트 호출 좀 별로라서 고민해보면 좋을 것 같아요.
-            invitedMemberCount = allBillGatheringMembers.count(),
-            invitationSubmittedCount = allBillGatheringMembers.count { it.isInvitationSubmitted },
-            invitationCheckedMemberCount = allBillGatheringMembers.count { it.isChecked },
+            invitedMemberCount = bill.getBillInvitedMemberCount(allBillGatheringMembers),
+            invitationSubmittedCount = bill.getBillInvitationSubmittedCount(allBillGatheringMembers),
+            invitationCheckedMemberCount = bill.getBillInvitationCheckedMemberCount(allBillGatheringMembers),
             isViewed = bill.getIsBillViewed(gatheringMembersByRetrievedMember),
             isJoined = bill.getIsBillJoined(gatheringMembersByRetrievedMember),
             isInvitationSubmitted = bill.getIsBillInvitationSubmitted(gatheringMembersByRetrievedMember),
@@ -112,7 +112,7 @@ class BillMapper(
 
 //        TODO : 여기서 모든 gathering에 대해서 조회해서 체크하는 로직 필요(각 gathering마다 멤버가 다를 수 있어서)
         val allBillGatheringMembers =
-            gatheringQueryUseCase.findGatheringMemberByGatheringId(gatheringDetails.get(0).gatheringId)
+            gatheringQueryUseCase.getAllGatheringMembersByBillId(bill.id)
 
         val gatheringMembersByRetrievedMember = allBillGatheringMembers.filter { it.memberId == memberId }
 
@@ -143,9 +143,9 @@ class BillMapper(
                 instantToLocalDateTime(bill.createdAt ?: throw BillException.BillNotFoundException()),
             billAccountId = bill.billAccount.id?.value ?: throw BillAccountException.BillAccountNotFoundException(),
 //            TODO : 매번 카운트 호출 좀 별로라서 고민해보면 좋을 것 같아요.
-            invitedMemberCount = allBillGatheringMembers.count(),
-            invitationSubmittedCount = allBillGatheringMembers.count { it.isInvitationSubmitted },
-            invitationCheckedMemberCount = allBillGatheringMembers.count { it.isChecked },
+            invitedMemberCount = bill.getBillInvitedMemberCount(allBillGatheringMembers),
+            invitationSubmittedCount = bill.getBillInvitationSubmittedCount(allBillGatheringMembers),
+            invitationCheckedMemberCount = bill.getBillInvitationCheckedMemberCount(allBillGatheringMembers),
             participantCount = participantCount,
             isViewed = bill.getIsBillViewed(gatheringMembersByRetrievedMember),
             isJoined = bill.getIsBillJoined(gatheringMembersByRetrievedMember),

--- a/src/main/kotlin/com/server/dpmcore/bill/bill/presentation/mapper/BillMapper.kt
+++ b/src/main/kotlin/com/server/dpmcore/bill/bill/presentation/mapper/BillMapper.kt
@@ -25,8 +25,10 @@ class BillMapper(
         bill: Bill,
         memberId: MemberId,
     ): BillDetailResponse {
+        if (bill.id == null) throw BillException.BillNotFoundException()
+
         val gatherings =
-            gatheringQueryUseCase.getAllGatheringsByBillId(bill.id ?: throw BillException.BillNotFoundException())
+            gatheringQueryUseCase.getAllGatheringsByBillId(bill.id)
         if (gatherings.isEmpty()) throw GatheringException.GatheringRequiredException()
 
         val gatheringReceipt =
@@ -45,7 +47,7 @@ class BillMapper(
         val gatheringMembersByRetrievedMember = allBillGatheringMembers.filter { it.memberId == memberId }
 
         return BillDetailResponse(
-            billId = bill.id ?: throw BillException.BillNotFoundException(),
+            billId = bill.id,
             title = bill.title,
             description = bill.description,
             hostUserId = bill.hostUserId.value,

--- a/src/main/kotlin/com/server/dpmcore/bill/bill/presentation/mapper/BillMapper.kt
+++ b/src/main/kotlin/com/server/dpmcore/bill/bill/presentation/mapper/BillMapper.kt
@@ -49,9 +49,9 @@ class BillMapper(
             title = bill.title,
             description = bill.description,
             hostUserId = bill.hostUserId.value,
-            billTotalAmount = bill.getBillTotalAmount(gatheringReceipt),
+            billTotalAmount = Bill.getBillTotalAmount(gatheringReceipt),
             billTotalSplitAmount =
-                bill.getMemberBillSplitAmount(
+                Bill.getMemberBillSplitAmount(
                     memberId,
                     gatheringMembersByRetrievedMember,
                     gatheringReceipt,
@@ -64,12 +64,12 @@ class BillMapper(
                 ),
             billAccountId = bill.billAccount.id?.value ?: 0L,
 //            TODO : 매번 카운트 호출 좀 별로라서 고민해보면 좋을 것 같아요.
-            invitedMemberCount = bill.getBillInvitedMemberCount(allBillGatheringMembers),
-            invitationSubmittedCount = bill.getBillInvitationSubmittedCount(allBillGatheringMembers),
-            invitationCheckedMemberCount = bill.getBillInvitationCheckedMemberCount(allBillGatheringMembers),
-            isViewed = bill.getIsBillViewed(gatheringMembersByRetrievedMember),
-            isJoined = bill.getIsBillJoined(gatheringMembersByRetrievedMember),
-            isInvitationSubmitted = bill.getIsBillInvitationSubmitted(gatheringMembersByRetrievedMember),
+            invitedMemberCount = Bill.getBillInvitedMemberCount(allBillGatheringMembers),
+            invitationSubmittedCount = Bill.getBillInvitationSubmittedCount(allBillGatheringMembers),
+            invitationCheckedMemberCount = Bill.getBillInvitationCheckedMemberCount(allBillGatheringMembers),
+            isViewed = Bill.getIsBillViewed(gatheringMembersByRetrievedMember),
+            isJoined = Bill.getIsBillJoined(gatheringMembersByRetrievedMember),
+            isInvitationSubmitted = Bill.getIsBillInvitationSubmitted(gatheringMembersByRetrievedMember),
             gatherings =
                 gatherings.map { gathering ->
 
@@ -78,7 +78,7 @@ class BillMapper(
                             gathering.id
                                 ?: throw GatheringException.GatheringNotFoundException(),
                         )
-                    val splitAmount = bill.getMemberBillSplitAmount(memberId, gatheringMembers, gatheringReceipt)
+                    val splitAmount = Bill.getMemberBillSplitAmount(memberId, gatheringMembers, gatheringReceipt)
 
                     BillDetailGatheringResponse.from(gathering, gatheringMembers, splitAmount)
                 },
@@ -143,13 +143,13 @@ class BillMapper(
                 instantToLocalDateTime(bill.createdAt ?: throw BillException.BillNotFoundException()),
             billAccountId = bill.billAccount.id?.value ?: throw BillAccountException.BillAccountNotFoundException(),
 //            TODO : 매번 카운트 호출 좀 별로라서 고민해보면 좋을 것 같아요.
-            invitedMemberCount = bill.getBillInvitedMemberCount(allBillGatheringMembers),
-            invitationSubmittedCount = bill.getBillInvitationSubmittedCount(allBillGatheringMembers),
-            invitationCheckedMemberCount = bill.getBillInvitationCheckedMemberCount(allBillGatheringMembers),
+            invitedMemberCount = Bill.getBillInvitedMemberCount(allBillGatheringMembers),
+            invitationSubmittedCount = Bill.getBillInvitationSubmittedCount(allBillGatheringMembers),
+            invitationCheckedMemberCount = Bill.getBillInvitationCheckedMemberCount(allBillGatheringMembers),
             participantCount = participantCount,
-            isViewed = bill.getIsBillViewed(gatheringMembersByRetrievedMember),
-            isJoined = bill.getIsBillJoined(gatheringMembersByRetrievedMember),
-            isInvitationSubmitted = bill.getIsBillInvitationSubmitted(gatheringMembersByRetrievedMember),
+            isViewed = Bill.getIsBillViewed(gatheringMembersByRetrievedMember),
+            isJoined = Bill.getIsBillJoined(gatheringMembersByRetrievedMember),
+            isInvitationSubmitted = Bill.getIsBillInvitationSubmitted(gatheringMembersByRetrievedMember),
 //            inviteAuthorities = TODO(),
             gatherings = gatheringDetails,
         )

--- a/src/main/kotlin/com/server/dpmcore/bill/bill/presentation/mapper/BillMapper.kt
+++ b/src/main/kotlin/com/server/dpmcore/bill/bill/presentation/mapper/BillMapper.kt
@@ -40,9 +40,7 @@ class BillMapper(
             }
 
         val allBillGatheringMembers =
-            gatheringQueryUseCase.findGatheringMemberByGatheringId(
-                gatherings.get(0).id ?: throw GatheringException.GatheringIdRequiredException(),
-            )
+            gatheringQueryUseCase.getAllGatheringMembersByBillId(bill.id)
 
         val gatheringMembersByRetrievedMember = allBillGatheringMembers.filter { it.memberId == memberId }
 

--- a/src/main/kotlin/com/server/dpmcore/bill/bill/presentation/mapper/BillMapper.kt
+++ b/src/main/kotlin/com/server/dpmcore/bill/bill/presentation/mapper/BillMapper.kt
@@ -11,6 +11,7 @@ import com.server.dpmcore.bill.exception.BillException
 import com.server.dpmcore.gathering.exception.GatheringException
 import com.server.dpmcore.gathering.gathering.domain.model.Gathering
 import com.server.dpmcore.gathering.gathering.domain.port.inbound.GatheringQueryUseCase
+import com.server.dpmcore.member.member.domain.model.MemberId
 import com.server.dpmcore.session.presentation.mapper.TimeMapper.instantToLocalDateTime
 import org.springframework.stereotype.Component
 import java.time.LocalDateTime
@@ -48,8 +49,8 @@ class BillMapper(
             title = bill.title,
             description = bill.description,
             hostUserId = bill.hostUserId.value,
-            billTotalAmount = billTotalAmount,
-            billTotalSplitAmount = billTotalSplitAmount,
+            billTotalAmount = bill.getBillTotalAmount(gatheringReceipt),
+            billTotalSplitAmount = bill.getMemberBillSplitAmount(gatheringMembersByRetrievedMember, gatheringReceipt),
             billStatus = bill.billStatus,
             createdAt =
                 LocalDateTime.ofInstant(
@@ -58,9 +59,9 @@ class BillMapper(
                 ),
             billAccountId = bill.billAccount.id?.value ?: 0L,
 //            TODO : 매번 카운트 호출 좀 별로라서 고민해보면 좋을 것 같아요.
-            invitedMemberCount = gatheringMembers.count(),
-            invitationSubmittedCount = gatheringMembers.count { it.isInvitationSubmitted },
-            invitationCheckedMemberCount = gatheringMembers.count { it.isChecked },
+            invitedMemberCount = allBillGatheringMembers.count(),
+            invitationSubmittedCount = allBillGatheringMembers.count { it.isInvitationSubmitted },
+            invitationCheckedMemberCount = allBillGatheringMembers.count { it.isChecked },
             isViewed = bill.getIsBillViewed(gatheringMembersByRetrievedMember),
             isJoined = bill.getIsBillJoined(gatheringMembersByRetrievedMember),
             isInvitationSubmitted = bill.getIsBillInvitationSubmitted(gatheringMembersByRetrievedMember),
@@ -141,9 +142,9 @@ class BillMapper(
                 instantToLocalDateTime(bill.createdAt ?: throw BillException.BillNotFoundException()),
             billAccountId = bill.billAccount.id?.value ?: throw BillAccountException.BillAccountNotFoundException(),
 //            TODO : 매번 카운트 호출 좀 별로라서 고민해보면 좋을 것 같아요.
-            invitedMemberCount = gatheringMembers.count(),
-            invitationSubmittedCount = gatheringMembers.count { it.isInvitationSubmitted },
-            invitationCheckedMemberCount = gatheringMembers.count { it.isChecked },
+            invitedMemberCount = allBillGatheringMembers.count(),
+            invitationSubmittedCount = allBillGatheringMembers.count { it.isInvitationSubmitted },
+            invitationCheckedMemberCount = allBillGatheringMembers.count { it.isChecked },
             participantCount = participantCount,
             isViewed = bill.getIsBillViewed(gatheringMembersByRetrievedMember),
             isJoined = bill.getIsBillJoined(gatheringMembersByRetrievedMember),

--- a/src/main/kotlin/com/server/dpmcore/bill/bill/presentation/mapper/BillMapper.kt
+++ b/src/main/kotlin/com/server/dpmcore/bill/bill/presentation/mapper/BillMapper.kt
@@ -50,7 +50,12 @@ class BillMapper(
             description = bill.description,
             hostUserId = bill.hostUserId.value,
             billTotalAmount = bill.getBillTotalAmount(gatheringReceipt),
-            billTotalSplitAmount = bill.getMemberBillSplitAmount(gatheringMembersByRetrievedMember, gatheringReceipt),
+            billTotalSplitAmount =
+                bill.getMemberBillSplitAmount(
+                    memberId,
+                    gatheringMembersByRetrievedMember,
+                    gatheringReceipt,
+                ),
             billStatus = bill.billStatus,
             createdAt =
                 LocalDateTime.ofInstant(
@@ -73,11 +78,7 @@ class BillMapper(
                             gathering.id
                                 ?: throw GatheringException.GatheringNotFoundException(),
                         )
-                    val splitAmount =
-                        gatheringReceipt
-                            .find {
-                                it.gatheringId == gathering.id
-                            }?.splitAmount ?: 0
+                    val splitAmount = bill.getMemberBillSplitAmount(memberId, gatheringMembers, gatheringReceipt)
 
                     BillDetailGatheringResponse.from(gathering, gatheringMembers, splitAmount)
                 },

--- a/src/main/kotlin/com/server/dpmcore/bill/bill/presentation/mapper/BillMapper.kt
+++ b/src/main/kotlin/com/server/dpmcore/bill/bill/presentation/mapper/BillMapper.kt
@@ -124,7 +124,7 @@ class BillMapper(
                 .filter { it.isJoined }
                 .forEach { gatheringMember ->
                     participants
-                        .computeIfAbsent(gatheringMember.memberId!!.value) { mutableListOf() }
+                        .computeIfAbsent(gatheringMember.memberId.value) { mutableListOf() }
                         .add(gatheringDetail.gatheringId.value)
                 }
         }
@@ -135,7 +135,7 @@ class BillMapper(
 
         return BillListDetailResponse(
             title = bill.title,
-            billId = bill.id ?: throw BillException.BillNotFoundException(),
+            billId = bill.id,
             description = bill.description,
             billTotalAmount = billTotalAmount,
             billStatus = bill.billStatus,

--- a/src/main/kotlin/com/server/dpmcore/gathering/gathering/application/GatheringQueryService.kt
+++ b/src/main/kotlin/com/server/dpmcore/gathering/gathering/application/GatheringQueryService.kt
@@ -106,4 +106,9 @@ class GatheringQueryService(
                 ?: throw GatheringException.GatheringNotFoundException(),
         )
     }
+
+    override fun getAllGatheringMembersByBillId(billId: BillId): List<GatheringMember> =
+        getAllGatheringIdsByBillId(billId).flatMap { gatheringId ->
+            gatheringMemberQueryService.getGatheringMemberByGatheringId(gatheringId)
+        }
 }

--- a/src/main/kotlin/com/server/dpmcore/gathering/gathering/domain/port/inbound/GatheringQueryUseCase.kt
+++ b/src/main/kotlin/com/server/dpmcore/gathering/gathering/domain/port/inbound/GatheringQueryUseCase.kt
@@ -29,4 +29,6 @@ interface GatheringQueryUseCase {
     ): List<SubmittedParticipantGathering>
 
     fun getBillMemberSubmittedList(billId: BillId): List<BillMemberIsInvitationSubmittedQueryModel>
+
+    fun getAllGatheringMembersByBillId(billId: BillId): List<GatheringMember>
 }

--- a/src/main/kotlin/com/server/dpmcore/gathering/gatheringMember/domain/model/GatheringMember.kt
+++ b/src/main/kotlin/com/server/dpmcore/gathering/gatheringMember/domain/model/GatheringMember.kt
@@ -63,32 +63,7 @@ class GatheringMember(
         this.updatedAt = Instant.now()
     }
 
-    fun isDeleted(): Boolean = deletedAt != null
-
     fun isConfirmed(): Boolean = completedAt != null
-
-    fun canUpdateAttendance(): Boolean = !isConfirmed()
-
-    /**
-     * 참석 여부 체크를 수행합니다.
-     * 이미 확정된 경우 예외를 발생시킵니다.
-     */
-    fun checkAttendance(now: Instant): GatheringMember {
-        if (isConfirmed()) {
-            throw GatheringMemberException.AlreadyConfirmedMemberException()
-        }
-
-        return GatheringMember(
-            id = id,
-            gatheringId = gatheringId,
-            memberId = memberId,
-            isChecked = true,
-            completedAt = now,
-            createdAt = createdAt,
-            updatedAt = now,
-            deletedAt = deletedAt,
-        )
-    }
 
     override fun equals(other: Any?): Boolean {
         if (this === other) return true

--- a/src/main/kotlin/com/server/dpmcore/gathering/gatheringMember/domain/model/GatheringMember.kt
+++ b/src/main/kotlin/com/server/dpmcore/gathering/gatheringMember/domain/model/GatheringMember.kt
@@ -110,4 +110,16 @@ class GatheringMember(
                 updatedAt = Instant.now(),
             )
     }
+
+    override fun toString(): String =
+        "GatheringMember(id=$id," +
+            "gatheringId=$gatheringId," +
+            "memberId=$memberId," +
+            "isChecked=$isChecked," +
+            "isJoined=$isJoined," +
+            "isInvitationSubmitted=$isInvitationSubmitted," +
+            "createdAt=$createdAt," +
+            "completedAt=$completedAt," +
+            "updatedAt=$updatedAt," +
+            "deletedAt=$deletedAt)"
 }


### PR DESCRIPTION
## Summary

>- close #138 

<!-- 해당 PR에 대한 요약을 작성해주세요. -->

## Tasks

- Bill 도메인으로 처리 이관
  - TotalAmount
  - SplitAmount
- 정산 상세 조회 API
  - gatheringMemeber 조회 시 모든 gathering에 대한 멤버 가져오도록 수정
  - 열람 여부 추가
  - 참여 여부 추가
  - 정산 여부 추가
- 정산 목록 조회 API
  - 열람 여부 추가
  - 참여 여부 추가
  - 정산 여부 추가
- 정산서 열람 여부 리네이밍
  - isChecked -> isViewed

## ETC

배포 시 DDL update 문이 필요해요.
```sql
ALTER TABLE gathering_members
    CHANGE COLUMN is_checked is_viewed BIT(1) NOT NULL;
```

<!-- 추가적인 정보나 참고 사항을 작성해주세요. -->

## Screenshot

<!-- (없을 경우 삭제) 작업한 내용에 대한 스크린샷을 첨부해주세요._ -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - 청구서 상세/목록이 로그인된 사용자(memberId) 기준으로 개인화되어 표시됩니다.
  - 본인 기준 총액과 분담 금액이 사용자별로 계산되어 제공됩니다.
  - 청구서별 상태 표시 추가: 열람(isViewed), 참여(isJoined), 초대 응답(isInvitationSubmitted).
  - 청구서별 참가자·응답·확인 수집계가 전체 참여자 집계 기준으로 정확히 계산됩니다.

- Refactor
  - 조회 API와 목록/상세 매핑 흐름에 사용자 컨텍스트(memberId) 및 전체 참여자 집계를 통합해 일관성 개선.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->