### PR TITLE
refactor: 출석 세션별/사람별 정렬 조건 추가 및 paginate 정렬 제거

### DIFF
--- a/src/main/kotlin/com/server/dpmcore/attendance/infrastructure/repository/AttendanceRepository.kt
+++ b/src/main/kotlin/com/server/dpmcore/attendance/infrastructure/repository/AttendanceRepository.kt
@@ -64,7 +64,7 @@ class AttendanceRepository(
             .on(MEMBER_TEAMS.TEAM_ID.eq(TEAMS.TEAM_ID))
             .where(
                 query.toCondition(myTeamNumber),
-            ).orderBy(ATTENDANCES.MEMBER_ID.asc(), TEAMS.NUMBER.asc())
+            ).orderBy(TEAMS.NUMBER.asc(), MEMBERS.NAME.asc())
             .limit(PAGE_SIZE + 1)
             .fetch { record ->
                 SessionAttendanceQueryModel(
@@ -118,7 +118,7 @@ class AttendanceRepository(
                 MEMBERS.NAME,
                 TEAMS.NUMBER,
                 MEMBERS.PART,
-            ).orderBy(ATTENDANCES.MEMBER_ID.asc(), TEAMS.NUMBER.asc())
+            ).orderBy(TEAMS.NUMBER.asc(), MEMBERS.NAME.asc())
             .limit(PAGE_SIZE + 1)
             .fetch { record ->
                 MemberAttendanceQueryModel(

--- a/src/main/kotlin/com/server/dpmcore/common/util/ListPaginationExtensions.kt
+++ b/src/main/kotlin/com/server/dpmcore/common/util/ListPaginationExtensions.kt
@@ -12,17 +12,17 @@ inline fun <T> List<T>.paginate(
     pageSize: Int = PAGE_SIZE,
     crossinline idSelector: (T) -> Long,
 ): PaginatedResult<T> {
-    val sorted = this.sortedBy { idSelector(it) }
+    val content = if (this.size > pageSize) this.take(pageSize) else this
 
-    return if (sorted.size > pageSize) {
+    return if (this.size > pageSize) {
         PaginatedResult(
-            content = sorted.take(pageSize),
+            content = content,
             hasNext = true,
-            nextCursorId = idSelector(sorted.last()),
+            nextCursorId = idSelector(content.last()),
         )
     } else {
         PaginatedResult(
-            content = sorted,
+            content = content,
             hasNext = false,
             nextCursorId = null,
         )


### PR DESCRIPTION
## Summary

>- #159 

출석 페이지에서 정렬 조건을 수정하고 paginate 확장 함수의 ID기반 정렬을 제거하였습니다.

아래와 같은 조건으로 정렬 됩니다.
1. 팀 별 정렬
2. 가나다 순 정렬

<!-- 해당 PR에 대한 요약을 작성해주세요. -->

## Tasks

- 출석 세션별/사람별 정렬 조건 추가 및 paginate 정렬 제거

## ETC

<!-- 추가적인 정보나 참고 사항을 작성해주세요. -->

## Screenshot

<!-- (없을 경우 삭제) 작업한 내용에 대한 스크린샷을 첨부해주세요._ -->
