### PR TITLE
fix: CustomResponseStatusAspect에서 proxy 객체가 HttpResponse 잡도록 경로 수정

### DIFF
--- a/application/src/main/kotlin/core/application/common/exception/CustomResponseStatusAspect.kt
+++ b/application/src/main/kotlin/core/application/common/exception/CustomResponseStatusAspect.kt
@@ -11,7 +11,7 @@ import org.springframework.stereotype.Component
 class CustomResponseStatusAspect(
     private val response: HttpServletResponse,
 ) {
-    @Around("within(com.server.dpmcore..*Controller)")
+    @Around("within(core.application..*Controller)")
     @Throws(Throwable::class)
     fun handleResponseStatus(joinPoint: ProceedingJoinPoint): Any? {
         val result = joinPoint.proceed()


### PR DESCRIPTION
## Summary

>- #181 

지난 아키텍처 변경에서 Pointcut 경로가 반영되지 않았습니다. 이를 수정합니다

<!-- 해당 PR에 대한 요약을 작성해주세요. -->

## Tasks

- CustomResponseStatusAspect에서 proxy 객체가 HttpResponse 잡도록 경로 수정

## ETC

<!-- 추가적인 정보나 참고 사항을 작성해주세요. -->

## Screenshot
<img width="1282" height="317" alt="스크린샷 2025-11-03 오후 7 58 57" src="https://github.com/user-attachments/assets/31918b88-47fe-4d44-87ea-2dda0b73598a" />

<!-- (없을 경우 삭제) 작업한 내용에 대한 스크린샷을 첨부해주세요._ -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * 응답 상태 처리 메커니즘의 적용 범위를 조정했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->