### PR TITLE
fix : API-Controller 어노테이션 일치화

### DIFF
--- a/src/main/kotlin/com/server/dpmcore/bill/bill/presentation/controller/BillCommandApi.kt
+++ b/src/main/kotlin/com/server/dpmcore/bill/bill/presentation/controller/BillCommandApi.kt
@@ -123,7 +123,7 @@ interface BillCommandApi {
     fun updateMemberDeposit(
         @Positive billId: BillId,
         memberId: MemberId,
-        updateMemberDepositRequest: UpdateMemberDepositRequest,
+        @Valid updateMemberDepositRequest: UpdateMemberDepositRequest,
     ): CustomResponse<Void>
 
     @Operation(
@@ -139,8 +139,8 @@ interface BillCommandApi {
             ),
         ],
     )
-    fun updateMembersDeposit(
+    fun updateMemberListDeposit(
         @Positive billId: BillId,
-        updateMemberDepositRequest: UpdateMemberListDepositRequest,
+        @Valid updateMemberListDepositRequest: UpdateMemberListDepositRequest,
     ): CustomResponse<Void>
 }

--- a/src/main/kotlin/com/server/dpmcore/bill/bill/presentation/controller/BillCommandController.kt
+++ b/src/main/kotlin/com/server/dpmcore/bill/bill/presentation/controller/BillCommandController.kt
@@ -95,7 +95,7 @@ class BillCommandController(
 
     @PreAuthorize("hasRole('ROLE_ORGANIZER')")
     @PatchMapping("/{billId}/members/deposit")
-    override fun updateMembersDeposit(
+    override fun updateMemberListDeposit(
         @Positive @PathVariable billId: BillId,
         @RequestBody @Valid updateMemberListDepositRequest: UpdateMemberListDepositRequest,
     ): CustomResponse<Void> {


### PR DESCRIPTION
## Summary

>- close #150 

<!-- 해당 PR에 대한 요약을 작성해주세요. -->

## Tasks

- API와 Controller 어노테이션 일치화

## ETC

<!-- 추가적인 정보나 참고 사항을 작성해주세요. -->

## Screenshot

<!-- (없을 경우 삭제) 작업한 내용에 대한 스크린샷을 첨부해주세요._ -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신규 기능
  - 단일 멤버 및 멤버 목록 예치금 업데이트 요청에 유효성 검증이 추가되어, 형식 불일치나 누락 시 즉시 오류가 반환됩니다.

- 리팩터링
  - 멤버 예치금 일괄 업데이트 API 명칭이 updateMemberListDeposit으로 정비되었습니다. 엔드포인트 경로와 동작은 동일하며, 호출 로직은 변경 없이 작동합니다. 다만 클라이언트에서 메서드명에 의존하는 경우 이름 업데이트가 필요할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->