### PR TITLE
fix : 정산 상세 조회 joinMemberCount 버그 수정

### DIFF
--- a/src/main/kotlin/com/server/dpmcore/bill/bill/presentation/dto/response/BillDetailGatheringResponse.kt
+++ b/src/main/kotlin/com/server/dpmcore/bill/bill/presentation/dto/response/BillDetailGatheringResponse.kt
@@ -82,7 +82,7 @@ data class BillDetailGatheringResponse(
                         java.time.ZoneId.of(TIME_ZONE),
                     ),
                 category = gathering.category,
-                joinMemberCount = gathering.getGatheringJoinMemberCount(),
+                joinMemberCount = gathering.getGatheringJoinMemberCount(gatheringMembers),
                 amount = gathering.gatheringReceipt?.amount ?: 0,
                 splitAmount = splitAmount,
             )

--- a/src/main/kotlin/com/server/dpmcore/bill/bill/presentation/dto/response/BillDetailInviteAuthorityResponse.kt
+++ b/src/main/kotlin/com/server/dpmcore/bill/bill/presentation/dto/response/BillDetailInviteAuthorityResponse.kt
@@ -8,7 +8,7 @@ data class BillDetailInviteAuthorityResponse(
         example = "1",
         requiredMode = Schema.RequiredMode.REQUIRED,
     )
-    val inviteAuthorityId: Long = 1L,
+    val invitedAuthorityId: Long = 1L,
     @field:Schema(
         description = "정산 초대 대상 그룹 이름",
         example = "17_DEEPER",
@@ -26,12 +26,12 @@ data class BillDetailInviteAuthorityResponse(
         fun defaultInviteAuthorityResponse(): List<BillDetailInviteAuthorityResponse> =
             listOf(
                 BillDetailInviteAuthorityResponse(
-                    inviteAuthorityId = 1L,
+                    invitedAuthorityId = 1L,
                     authorityName = "17_DEEPER",
                     authorityMemberCount = 64,
                 ),
                 BillDetailInviteAuthorityResponse(
-                    inviteAuthorityId = 2L,
+                    invitedAuthorityId = 2L,
                     authorityName = "17_ORGANIZER",
                     authorityMemberCount = 12,
                 ),

--- a/src/main/kotlin/com/server/dpmcore/gathering/exception/GatheringException.kt
+++ b/src/main/kotlin/com/server/dpmcore/gathering/exception/GatheringException.kt
@@ -18,6 +18,6 @@ open class GatheringException(
     )
 
     class GatheringNotParticipantMemberException : GatheringException(
-        GatheringExceptionCode.GATHERING_NOT_PARTICIPAINT_MEMBER,
+        GatheringExceptionCode.GATHERING_NOT_PARTICIPANT_MEMBER,
     )
 }

--- a/src/main/kotlin/com/server/dpmcore/gathering/exception/GatheringException.kt
+++ b/src/main/kotlin/com/server/dpmcore/gathering/exception/GatheringException.kt
@@ -16,4 +16,8 @@ open class GatheringException(
     class GatheringNotIncludedInBillException : GatheringException(
         GatheringExceptionCode.GATHERING_NOT_INCLUDED_IN_BILL,
     )
+
+    class GatheringNotParticipantMemberException : GatheringException(
+        GatheringExceptionCode.GATHERING_NOT_PARTICIPAINT_MEMBER,
+    )
 }

--- a/src/main/kotlin/com/server/dpmcore/gathering/exception/GatheringExceptionCode.kt
+++ b/src/main/kotlin/com/server/dpmcore/gathering/exception/GatheringExceptionCode.kt
@@ -17,7 +17,7 @@ enum class GatheringExceptionCode(
     GATHERING_REQUIRED(HttpStatus.BAD_REQUEST, "GATHERING-400-02", "회식은 필수로 존재해야합니다."),
     GATHERING_ID_REQUIRED(HttpStatus.BAD_REQUEST, "GATHERING-400-03", "회식 ID는 필수로 존재해야합니다."),
     GATHERING_NOT_INCLUDED_IN_BILL(HttpStatus.BAD_REQUEST, "GATHERING-400-04", "해당 정산에 포함되지 않은 회식입니다."),
-    GATHERING_NOT_PARTICIPAINT_MEMBER(HttpStatus.BAD_REQUEST, "GATHERING-400-05", "정산에 참여하지 않은 멤버입니다."),
+    GATHERING_NOT_PARTICIPANT_MEMBER(HttpStatus.BAD_REQUEST, "GATHERING-400-05", "정산에 참여하지 않은 멤버입니다."),
     ;
 
     override fun getStatus(): HttpStatus = status

--- a/src/main/kotlin/com/server/dpmcore/gathering/exception/GatheringExceptionCode.kt
+++ b/src/main/kotlin/com/server/dpmcore/gathering/exception/GatheringExceptionCode.kt
@@ -17,6 +17,7 @@ enum class GatheringExceptionCode(
     GATHERING_REQUIRED(HttpStatus.BAD_REQUEST, "GATHERING-404-02", "회식은 필수로 존재해야합니다."),
     GATHERING_ID_REQUIRED(HttpStatus.BAD_REQUEST, "GATHERING-404-03", "회식 ID는 필수로 존재해야합니다."),
     GATHERING_NOT_INCLUDED_IN_BILL(HttpStatus.BAD_REQUEST, "GATHERING-400-02", "해당 정산에 포함되지 않은 회식입니다."),
+    GATHERING_NOT_PARTICIPAINT_MEMBER(HttpStatus.BAD_REQUEST, "GATHERING-400-05", "정산에 참여하지 않은 멤버입니다."),
     ;
 
     override fun getStatus(): HttpStatus = status

--- a/src/main/kotlin/com/server/dpmcore/gathering/exception/GatheringExceptionCode.kt
+++ b/src/main/kotlin/com/server/dpmcore/gathering/exception/GatheringExceptionCode.kt
@@ -13,10 +13,10 @@ enum class GatheringExceptionCode(
     INVALID_INPUT(HttpStatus.BAD_REQUEST, "GATHERING-400-01", "올바른 입력 형식이 아닙니다."),
     SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "GATHERING-500-01", "예상치 못한 서버 에러가 발생했습니다"),
 
-    GATHERING_NOT_FOUND(HttpStatus.BAD_REQUEST, "GATHERING-404-01", "존재하지 않는 회식입니다."),
-    GATHERING_REQUIRED(HttpStatus.BAD_REQUEST, "GATHERING-404-02", "회식은 필수로 존재해야합니다."),
-    GATHERING_ID_REQUIRED(HttpStatus.BAD_REQUEST, "GATHERING-404-03", "회식 ID는 필수로 존재해야합니다."),
-    GATHERING_NOT_INCLUDED_IN_BILL(HttpStatus.BAD_REQUEST, "GATHERING-400-02", "해당 정산에 포함되지 않은 회식입니다."),
+    GATHERING_NOT_FOUND(HttpStatus.NOT_FOUND, "GATHERING-404-01", "존재하지 않는 회식입니다."),
+    GATHERING_REQUIRED(HttpStatus.BAD_REQUEST, "GATHERING-400-02", "회식은 필수로 존재해야합니다."),
+    GATHERING_ID_REQUIRED(HttpStatus.BAD_REQUEST, "GATHERING-400-03", "회식 ID는 필수로 존재해야합니다."),
+    GATHERING_NOT_INCLUDED_IN_BILL(HttpStatus.BAD_REQUEST, "GATHERING-400-04", "해당 정산에 포함되지 않은 회식입니다."),
     GATHERING_NOT_PARTICIPAINT_MEMBER(HttpStatus.BAD_REQUEST, "GATHERING-400-05", "정산에 참여하지 않은 멤버입니다."),
     ;
 

--- a/src/main/kotlin/com/server/dpmcore/gathering/gathering/domain/model/Gathering.kt
+++ b/src/main/kotlin/com/server/dpmcore/gathering/gathering/domain/model/Gathering.kt
@@ -1,6 +1,7 @@
 package com.server.dpmcore.gathering.gathering.domain.model
 
 import com.server.dpmcore.bill.bill.domain.model.BillId
+import com.server.dpmcore.gathering.exception.GatheringException
 import com.server.dpmcore.gathering.gathering.domain.port.inbound.command.GatheringCreateCommand
 import com.server.dpmcore.gathering.gatheringMember.domain.model.GatheringMember
 import com.server.dpmcore.gathering.gatheringReceipt.domain.model.GatheringReceipt
@@ -45,16 +46,21 @@ class Gathering(
 
     fun isDeleted(): Boolean = deletedAt != null
 
-//    TODO : 회식 멤버가 null일 수 있음
-    fun getGatheringJoinMemberCount(gatheringMembers: List<GatheringMember>) =
-        gatheringMembers.count { gatheringMember ->
-            gatheringMember.isJoined && gatheringMember.deletedAt == null
+    //    TODO : 회식 멤버가 null일 수 있음
+    fun getGatheringJoinMemberCount(gatheringMembers: List<GatheringMember>): Int {
+        var joinMemberCount = 0
+
+        gatheringMembers.forEach { gatheringMember ->
+            if (gatheringMember.gatheringId != this.id) {
+                throw GatheringException.GatheringNotParticipantMemberException()
+            }
+            if (gatheringMember.isJoined && gatheringMember.deletedAt == null) {
+                joinMemberCount++
+            }
         }
 
-    fun getBillViewCount() =
-        gatheringMembers.count { gatheringMember ->
-            gatheringMember.isViewed
-        }
+        return joinMemberCount
+    }
 
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
@@ -66,8 +72,8 @@ class Gathering(
 
     override fun toString(): String =
         "Gathering(id=$id, title='$title', description=$description, heldAt=$heldAt, category=$category, " +
-                "hostUserId=$hostUserId, roundNumber=$roundNumber, createdAt=$createdAt, updatedAt=$updatedAt, " +
-                "deletedAt=$deletedAt, bill=$billId"
+            "hostUserId=$hostUserId, roundNumber=$roundNumber, createdAt=$createdAt, updatedAt=$updatedAt, " +
+            "deletedAt=$deletedAt, bill=$billId"
 
     companion object {
         fun create(command: GatheringCreateCommand): Gathering =

--- a/src/main/kotlin/com/server/dpmcore/gathering/gathering/domain/model/Gathering.kt
+++ b/src/main/kotlin/com/server/dpmcore/gathering/gathering/domain/model/Gathering.kt
@@ -47,7 +47,7 @@ class Gathering(
     fun isDeleted(): Boolean = deletedAt != null
 
 //    TODO : 회식 멤버가 null일 수 있음
-    fun getGatheringJoinMemberCount() =
+    fun getGatheringJoinMemberCount(gatheringMembers: List<GatheringMember>) =
         gatheringMembers.count { gatheringMember ->
             gatheringMember.isJoined && gatheringMember.deletedAt == null
         }

--- a/src/main/kotlin/com/server/dpmcore/gathering/gathering/domain/model/Gathering.kt
+++ b/src/main/kotlin/com/server/dpmcore/gathering/gathering/domain/model/Gathering.kt
@@ -32,7 +32,6 @@ class Gathering(
     updatedAt: Instant? = null,
     deletedAt: Instant? = null,
     billId: BillId? = null,
-    var gatheringMembers: MutableList<GatheringMember> = mutableListOf(),
     var gatheringReceipt: GatheringReceipt? = null,
 ) {
     var updatedAt: Instant? = updatedAt
@@ -67,8 +66,8 @@ class Gathering(
 
     override fun toString(): String =
         "Gathering(id=$id, title='$title', description=$description, heldAt=$heldAt, category=$category, " +
-            "hostUserId=$hostUserId, roundNumber=$roundNumber, createdAt=$createdAt, updatedAt=$updatedAt, " +
-            "deletedAt=$deletedAt, bill=$billId, gatheringMembers=$gatheringMembers)"
+                "hostUserId=$hostUserId, roundNumber=$roundNumber, createdAt=$createdAt, updatedAt=$updatedAt, " +
+                "deletedAt=$deletedAt, bill=$billId"
 
     companion object {
         fun create(command: GatheringCreateCommand): Gathering =

--- a/src/main/kotlin/com/server/dpmcore/gathering/gathering/domain/model/Gathering.kt
+++ b/src/main/kotlin/com/server/dpmcore/gathering/gathering/domain/model/Gathering.kt
@@ -48,6 +48,8 @@ class Gathering(
 
     //    TODO : 회식 멤버가 null일 수 있음
     fun getGatheringJoinMemberCount(gatheringMembers: List<GatheringMember>): Int {
+        if (this.id == null) throw GatheringException.GatheringIdRequiredException()
+
         var joinMemberCount = 0
 
         gatheringMembers.forEach { gatheringMember ->


### PR DESCRIPTION
## Summary

>- close #149 

<!-- 해당 PR에 대한 요약을 작성해주세요. -->

## Tasks

- joinMemberCount 버그 수정
- 변수명 통일(초대된 그룹 식별자)
- Gathering 예외 코드 수정
  - 상황에 맞지 않는 코드들 수정

## ETC

<!-- 추가적인 정보나 참고 사항을 작성해주세요. -->

## Screenshot

<!-- (없을 경우 삭제) 작업한 내용에 대한 스크린샷을 첨부해주세요._ -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **버그 수정**
  * 제공된 멤버 목록을 기준으로 모임 참가자 수 집계가 정확히 표시되도록 개선했습니다.
  * 참여하지 않은 멤버에 대한 요청 시 새 예외가 발생하도록 처리해 오류 상황을 명확히 구분합니다.
  * 일부 모임 관련 오류의 HTTP 상태 및 오류 코드 매핑을 조정했습니다.

* **리팩터**
  * 청구서 상세 초대 권한 응답 필드명이 inviteAuthorityId → invitedAuthorityId로 변경되어, 해당 필드를 사용하는 클라이언트는 명칭을 업데이트해야 합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->