### PR TITLE
feat: 사람별 출석 리스트 상세 조회 조퇴 상태 값 포함

### DIFF
--- a/src/main/kotlin/com/server/dpmcore/attendance/application/query/model/MemberDetailAttendanceQueryModel.kt
+++ b/src/main/kotlin/com/server/dpmcore/attendance/application/query/model/MemberDetailAttendanceQueryModel.kt
@@ -10,4 +10,5 @@ data class MemberDetailAttendanceQueryModel(
     val excusedAbsentCount: Int,
     val onlineAbsentCount: Int,
     val offlineAbsentCount: Int,
+    val earlyLeaveCount: Int,
 )

--- a/src/main/kotlin/com/server/dpmcore/attendance/infrastructure/repository/AttendanceRepository.kt
+++ b/src/main/kotlin/com/server/dpmcore/attendance/infrastructure/repository/AttendanceRepository.kt
@@ -235,6 +235,10 @@ class AttendanceRepository(
                         DSL.inline(1),
                     ).otherwise(DSL.inline(0)),
                 ).`as`(OFFLINE_ABSENT_COUNT),
+                sum(
+                    `when`(ATTENDANCES.STATUS.eq(AttendanceStatus.EARLY_LEAVE.name), DSL.inline(1))
+                        .otherwise(DSL.inline(0)),
+                ).`as`(EARLY_LEAVE_COUNT),
             ).from(ATTENDANCES)
             .join(MEMBERS)
             .on(ATTENDANCES.MEMBER_ID.eq(MEMBERS.MEMBER_ID))
@@ -261,6 +265,7 @@ class AttendanceRepository(
                     excusedAbsentCount = it.get(EXCUSED_ABSENT_COUNT, Int::class.java) ?: 0,
                     onlineAbsentCount = it.get(ONLINE_ABSENT_COUNT, Int::class.java) ?: 0,
                     offlineAbsentCount = it.get(OFFLINE_ABSENT_COUNT, Int::class.java) ?: 0,
+                    earlyLeaveCount = it.get(EARLY_LEAVE_COUNT, Int::class.java) ?: 0,
                 )
             }
 
@@ -337,5 +342,6 @@ class AttendanceRepository(
         private const val OFFLINE_ABSENT_COUNT = "offline_absent_count"
         private const val PRESENT_COUNT = "present_count"
         private const val EXCUSED_ABSENT_COUNT = "excused_absent_count"
+        private const val EARLY_LEAVE_COUNT = "early_leave_count"
     }
 }

--- a/src/main/kotlin/com/server/dpmcore/attendance/presentation/AttendanceApi.kt
+++ b/src/main/kotlin/com/server/dpmcore/attendance/presentation/AttendanceApi.kt
@@ -401,7 +401,8 @@ interface AttendanceApi {
                                                 "presentCount": 1,
                                                 "lateCount": 1,
                                                 "excusedAbsentCount": 0,
-                                                "absentCount": 0
+                                                "absentCount": 0,
+                                                "earlyLeaveCount": 0
                                             },
                                             "sessions": [
                                                 {

--- a/src/main/kotlin/com/server/dpmcore/attendance/presentation/AttendanceApi.kt
+++ b/src/main/kotlin/com/server/dpmcore/attendance/presentation/AttendanceApi.kt
@@ -337,7 +337,8 @@ interface AttendanceApi {
                                                 "presentCount": 1,
                                                 "lateCount": 1,
                                                 "excusedAbsentCount": 0,
-                                                "absentCount": 0
+                                                "absentCount": 0,
+                                                "earlyLeaveCount": 0
                                             },
                                             "sessions": [
                                                 {

--- a/src/main/kotlin/com/server/dpmcore/attendance/presentation/dto/response/DetailMemberAttendancesResponse.kt
+++ b/src/main/kotlin/com/server/dpmcore/attendance/presentation/dto/response/DetailMemberAttendancesResponse.kt
@@ -21,6 +21,7 @@ data class MemberDetailAttendanceCountInfo(
     val lateCount: Int,
     val excusedAbsentCount: Int,
     val absentCount: Int,
+    val earlyLeaveCount: Int,
 )
 
 data class MemberDetailSessionInfo(

--- a/src/main/kotlin/com/server/dpmcore/attendance/presentation/mapper/AttendanceMapper.kt
+++ b/src/main/kotlin/com/server/dpmcore/attendance/presentation/mapper/AttendanceMapper.kt
@@ -124,6 +124,7 @@ object AttendanceMapper {
                     lateCount = memberAttendanceModel.lateCount,
                     excusedAbsentCount = memberAttendanceModel.excusedAbsentCount,
                     absentCount = memberAttendanceModel.onlineAbsentCount + memberAttendanceModel.offlineAbsentCount,
+                    earlyLeaveCount = memberAttendanceModel.earlyLeaveCount,
                 ),
             sessions =
                 sessionAttendancesModel.map { session ->


### PR DESCRIPTION
## Summary

>- #167 

`GET /v1/members/{memberId}/attendances`, `GET /v1/members/me/attendances` 에서 조퇴 상태 값이 누락되어 포함하도록 수정하였습니다.

<!-- 해당 PR에 대한 요약을 작성해주세요. -->

## Tasks

- 사람별 출석 리스트 상세 조회 조퇴 상태 값 포함

## ETC

<!-- 추가적인 정보나 참고 사항을 작성해주세요. -->

## Screenshot

<!-- (없을 경우 삭제) 작업한 내용에 대한 스크린샷을 첨부해주세요._ -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신규 기능
  - 출석 요약에 조퇴 횟수(earlyLeaveCount) 항목이 추가되었습니다.
  - 사람별 출석 상세 및 나의 출석 상세 응답에 earlyLeaveCount가 포함되어 더 풍부한 통계 제공.
  - 목록/상세 조회 모두에서 조퇴 집계가 반영되어 카운트 정보가 확장되었습니다.

- 문서
  - API 예시 응답에 earlyLeaveCount 필드를 추가해 최신 응답 형식을 명확히 반영했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->