### PR TITLE
chore: CustomReponse 타입 OpenApi Schema로 변환하도록 ModelConverter 구현

### DIFF
--- a/src/main/kotlin/com/server/dpmcore/bill/bill/presentation/controller/BillQueryApi.kt
+++ b/src/main/kotlin/com/server/dpmcore/bill/bill/presentation/controller/BillQueryApi.kt
@@ -25,72 +25,6 @@ interface BillQueryApi {
             ApiResponse(
                 responseCode = "200",
                 description = "정산서 조회 성공",
-                content = [
-                    Content(
-                        mediaType = APPLICATION_JSON_VALUE,
-                        schema = Schema(implementation = CustomResponse::class),
-                        examples = [
-                            ExampleObject(
-                                name = "정산서 조회 성공 응답",
-                                value = """
-                                    {
-                                      "status": "OK",
-                                      "message": "요청에 성공했습니다",
-                                      "code": "GLOBAL-200-01",
-                                      "data": {
-                                        "billId": 1,
-                                        "title": "1차 회식 정산",
-                                        "description": "1차 회식에 대한 정산입니다.",
-                                        "hostUserId": 17,
-                                        "billTotalAmount": 220000,
-                                        "billTotalSplitAmount": 170000,
-                                        "billStatus": "IN_PROGRESS",
-                                        "createdAt": "2024-01-01T19:00:00",
-                                        "billAccountId": 1,
-                                        "invitedMemberCount": 2,
-                                        "invitationSubmittedCount": 0,
-                                        "invitationCheckedMemberCount": 1,
-                                        "inviteAuthorities": [
-                                          {
-                                            "inviteAuthorityId": 1,
-                                            "authorityName": "17_DEEPER",
-                                            "authorityMemberCount": 64
-                                          },
-                                          {
-                                            "inviteAuthorityId": 2,
-                                            "authorityName": "17_ORGANIZER",
-                                            "authorityMemberCount": 12
-                                          }
-                                        ],
-                                        "gatherings": [
-                                          {
-                                            "gatheringId": 1,
-                                            "title": "1차 회식",
-                                            "description": "첫 번째 회식입니다.",
-                                            "roundNumber": 1,
-                                            "heldAt": "2024-01-06T04:00:00",
-                                            "category": "GATHERING",
-                                            "joinMemberCount": 0,
-                                            "amount": 100000
-                                          },
-                                          {
-                                            "gatheringId": 2,
-                                            "title": "2차 회식",
-                                            "description": "두 번째 회식입니다.",
-                                            "roundNumber": 2,
-                                            "heldAt": "2024-01-06T06:00:00",
-                                            "category": "GATHERING",
-                                            "joinMemberCount": 0,
-                                            "amount": 120000
-                                          }
-                                        ]
-                                      }
-                                    }
-                            """,
-                            ),
-                        ],
-                    ),
-                ],
             ),
         ],
     )
@@ -110,79 +44,6 @@ interface BillQueryApi {
             ApiResponse(
                 responseCode = "200",
                 description = "정산서 목록 조회 성공",
-                content = [
-                    Content(
-                        mediaType = APPLICATION_JSON_VALUE,
-                        schema = Schema(implementation = CustomResponse::class),
-                        examples = [
-                            ExampleObject(
-                                name = "정산서 목록 조회 성공 응답",
-                                value = """
-                                    {
-                                      "status": "OK",
-                                      "message": "요청에 성공했습니다",
-                                      "code": "GLOBAL-200-01",
-                                      "data": {
-                                        "bills": [
-                                          {
-                                            "billId": 1,
-                                            "title": "1차 회식 정산",
-                                            "description": "1차 회식에 대한 정산입니다.",
-                                            "billTotalAmount": 220000,
-                                            "billStatus": "IN_PROGRESS",
-                                            "createdAt": "2024-01-01T19:00:00",
-                                            "billAccountId": 1,
-                                            "invitedMemberCount": 2,
-                                            "invitationSubmittedCount": 0,
-                                            "invitationCheckedMemberCount": 1,
-                                            "inviteAuthorities": [
-                                              {
-                                                "invitedAuthorityId": 1,
-                                                "authorityName": "17_DEEPER",
-                                                "authorityMemberCount": 64
-                                              },
-                                              {
-                                                "invitedAuthorityId": 2,
-                                                "authorityName": "17_ORGANIZER",
-                                                "authorityMemberCount": 12
-                                              }
-                                            ],
-                                            "gatherings": [
-                                              {
-                                                "gatheringId": 1,
-                                                "title": "1차 회식",
-                                                "description": "첫 번째 회식입니다.",
-                                                "roundNumber": 1,
-                                                "heldAt": "2024-01-06T04:00:00",
-                                                "category": "GATHERING",
-                                                "receipt": null,
-                                                "joinMemberCount": 2,
-                                                "amount": 100000,
-                                                "splitAmount": 50000
-                                              },
-                                              {
-                                                "gatheringId": 2,
-                                                "title": "2차 회식",
-                                                "description": "두 번째 회식입니다.",
-                                                "roundNumber": 2,
-                                                "heldAt": "2024-01-06T06:00:00",
-                                                "category": "GATHERING",
-                                                "receipt": null,
-                                                "joinMemberCount": 1,
-                                                "amount": 120000,
-                                                "splitAmount": 120000
-                                              }
-                                            ]
-                                          }
-                                        ]
-                                      }
-                                    }
-
-                            """,
-                            ),
-                        ],
-                    ),
-                ],
             ),
         ],
     )
@@ -197,43 +58,6 @@ interface BillQueryApi {
     @ApiResponse(
         responseCode = "200",
         description = "정산서 멤버별 최종 금액 조회 성공",
-        content = [
-            Content(
-                mediaType = APPLICATION_JSON_VALUE,
-                schema = Schema(implementation = CustomResponse::class),
-                examples = [
-                    ExampleObject(
-                        name = "정산서 멤버별 최종 금액 조회 성공 응답",
-                        value = """
-                        {
-                          "status": "OK",
-                          "message": "요청에 성공했습니다",
-                          "code": "GLOBAL-200-01",
-                          "data": {
-                              "members": [
-                              {
-                                "name": "이한음",
-                                "authority": "17_ORGANIZER",
-                                "splitAmount": 25000
-                              },
-                              {
-                                "name": "신민철",
-                                "authority": "17_ORGANIZER",
-                                "splitAmount": 18000
-                              },
-                              {
-                                "name": "정준원",
-                                "authority": "17_DEEPER",
-                                "splitAmount": 12000
-                              }
-                            ]
-                          }
-                        }
-                    """,
-                    ),
-                ],
-            ),
-        ],
     )
     @Operation(
         summary = "정산서 멤버별 최종 금액 조회 API",
@@ -246,36 +70,6 @@ interface BillQueryApi {
     @ApiResponse(
         responseCode = "200",
         description = "이전에 제출한 정산 참여 여부 조회 성공",
-        content = [
-            Content(
-                mediaType = APPLICATION_JSON_VALUE,
-                schema = Schema(implementation = CustomResponse::class),
-                examples = [
-                    ExampleObject(
-                        name = "이전에 제출한 정산 참여 여부 성공 응답",
-                        value = """
-                        {
-                          "status": "OK",
-                          "message": "요청에 성공했습니다",
-                          "code": "GLOBAL-200-01",
-                          "data": {
-                            "gatheringParticipationList": [
-                              {
-                                "gatheringId": 1,
-                                "isJoined": true
-                              },
-                              {
-                                "gatheringId": 2,
-                                "isJoined": true
-                              }
-                            ]
-                          }
-                        }
-                    """,
-                    ),
-                ],
-            ),
-        ],
     )
     @Operation(
         summary = "이전에 제출한 정산 참여 여부 조회 API",
@@ -289,42 +83,6 @@ interface BillQueryApi {
     @ApiResponse(
         responseCode = "200",
         description = "정산 참여 제출 여부 조회 성공",
-        content = [
-            Content(
-                mediaType = APPLICATION_JSON_VALUE,
-                schema = Schema(implementation = CustomResponse::class),
-                examples = [
-                    ExampleObject(
-                        name = "정산 참여 제출 여부 조회 성공 응답",
-                        value = """
-                        {
-                          "status": "OK",
-                          "message": "요청에 성공했습니다",
-                          "code": "GLOBAL-200-01",
-                          "data": {
-                            "members": [
-                              {
-                                "name": "정준원",
-                                "teamNumber": 1,
-                                "authority": "ORGANIZER",
-                                "part": "SERVER",
-                                "isInvitationSubmitted": false
-                              },
-                              {
-                                "name": "신민철",
-                                "teamNumber": 1,
-                                "authority": "DEEPER",
-                                "part": "SERVER",
-                                "isInvitationSubmitted": false
-                              }
-                            ]
-                          }
-                        }
-                    """,
-                    ),
-                ],
-            ),
-        ],
     )
     @Operation(
         summary = "정산 참여 제출 여부 조회 API",

--- a/src/main/kotlin/com/server/dpmcore/common/configuration/SwaggerConvertersConfig.kt
+++ b/src/main/kotlin/com/server/dpmcore/common/configuration/SwaggerConvertersConfig.kt
@@ -1,0 +1,19 @@
+package com.server.dpmcore.common.configuration
+
+import com.server.dpmcore.common.converter.ResponseModelConverter
+import io.swagger.v3.core.converter.ModelConverters
+import org.slf4j.LoggerFactory
+import org.springdoc.core.customizers.OpenApiCustomizer
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+class SwaggerConvertersConfig {
+
+    @Bean
+    fun registerResponseModelConverter(): OpenApiCustomizer = OpenApiCustomizer { _ ->
+        val converters = ModelConverters.getInstance()
+        converters.addConverter(ResponseModelConverter())
+            
+    }
+}

--- a/src/main/kotlin/com/server/dpmcore/common/converter/ResponseModelConverter.kt
+++ b/src/main/kotlin/com/server/dpmcore/common/converter/ResponseModelConverter.kt
@@ -1,0 +1,67 @@
+package com.server.dpmcore.common.converter
+
+import com.server.dpmcore.common.exception.CustomResponse
+import io.swagger.v3.core.converter.AnnotatedType
+import io.swagger.v3.core.converter.ModelConverter
+import io.swagger.v3.core.converter.ModelConverterContext
+import io.swagger.v3.oas.models.media.ObjectSchema
+import io.swagger.v3.oas.models.media.Schema
+import io.swagger.v3.oas.models.media.StringSchema
+import org.slf4j.LoggerFactory
+import org.springframework.http.HttpEntity
+import org.springframework.http.ResponseEntity
+import java.lang.reflect.ParameterizedType
+import java.lang.reflect.Type
+
+class ResponseModelConverter : ModelConverter {
+
+    override fun resolve(
+        type: AnnotatedType,
+        context: ModelConverterContext,
+        chain: MutableIterator<ModelConverter>
+    ): Schema<*>? {
+        val root = type.type ?: return next(chain, type, context)
+
+        val unwrapped = unwrapKnownWrappers(root)
+
+        val p = unwrapped as? ParameterizedType ?: return next(chain, type, context)
+        val raw = p.rawType as? Class<*> ?: return next(chain, type, context)
+        if (raw != CustomResponse::class.java) return next(chain, type, context)
+
+        val t: Type = p.actualTypeArguments.firstOrNull() ?: return next(chain, type, context)
+        val tSchema = context.resolve(AnnotatedType(t))
+
+        val schemaName = tSchema.name
+            ?: (t as? Class<*>)?.simpleName
+            ?: (t as? ParameterizedType)?.rawType.let { (it as? Class<*>)?.simpleName }
+            ?: "Anonymous"
+
+
+        val s = ObjectSchema().apply {
+            name = schemaName
+            addProperty("status", StringSchema())
+            addProperty("message", StringSchema())
+            addProperty("code", StringSchema())
+            addProperty("data", tSchema)
+        }
+
+        return s
+    }
+
+    private fun unwrapKnownWrappers(type: Type): Type {
+        var current = type
+        while (current is ParameterizedType) {
+            val raw = current.rawType as? Class<*>
+            if (raw == ResponseEntity::class.java || raw == HttpEntity::class.java) {
+                current = current.actualTypeArguments.firstOrNull() ?: return current
+            } else break
+        }
+        return current
+    }
+
+    private fun next(
+        chain: MutableIterator<ModelConverter>,
+        type: AnnotatedType,
+        context: ModelConverterContext
+    ): Schema<*>? = if (chain.hasNext()) chain.next().resolve(type, context, chain) else null
+}


### PR DESCRIPTION
- Add SwaggerConvertersConfig to register a custom OpenAPI converter
- Implement ResponseModelConverter to auto-generate schemas for common responses

## Summary

- CustomResponse generic을 openapi schema로 변환하는 converter 추가


## ETC

<!-- 추가적인 정보나 참고 사항을 작성해주세요. -->

- CustomResponse generic으로 타입을 넘기고 있기 때문에 openapi schema로 인식하지 못하는 이슈를 해결하기 위해
`ResponseConverter` 적용
- interface 작성 시 `Content` 영역이 generic으로 대체되어 적용 됨.
- `BillQueryApi` 적용된 상태
- `ResponseEntity` 또는 `HttpEntity` 사용 시 적용되지 않는 이슈가 있어 예외처리 추가


## Screenshot

<!-- (없을 경우 삭제) 작업한 내용에 대한 스크린샷을 첨부해주세요._ -->
<img width="769" height="786" alt="스크린샷 2025-08-25 오후 2 48 26" src="https://github.com/user-attachments/assets/e3da77fa-48cc-4150-86fe-138db3a747ec" />
<img width="732" height="1293" alt="스크린샷 2025-08-25 오후 2 48 21" src="https://github.com/user-attachments/assets/76711df7-57b1-4d8e-b944-404a9d09190c" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 문서화
  - API 문서 응답 모델을 통일했습니다. Swagger/OpenAPI에서 모든 표준 응답을 status, message, code, data 필드로 일관되게 표시합니다.
  - 정산서 관련 여러 조회 엔드포인트의 예시 응답(payload) 인라인 샘플을 제거하여 문서를 간결화했습니다.
  - Swagger UI 가독성과 일관성이 향상되어 스키마 중심으로 응답 구조를 확인할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->