### PR TITLE
hotfix: gathering_members schema 변경에 따른 필드명 수정 반영

### DIFF
--- a/src/main/kotlin/com/server/dpmcore/bill/bill/domain/model/Bill.kt
+++ b/src/main/kotlin/com/server/dpmcore/bill/bill/domain/model/Bill.kt
@@ -121,7 +121,7 @@ class Bill(
 
         fun getBillTotalAmount(gatheringReceipts: List<GatheringReceipt>): Int = gatheringReceipts.sumOf { it.amount }
 
-        fun getIsBillViewed(gatheringMembers: List<GatheringMember>): Boolean = gatheringMembers.any { it.isChecked }
+        fun getIsBillViewed(gatheringMembers: List<GatheringMember>): Boolean = gatheringMembers.any { it.isViewed }
 
         fun getIsBillJoined(gatheringMembers: List<GatheringMember>): Boolean = gatheringMembers.any { it.isJoined }
 
@@ -149,7 +149,7 @@ class Bill(
         fun getBillInvitationCheckedMemberCount(allBillGatheringMembers: List<GatheringMember>): Int {
             val invitationCheckedMemberSet = mutableSetOf<MemberId>()
             allBillGatheringMembers.forEach { gatheringMember ->
-                if (gatheringMember.isChecked) {
+                if (gatheringMember.isViewed) {
                     invitationCheckedMemberSet.add(gatheringMember.memberId)
                 }
             }

--- a/src/main/kotlin/com/server/dpmcore/gathering/gathering/domain/model/Gathering.kt
+++ b/src/main/kotlin/com/server/dpmcore/gathering/gathering/domain/model/Gathering.kt
@@ -54,7 +54,7 @@ class Gathering(
 
     fun getBillViewCount() =
         gatheringMembers.count { gatheringMember ->
-            gatheringMember.isChecked
+            gatheringMember.isViewed
         }
 
     override fun equals(other: Any?): Boolean {

--- a/src/main/kotlin/com/server/dpmcore/gathering/gatheringMember/domain/model/GatheringMember.kt
+++ b/src/main/kotlin/com/server/dpmcore/gathering/gatheringMember/domain/model/GatheringMember.kt
@@ -16,7 +16,7 @@ class GatheringMember(
     val id: GatheringMemberId? = null,
     val memberId: MemberId,
     val gatheringId: GatheringId,
-    isChecked: Boolean = false,
+    isViewed: Boolean = false,
     isJoined: Boolean = false,
     isInvitationSubmitted: Boolean = false,
     val createdAt: Instant? = null,
@@ -24,7 +24,7 @@ class GatheringMember(
     updatedAt: Instant? = null,
     deletedAt: Instant? = null,
 ) {
-    var isChecked: Boolean = isChecked
+    var isViewed: Boolean = isViewed
         private set
 
     var isJoined: Boolean = isJoined
@@ -43,7 +43,7 @@ class GatheringMember(
         private set
 
     fun markAsChecked() {
-        this.isChecked = true
+        this.isViewed = true
         this.updatedAt = Instant.now()
     }
 
@@ -90,7 +90,7 @@ class GatheringMember(
         "GatheringMember(id=$id," +
             "gatheringId=$gatheringId," +
             "memberId=$memberId," +
-            "isChecked=$isChecked," +
+            "isViewed=$isViewed," +
             "isJoined=$isJoined," +
             "isInvitationSubmitted=$isInvitationSubmitted," +
             "createdAt=$createdAt," +

--- a/src/main/kotlin/com/server/dpmcore/gathering/gatheringMember/infrastructure/entity/GatheringMemberEntity.kt
+++ b/src/main/kotlin/com/server/dpmcore/gathering/gatheringMember/infrastructure/entity/GatheringMemberEntity.kt
@@ -29,8 +29,8 @@ class GatheringMemberEntity(
     val gathering: GatheringEntity? = null,
     @Column(name = "member_id", nullable = false)
     val memberId: Long,
-    @Column(name = "is_checked", nullable = false)
-    val isChecked: Boolean = false,
+    @Column(name = "is_viewed", nullable = false)
+    val isViewed: Boolean = false,
     @Column(name = "is_joined", nullable = false)
     val isJoined: Boolean = false,
     @Column(name = "is_invitation_submitted", nullable = false)
@@ -52,7 +52,7 @@ class GatheringMemberEntity(
             GatheringMemberEntity(
                 id = gatheringMember.id?.value ?: 0L,
                 memberId = gatheringMember.memberId.value,
-                isChecked = gatheringMember.isChecked,
+                isViewed = gatheringMember.isViewed,
                 isJoined = gatheringMember.isJoined,
                 completedAt = gatheringMember.completedAt,
                 createdAt = gatheringMember.createdAt ?: Instant.now(),
@@ -67,7 +67,7 @@ class GatheringMemberEntity(
             id = GatheringMemberId(id),
             gatheringId = GatheringId(gathering?.id ?: 0L),
             memberId = MemberId(memberId),
-            isChecked = isChecked,
+            isViewed = isViewed,
             isJoined = isJoined,
             isInvitationSubmitted = isInvitationSubmitted,
             completedAt = completedAt,

--- a/src/main/kotlin/com/server/dpmcore/gathering/gatheringMember/infrastructure/repository/GatheringMemberRepository.kt
+++ b/src/main/kotlin/com/server/dpmcore/gathering/gatheringMember/infrastructure/repository/GatheringMemberRepository.kt
@@ -53,7 +53,7 @@ class GatheringMemberRepository(
         queryFactory
             .updateQuery<GatheringMemberEntity> {
                 where(col(GatheringMemberEntity::id).equal(id))
-                set(col(GatheringMemberEntity::isChecked), gatheringMember.isChecked)
+                set(col(GatheringMemberEntity::isViewed), gatheringMember.isViewed)
                 set(col(GatheringMemberEntity::isJoined), gatheringMember.isJoined)
                 set(col(GatheringMemberEntity::completedAt), gatheringMember.completedAt)
                 set(col(GatheringMemberEntity::updatedAt), gatheringMember.updatedAt)

--- a/src/main/kotlin/com/server/dpmcore/gathering/gatheringMember/presentation/mapper/GatheringMemberMapper.kt
+++ b/src/main/kotlin/com/server/dpmcore/gathering/gatheringMember/presentation/mapper/GatheringMemberMapper.kt
@@ -18,7 +18,7 @@ object GatheringMemberMapper {
                 gatheringMember.id
                     ?: throw GatheringMemberException.GatheringMemberIdRequiredException(),
             memberId = gatheringMember.memberId.value,
-            isCompleted = gatheringMember.isChecked,
+            isCompleted = gatheringMember.isViewed,
             isJoined = gatheringMember.isJoined,
         )
 }


### PR DESCRIPTION
## Summary

>- #143 

gathering_members schema 변경에 따른 필드명 수정을 반영하였습니다.

<!-- 해당 PR에 대한 요약을 작성해주세요. -->

## Tasks

- gathering_members schema 변경에 따른 필드명 수정 반영

## ETC

변경된 jOOQ codegen을 적용하려면 본 PR 머지 후 `./gradlew clean generateJooq`를 실행 해주세요.
@wjdwnsdnjs13 @its-sky 


## Screenshot

<!-- (없을 경우 삭제) 작업한 내용에 대한 스크린샷을 첨부해주세요._ -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 버그 수정
  - 청구서의 ‘조회 여부’ 계산과 조회/초대 확인 카운트가 ‘조회됨’ 상태 기준으로 일관되게 동작합니다.
- 리팩터
  - 상태 플래그를 ‘확인됨’에서 ‘조회됨’으로 정비해 용어와 동작을 일치시켰습니다.
- 문서화
  - 해당 없음
- 기타 작업
  - 내부 매핑과 저장소 갱신 로직을 ‘조회됨’ 상태에 맞춰 정리했습니다.
- 변경 사항
  - 일부 응답에서 완료 여부가 ‘조회됨’ 상태를 반영하도록 매핑이 조정되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->