### PR TITLE
refactor: 도메인 서비스 간 의존 관계 추상화 및 모델 패키지 구조 개선

### DIFF
--- a/src/main/kotlin/com/server/dpmcore/cohort/application/CohortQueryService.kt
+++ b/src/main/kotlin/com/server/dpmcore/cohort/application/CohortQueryService.kt
@@ -4,7 +4,7 @@ import com.server.dpmcore.cohort.application.config.CohortProperties
 import com.server.dpmcore.cohort.domain.exception.CohortNotFoundException
 import com.server.dpmcore.cohort.domain.model.CohortId
 import com.server.dpmcore.cohort.domain.port.inbound.CohortQueryUseCase
-import com.server.dpmcore.cohort.domain.port.outbount.CohortPersistencePort
+import com.server.dpmcore.cohort.domain.port.outbound.CohortPersistencePort
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 

--- a/src/main/kotlin/com/server/dpmcore/cohort/application/CohortQueryService.kt
+++ b/src/main/kotlin/com/server/dpmcore/cohort/application/CohortQueryService.kt
@@ -3,7 +3,8 @@ package com.server.dpmcore.cohort.application
 import com.server.dpmcore.cohort.application.config.CohortProperties
 import com.server.dpmcore.cohort.domain.exception.CohortNotFoundException
 import com.server.dpmcore.cohort.domain.model.CohortId
-import com.server.dpmcore.cohort.domain.port.CohortPersistencePort
+import com.server.dpmcore.cohort.domain.port.inbound.CohortQueryUseCase
+import com.server.dpmcore.cohort.domain.port.outbount.CohortPersistencePort
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
@@ -12,8 +13,8 @@ import org.springframework.transaction.annotation.Transactional
 class CohortQueryService(
     private val cohortPersistencePort: CohortPersistencePort,
     private val cohortProperties: CohortProperties,
-) {
-    fun getLatestCohortId(): CohortId =
+) : CohortQueryUseCase {
+    override fun getLatestCohortId(): CohortId =
         cohortPersistencePort.findCohortIdByValue(cohortProperties.value)
             ?: throw CohortNotFoundException()
 }

--- a/src/main/kotlin/com/server/dpmcore/cohort/domain/port/inbound/CohortQueryUseCase.kt
+++ b/src/main/kotlin/com/server/dpmcore/cohort/domain/port/inbound/CohortQueryUseCase.kt
@@ -1,0 +1,7 @@
+package com.server.dpmcore.cohort.domain.port.inbound
+
+import com.server.dpmcore.cohort.domain.model.CohortId
+
+interface CohortQueryUseCase {
+    fun getLatestCohortId(): CohortId
+}

--- a/src/main/kotlin/com/server/dpmcore/cohort/domain/port/outbound/CohortPersistencePort.kt
+++ b/src/main/kotlin/com/server/dpmcore/cohort/domain/port/outbound/CohortPersistencePort.kt
@@ -1,4 +1,4 @@
-package com.server.dpmcore.cohort.domain.port.outbount
+package com.server.dpmcore.cohort.domain.port.outbound
 
 import com.server.dpmcore.cohort.domain.model.CohortId
 

--- a/src/main/kotlin/com/server/dpmcore/cohort/domain/port/outbount/CohortPersistencePort.kt
+++ b/src/main/kotlin/com/server/dpmcore/cohort/domain/port/outbount/CohortPersistencePort.kt
@@ -1,4 +1,4 @@
-package com.server.dpmcore.cohort.domain.port
+package com.server.dpmcore.cohort.domain.port.outbount
 
 import com.server.dpmcore.cohort.domain.model.CohortId
 

--- a/src/main/kotlin/com/server/dpmcore/cohort/infrastructure/repository/CohortRepository.kt
+++ b/src/main/kotlin/com/server/dpmcore/cohort/infrastructure/repository/CohortRepository.kt
@@ -3,7 +3,7 @@ package com.server.dpmcore.cohort.infrastructure.repository
 import com.linecorp.kotlinjdsl.querydsl.expression.col
 import com.linecorp.kotlinjdsl.spring.data.SpringDataQueryFactory
 import com.server.dpmcore.cohort.domain.model.CohortId
-import com.server.dpmcore.cohort.domain.port.outbount.CohortPersistencePort
+import com.server.dpmcore.cohort.domain.port.outbound.CohortPersistencePort
 import com.server.dpmcore.cohort.infrastructure.entity.CohortEntity
 import com.server.dpmcore.common.jdsl.singleQueryOrNull
 import org.springframework.stereotype.Repository

--- a/src/main/kotlin/com/server/dpmcore/cohort/infrastructure/repository/CohortRepository.kt
+++ b/src/main/kotlin/com/server/dpmcore/cohort/infrastructure/repository/CohortRepository.kt
@@ -3,7 +3,7 @@ package com.server.dpmcore.cohort.infrastructure.repository
 import com.linecorp.kotlinjdsl.querydsl.expression.col
 import com.linecorp.kotlinjdsl.spring.data.SpringDataQueryFactory
 import com.server.dpmcore.cohort.domain.model.CohortId
-import com.server.dpmcore.cohort.domain.port.CohortPersistencePort
+import com.server.dpmcore.cohort.domain.port.outbount.CohortPersistencePort
 import com.server.dpmcore.cohort.infrastructure.entity.CohortEntity
 import com.server.dpmcore.common.jdsl.singleQueryOrNull
 import org.springframework.stereotype.Repository

--- a/src/main/kotlin/com/server/dpmcore/member/member/application/MemberQueryService.kt
+++ b/src/main/kotlin/com/server/dpmcore/member/member/application/MemberQueryService.kt
@@ -4,9 +4,9 @@ import com.server.dpmcore.authority.domain.model.AuthorityId
 import com.server.dpmcore.member.member.application.exception.MemberNotFoundException
 import com.server.dpmcore.member.member.domain.exception.MemberTeamNotFoundException
 import com.server.dpmcore.member.member.domain.model.MemberId
+import com.server.dpmcore.member.member.domain.model.query.MemberNameAuthorityQueryModel
 import com.server.dpmcore.member.member.domain.port.inbound.MemberQueryByAuthorityUseCase
 import com.server.dpmcore.member.member.domain.port.inbound.MemberQueryUseCase
-import com.server.dpmcore.member.member.domain.port.inbound.query.MemberNameAuthorityQueryModel
 import com.server.dpmcore.member.member.domain.port.outbound.MemberPersistencePort
 import com.server.dpmcore.member.member.presentation.response.MemberDetailsResponse
 import com.server.dpmcore.member.memberAuthority.application.MemberAuthorityService

--- a/src/main/kotlin/com/server/dpmcore/member/member/domain/model/query/MemberNameAuthorityQueryModel.kt
+++ b/src/main/kotlin/com/server/dpmcore/member/member/domain/model/query/MemberNameAuthorityQueryModel.kt
@@ -1,4 +1,4 @@
-package com.server.dpmcore.member.member.domain.port.inbound.query
+package com.server.dpmcore.member.member.domain.model.query
 
 data class MemberNameAuthorityQueryModel(
     val name: String,

--- a/src/main/kotlin/com/server/dpmcore/member/member/domain/port/inbound/MemberQueryUseCase.kt
+++ b/src/main/kotlin/com/server/dpmcore/member/member/domain/port/inbound/MemberQueryUseCase.kt
@@ -1,7 +1,7 @@
 package com.server.dpmcore.member.member.domain.port.inbound
 
 import com.server.dpmcore.member.member.domain.model.MemberId
-import com.server.dpmcore.member.member.domain.port.inbound.query.MemberNameAuthorityQueryModel
+import com.server.dpmcore.member.member.domain.model.query.MemberNameAuthorityQueryModel
 
 interface MemberQueryUseCase {
     /**

--- a/src/main/kotlin/com/server/dpmcore/member/member/domain/port/outbound/MemberPersistencePort.kt
+++ b/src/main/kotlin/com/server/dpmcore/member/member/domain/port/outbound/MemberPersistencePort.kt
@@ -3,7 +3,7 @@ package com.server.dpmcore.member.member.domain.port.outbound
 import com.server.dpmcore.authority.domain.model.AuthorityId
 import com.server.dpmcore.member.member.domain.model.Member
 import com.server.dpmcore.member.member.domain.model.MemberId
-import com.server.dpmcore.member.member.domain.port.inbound.query.MemberNameAuthorityQueryModel
+import com.server.dpmcore.member.member.domain.model.query.MemberNameAuthorityQueryModel
 
 interface MemberPersistencePort {
     fun save(member: Member): Member

--- a/src/main/kotlin/com/server/dpmcore/member/member/infrastructure/repository/MemberRepository.kt
+++ b/src/main/kotlin/com/server/dpmcore/member/member/infrastructure/repository/MemberRepository.kt
@@ -7,7 +7,7 @@ import com.server.dpmcore.common.jdsl.singleQueryOrNull
 import com.server.dpmcore.member.member.application.exception.MemberNameAuthorityRequiredException
 import com.server.dpmcore.member.member.domain.model.Member
 import com.server.dpmcore.member.member.domain.model.MemberId
-import com.server.dpmcore.member.member.domain.port.inbound.query.MemberNameAuthorityQueryModel
+import com.server.dpmcore.member.member.domain.model.query.MemberNameAuthorityQueryModel
 import com.server.dpmcore.member.member.domain.port.outbound.MemberPersistencePort
 import com.server.dpmcore.member.member.infrastructure.entity.MemberEntity
 import org.jooq.DSLContext

--- a/src/main/kotlin/com/server/dpmcore/member/memberCohort/application/MemberCohortService.kt
+++ b/src/main/kotlin/com/server/dpmcore/member/memberCohort/application/MemberCohortService.kt
@@ -1,7 +1,7 @@
 package com.server.dpmcore.member.memberCohort.application
 
-import com.server.dpmcore.cohort.application.CohortQueryService
 import com.server.dpmcore.cohort.domain.exception.CohortNotFoundException
+import com.server.dpmcore.cohort.domain.port.inbound.CohortQueryUseCase
 import com.server.dpmcore.member.member.domain.model.MemberId
 import com.server.dpmcore.member.memberCohort.domain.model.MemberCohort
 import com.server.dpmcore.member.memberCohort.domain.port.outbound.MemberCohortPersistencePort
@@ -10,7 +10,7 @@ import org.springframework.stereotype.Service
 @Service
 class MemberCohortService(
     private val memberCohortPersistencePort: MemberCohortPersistencePort,
-    private val cohortQueryService: CohortQueryService,
+    private val cohortQueryUseCase: CohortQueryUseCase,
 ) {
     /**
      * 가장 최신 기수 정보를 조회하고 멤버를 해당 기수에 추가함.
@@ -22,7 +22,7 @@ class MemberCohortService(
      */
     fun addMemberToCohort(memberId: MemberId) {
         memberCohortPersistencePort.save(
-            MemberCohort.of(memberId, cohortQueryService.getLatestCohortId()),
+            MemberCohort.of(memberId, cohortQueryUseCase.getLatestCohortId()),
         )
     }
 }

--- a/src/main/kotlin/com/server/dpmcore/session/application/SessionQueryService.kt
+++ b/src/main/kotlin/com/server/dpmcore/session/application/SessionQueryService.kt
@@ -1,6 +1,6 @@
 package com.server.dpmcore.session.application
 
-import com.server.dpmcore.cohort.application.CohortQueryService
+import com.server.dpmcore.cohort.domain.port.inbound.CohortQueryUseCase
 import com.server.dpmcore.session.application.query.SessionWeekQueryModel
 import com.server.dpmcore.session.domain.exception.SessionNotFoundException
 import com.server.dpmcore.session.domain.model.Session
@@ -15,7 +15,7 @@ import java.time.ZoneId
 @Service
 @Transactional(readOnly = true)
 class SessionQueryService(
-    private val cohortQueryService: CohortQueryService,
+    private val cohortQueryUseCase: CohortQueryUseCase,
     private val sessionPersistencePort: SessionPersistencePort,
 ) {
     fun getNextSession(): Session? {
@@ -27,7 +27,7 @@ class SessionQueryService(
     }
 
     fun getAllSessions(): List<Session> {
-        val cohortId = cohortQueryService.getLatestCohortId()
+        val cohortId = cohortQueryUseCase.getLatestCohortId()
 
         return sessionPersistencePort.findAllSessions(cohortId)
     }
@@ -44,7 +44,7 @@ class SessionQueryService(
             ?: throw SessionNotFoundException()
 
     fun getSessionWeeks(): List<SessionWeekQueryModel> {
-        val cohortId = cohortQueryService.getLatestCohortId()
+        val cohortId = cohortQueryUseCase.getLatestCohortId()
 
         return sessionPersistencePort
             .findAllSessions(cohortId)


### PR DESCRIPTION
## Summary

>- #133 

도메인 서비스 간 강결합을 제거하기 위해 의존 관계를 UseCase로 추상화하고 모델 패키지 구조를 개선하였습니다.

<!-- 해당 PR에 대한 요약을 작성해주세요. -->

## Tasks

- command, query 모델 패키지 구조 개선
- 도메인 서비스간 의존관계 UseCase로 추상화

## ETC

<!-- 추가적인 정보나 참고 사항을 작성해주세요. -->

## Screenshot

<!-- (없을 경우 삭제) 작업한 내용에 대한 스크린샷을 첨부해주세요._ -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Refactor
  - 애플리케이션 서비스가 구체 구현 대신 유스케이스 인터페이스를 사용하도록 전환
  - 도메인 포트를 인바운드/아웃바운드로 재구성하여 모듈 경계를 명확화
  - 멤버 쿼리 모델의 패키지 구조 정리로 일관성 및 재사용성 향상
  - 전체적으로 결합도 감소, 테스트 용이성 및 유지보수성 향상(사용자 기능 변화 없음)

- Chores
  - 내부 모듈 경로와 의존성 정리를 통해 명명 및 구조 일관성 개선
<!-- end of auto-generated comment: release notes by coderabbit.ai -->