### PR TITLE
[feat]: apple oauth 2.0 login / DRAFT_FOR_DEV

### DIFF
--- a/.github/workflows/dev-cd.yml
+++ b/.github/workflows/dev-cd.yml
@@ -41,6 +41,7 @@ jobs:
             [🔗 작업 요약 보기](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})
 
   deploy:
+
     needs:
       - compile
     runs-on: ubuntu-22.04
@@ -50,6 +51,7 @@ jobs:
       DOCKER_REPOSITORY: ${{ secrets.DOCKER_REPOSITORY }}
       DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
       IMAGE_TAG: dev-${{ github.sha }}
+      APPLE_PRIVATE_KEY_PATH: ${{ secrets.APPLE_DEV__PRIVATE_KEY_PATH }}
 
     steps:
       - name: "레포지토리를 체크아웃한다."
@@ -69,6 +71,12 @@ jobs:
         with:
           username: ${{ env.DOCKER_USERNAME }}
           password: ${{ env.DOCKER_PASSWORD }}
+
+      - name: "Apple p8 key 파일 생성"
+        run: |
+          mkdir -p secrets
+          echo "${{ secrets.APPLE_P8_KEY }}" > secrets/AuthKey.p8
+          chmod 600 secrets/AuthKey.p8
 
       - name: "Jib을 사용하여 Docker 이미지를 빌드 후 Dockerhub에 푸시한다."
         run: |

--- a/application/build.gradle.kts
+++ b/application/build.gradle.kts
@@ -50,6 +50,17 @@ jib {
     container {
         ports = listOf("8080")
         jvmFlags = listOf("-Xms512m", "-Xmx512m", "-Duser.timezone=Asia/Seoul")
+        environment = mapOf(
+            "APPLE_PRIVATE_KEY_PATH" to "/app/secrets/AuthKey.p8"
+        )
+    }
+    extraDirectories {
+        paths {
+            path {
+                setFrom("secrets")
+                setInto("/app/secrets")
+            }
+        }
     }
 }
 
@@ -59,6 +70,10 @@ tasks.named<org.springframework.boot.gradle.tasks.bundling.BootJar>("bootJar") {
 
 springBoot {
     mainClass.set("core.application.CoreApplication")
+}
+
+tasks.withType<Test> {
+    useJUnitPlatform()
 }
 
 kotlin {

--- a/application/src/main/kotlin/core/application/member/application/service/auth/AppleAuthService.kt
+++ b/application/src/main/kotlin/core/application/member/application/service/auth/AppleAuthService.kt
@@ -1,0 +1,65 @@
+package core.application.member.application.service.auth
+
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import core.application.member.application.service.oauth.MemberOAuthService
+import core.application.security.oauth.apple.AppleTokenExchangeService
+import core.application.security.oauth.token.JwtTokenProvider
+import core.domain.member.enums.OAuthProvider
+import core.application.member.application.exception.MemberNotFoundException
+import core.domain.member.port.outbound.MemberOAuthPersistencePort
+import core.domain.member.port.outbound.MemberPersistencePort
+import core.domain.refreshToken.aggregate.RefreshToken
+import core.domain.refreshToken.port.outbound.RefreshTokenPersistencePort
+import org.springframework.core.env.Environment
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+class AppleAuthService(
+    private val appleTokenExchangeService: AppleTokenExchangeService,
+    private val memberOAuthPersistencePort: MemberOAuthPersistencePort,
+    private val memberPersistencePort: MemberPersistencePort,
+    private val memberOAuthService: MemberOAuthService,
+    private val jwtTokenProvider: JwtTokenProvider,
+    private val refreshTokenPersistencePort: RefreshTokenPersistencePort,
+    private val environment: Environment,
+    private val appleIdTokenValidator: core.application.security.oauth.apple.AppleIdTokenValidator,
+) {
+
+    @Transactional
+    fun login(authorizationCode: String): AuthTokenResponse {
+        // 1. Exchange Code for Tokens
+        val tokenResponse = appleTokenExchangeService.getTokens(authorizationCode)
+
+        // 2. Verify ID Token
+        val claims = appleIdTokenValidator.verify(tokenResponse.id_token)
+        val externalId = claims.subject ?: throw IllegalArgumentException("Invalid ID Token: sub missing")
+        val email = claims["email"] as? String
+
+        // 3. Find check existing Member
+        val memberOAuth = memberOAuthPersistencePort.findByProviderAndExternalId(OAuthProvider.APPLE, externalId)
+            ?: throw MemberNotFoundException()
+
+        val member = memberPersistencePort.findById(memberOAuth.memberId.value)
+                ?: throw IllegalStateException("MemberOAuth exists but Member not found")
+
+        // 4. Issue App Tokens
+        val accessToken = jwtTokenProvider.generateAccessToken(member.id!!.toString())
+        val refreshToken = jwtTokenProvider.generateRefreshToken(member.id!!.toString())
+
+        // 5. Save Refresh Token
+        val refreshTokenEntity = refreshTokenPersistencePort.findByMemberId(member.id!!.value)
+            ?.apply { rotate(refreshToken) }
+            ?: RefreshToken.create(member.id!!, refreshToken)
+        refreshTokenPersistencePort.save(refreshTokenEntity)
+
+        return AuthTokenResponse(accessToken, refreshToken)
+    }
+
+
+}
+
+data class AuthTokenResponse(
+    val accessToken: String,
+    val refreshToken: String,
+)

--- a/application/src/main/kotlin/core/application/member/presentation/controller/MemberLoginController.kt
+++ b/application/src/main/kotlin/core/application/member/presentation/controller/MemberLoginController.kt
@@ -4,14 +4,23 @@ import io.github.oshai.kotlinlogging.KotlinLogging
 import jakarta.servlet.http.Cookie
 import jakarta.servlet.http.HttpServletRequest
 import jakarta.servlet.http.HttpServletResponse
-import org.springframework.stereotype.Controller
+import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.web.bind.annotation.GetMapping
+import core.application.member.application.service.auth.AppleAuthService
+import core.application.member.application.service.auth.AuthTokenResponse
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RestController
 import java.net.URI
 
-@Controller
-class MemberLoginController {
+@Tag(name = "Member-Login", description = "Member Login API")
+@RestController
+class MemberLoginController(
+    private val appleAuthService: AppleAuthService,
+) {
     companion object {
         private const val KAKAO_REDIRECT_URL = "redirect:/oauth2/authorization/kakao"
+        private const val APPLE_REDIRECT_URL = "redirect:/oauth2/authorization/apple"
         private const val REQUEST_DOMAIN = "REQUEST_DOMAIN"
         private const val ORIGIN = "Origin"
         private const val REFERER = "Referer"
@@ -24,6 +33,40 @@ class MemberLoginController {
         request: HttpServletRequest,
         response: HttpServletResponse,
     ): String {
+        setCookie(request, response)
+        return KAKAO_REDIRECT_URL
+    }
+
+    @GetMapping("/login/apple")
+    fun appleLogin(
+        request: HttpServletRequest,
+        response: HttpServletResponse,
+    ): String {
+        setCookie(request, response)
+        return APPLE_REDIRECT_URL
+    }
+
+
+    /**
+     * apple login to support third-party login
+     * */
+    @PostMapping("/v1/auth/login/apple")
+    fun appleLoginV1(
+        @RequestBody body: AppleLoginRequest,
+        response: HttpServletResponse,
+    ): AuthTokenResponse {
+        val tokens = appleAuthService.login(body.authorizationCode)
+
+        addTokenCookies(response, tokens)
+
+        return tokens
+    }
+
+    data class AppleLoginRequest(
+        val authorizationCode: String,
+    )
+
+    private fun setCookie(request: HttpServletRequest, response: HttpServletResponse) {
         try {
             val requestDomain =
                 URI(request.getHeader(ORIGIN) ?: request.getHeader(REFERER) ?: request.requestURL.toString()).host
@@ -38,6 +81,22 @@ class MemberLoginController {
         } catch (e: Exception) {
             logger.warn(e) { "Failed to set REQUEST_DOMAIN cookie : ${e.message}" }
         }
-        return KAKAO_REDIRECT_URL
+    }
+
+    private fun addTokenCookies(response: HttpServletResponse, tokens: AuthTokenResponse) {
+        val accessTokenCookie = createCookie("accessToken", tokens.accessToken, 60 * 60 * 24) // 1 day
+        val refreshTokenCookie = createCookie("refreshToken", tokens.refreshToken, 60 * 60 * 24 * 30) // 30 days
+
+        response.addCookie(accessTokenCookie)
+        response.addCookie(refreshTokenCookie)
+    }
+
+    private fun createCookie(name: String, value: String, maxAgeSeconds: Int): Cookie {
+        return Cookie(name, value).apply {
+            path = "/"
+            maxAge = maxAgeSeconds
+            isHttpOnly = true
+            // secure = true // Enable in prod
+        }
     }
 }

--- a/application/src/main/kotlin/core/application/security/configuration/SecurityConfig.kt
+++ b/application/src/main/kotlin/core/application/security/configuration/SecurityConfig.kt
@@ -17,6 +17,8 @@ import org.springframework.security.web.authentication.AuthenticationSuccessHand
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter
 import org.springframework.security.web.authentication.logout.LogoutSuccessHandler
 
+import core.application.security.oauth.apple.AppleOAuth2AccessTokenResponseClient
+
 @Configuration
 @EnableWebSecurity
 @EnableMethodSecurity
@@ -28,6 +30,7 @@ class SecurityConfig(
     private val authenticationSuccessHandler: AuthenticationSuccessHandler,
     private val authenticationFailureHandler: AuthenticationFailureHandler,
     private val logoutSuccessHandler: LogoutSuccessHandler,
+    private val appleOAuth2AccessTokenResponseClient: AppleOAuth2AccessTokenResponseClient,
 ) {
     @Bean
     fun filterChain(httpSecurity: HttpSecurity): SecurityFilterChain {
@@ -80,6 +83,9 @@ class SecurityConfig(
             .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter::class.java)
             .oauth2Login { oauth2 ->
                 oauth2
+                    .tokenEndpoint {
+                        it.accessTokenResponseClient(appleOAuth2AccessTokenResponseClient)
+                    }
                     .authorizationEndpoint {
                         it.authorizationRequestRepository(authorizationRequestRepository)
                     }.userInfoEndpoint {
@@ -114,6 +120,10 @@ class SecurityConfig(
             arrayOf(
                 "/v1/reissue",
                 "/login/kakao",
+                "/login/apple",
+                "/auth",
+                "/oauth2/**",
+                "/login",
                 "/error",
             )
     }

--- a/application/src/main/kotlin/core/application/security/oauth/apple/AppleClientSecretGenerator.kt
+++ b/application/src/main/kotlin/core/application/security/oauth/apple/AppleClientSecretGenerator.kt
@@ -1,0 +1,59 @@
+package core.application.security.oauth.apple
+
+import core.application.security.properties.AppleProperties
+import io.jsonwebtoken.Jwts
+import jakarta.annotation.PostConstruct
+import org.springframework.core.io.Resource
+import org.springframework.stereotype.Component
+import java.security.KeyFactory
+import java.security.PrivateKey
+import java.security.spec.PKCS8EncodedKeySpec
+import java.time.LocalDateTime
+import java.time.ZoneId
+import java.util.Base64
+import java.util.Date
+@Component
+class AppleClientSecretGenerator(
+    private val appleProperties: AppleProperties,
+) {
+
+    private lateinit var privateKey: PrivateKey
+
+    @PostConstruct
+    fun init() {
+        privateKey = loadPrivateKeyOnce(appleProperties.privateKeyPath)
+    }
+
+    fun generateClientSecret(): String {
+        val now = Date()
+        val expiration = Date.from(
+            LocalDateTime.now()
+                .plusDays(180)
+                .atZone(ZoneId.systemDefault())
+                .toInstant()
+        )
+
+        return Jwts.builder()
+            .header()
+            .add("kid", appleProperties.keyId)
+            .and()
+            .issuer(appleProperties.teamId)
+            .subject(appleProperties.clientId)
+            .audience().add("https://appleid.apple.com").and()
+            .issuedAt(now)
+            .expiration(expiration)
+            .signWith(privateKey) // ✅ 캐싱된 키
+            .compact()
+    }
+
+    private fun loadPrivateKeyOnce(resource: Resource): PrivateKey {
+        val keyContent = resource.inputStream.bufferedReader().use { it.readText() }
+            .replace("-----BEGIN PRIVATE KEY-----", "")
+            .replace("-----END PRIVATE KEY-----", "")
+            .replace("\\s".toRegex(), "")
+
+        val decoded = Base64.getDecoder().decode(keyContent)
+        val keySpec = PKCS8EncodedKeySpec(decoded)
+        return KeyFactory.getInstance("EC").generatePrivate(keySpec)
+    }
+}

--- a/application/src/main/kotlin/core/application/security/oauth/apple/AppleIdTokenValidator.kt
+++ b/application/src/main/kotlin/core/application/security/oauth/apple/AppleIdTokenValidator.kt
@@ -1,0 +1,94 @@
+package core.application.security.oauth.apple
+
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.fasterxml.jackson.module.kotlin.readValue
+import core.application.security.properties.AppleProperties
+import io.jsonwebtoken.Claims
+import io.jsonwebtoken.Jwts
+import org.springframework.stereotype.Component
+import org.springframework.web.client.RestClient
+import java.math.BigInteger
+import java.security.KeyFactory
+import java.security.PublicKey
+import java.security.spec.RSAPublicKeySpec
+import java.util.Base64
+import java.util.concurrent.ConcurrentHashMap
+
+@Component
+class AppleIdTokenValidator(
+    private val appleProperties: AppleProperties,
+) {
+    private val restClient = RestClient.create()
+    private val objectMapper = jacksonObjectMapper()
+    private val applePublicKeys = ConcurrentHashMap<String, PublicKey>()
+
+    fun verify(idToken: String): Claims {
+        // 1. Get KID from Header
+        val header = getIdTokenHeader(idToken)
+        val kid = header["kid"] as? String ?: throw IllegalArgumentException("Invalid ID Token: kid missing")
+
+        // 2. Get Public Key (Cache or Fetch)
+        val publicKey = getPublicKey(kid)
+
+        // 3. Verify Signature & Claims
+        return Jwts.parser()
+            .verifyWith(publicKey)
+            .requireIssuer("https://appleid.apple.com")
+            .requireAudience(appleProperties.clientId)
+            .build()
+            .parseSignedClaims(idToken)
+            .payload
+    }
+
+    private fun getIdTokenHeader(idToken: String): Map<String, Any> {
+        val parts = idToken.split(".")
+        if (parts.size < 2) throw IllegalArgumentException("Invalid ID Token format")
+        val headerJson = String(Base64.getUrlDecoder().decode(parts[0]))
+        return objectMapper.readValue(headerJson)
+    }
+
+    private fun getPublicKey(kid: String): PublicKey {
+        return applePublicKeys[kid] ?: fetchAndCachePublicKeys()[kid]
+        ?: throw IllegalArgumentException("Matching key not found for kid: $kid")
+    }
+
+    private fun fetchAndCachePublicKeys(): Map<String, PublicKey> {
+        val response = restClient.get()
+            .uri("https://appleid.apple.com/auth/keys")
+            .retrieve()
+            .body(String::class.java)
+            ?: throw RuntimeException("Failed to fetch Apple public keys")
+
+        val keysDef = objectMapper.readValue<AppleKeysResponse>(response)
+        val newKeys = keysDef.keys.associate { key ->
+            key.kid to generatePublicKey(key)
+        }
+        
+        applePublicKeys.putAll(newKeys)
+        return newKeys
+    }
+
+    private fun generatePublicKey(keyDef: AppleKey): PublicKey {
+        val nBytes = Base64.getUrlDecoder().decode(keyDef.n)
+        val eBytes = Base64.getUrlDecoder().decode(keyDef.e)
+
+        val n = BigInteger(1, nBytes)
+        val e = BigInteger(1, eBytes)
+
+        val spec = RSAPublicKeySpec(n, e)
+        return KeyFactory.getInstance(keyDef.kty).generatePublic(spec)
+    }
+
+    data class AppleKeysResponse(
+        val keys: List<AppleKey>
+    )
+
+    data class AppleKey(
+        val kty: String,
+        val kid: String,
+        val use: String,
+        val alg: String,
+        val n: String,
+        val e: String
+    )
+}

--- a/application/src/main/kotlin/core/application/security/oauth/apple/AppleOAuth2AccessTokenResponseClient.kt
+++ b/application/src/main/kotlin/core/application/security/oauth/apple/AppleOAuth2AccessTokenResponseClient.kt
@@ -1,0 +1,41 @@
+package core.application.security.oauth.apple
+
+import org.springframework.security.oauth2.client.endpoint.RestClientAuthorizationCodeTokenResponseClient
+import org.springframework.security.oauth2.client.endpoint.OAuth2AccessTokenResponseClient
+import org.springframework.security.oauth2.client.endpoint.OAuth2AuthorizationCodeGrantRequest
+import org.springframework.security.oauth2.client.registration.ClientRegistration
+import org.springframework.security.oauth2.core.endpoint.OAuth2AccessTokenResponse
+import org.springframework.stereotype.Component
+
+@Component
+class AppleOAuth2AccessTokenResponseClient(
+    private val appleClientSecretGenerator: AppleClientSecretGenerator
+) : OAuth2AccessTokenResponseClient<OAuth2AuthorizationCodeGrantRequest> {
+
+    private val defaultClient = RestClientAuthorizationCodeTokenResponseClient()
+
+    override fun getTokenResponse(authorizationGrantRequest: OAuth2AuthorizationCodeGrantRequest): OAuth2AccessTokenResponse {
+        val clientRegistration = authorizationGrantRequest.clientRegistration
+
+        // Only intercept Apple requests to inject dynamic client_secret
+        if (clientRegistration.registrationId.equals("apple", ignoreCase = true)) {
+            val secret = appleClientSecretGenerator.generateClientSecret()
+
+            // Create a new ClientRegistration with the dynamic secret
+            val newClientRegistration = ClientRegistration
+                .withClientRegistration(clientRegistration)
+                .clientSecret(secret)
+                .build()
+
+            // Create a new request with the updated registration
+            val newRequest = OAuth2AuthorizationCodeGrantRequest(
+                newClientRegistration,
+                authorizationGrantRequest.authorizationExchange
+            )
+
+            return defaultClient.getTokenResponse(newRequest)
+        }
+
+        return defaultClient.getTokenResponse(authorizationGrantRequest)
+    }
+}

--- a/application/src/main/kotlin/core/application/security/oauth/apple/AppleTokenExchangeService.kt
+++ b/application/src/main/kotlin/core/application/security/oauth/apple/AppleTokenExchangeService.kt
@@ -1,0 +1,43 @@
+package core.application.security.oauth.apple
+
+import core.application.security.properties.AppleProperties
+import org.springframework.http.MediaType
+import org.springframework.stereotype.Service
+import org.springframework.util.LinkedMultiValueMap
+import org.springframework.web.client.RestClient
+
+@Service
+class AppleTokenExchangeService(
+    private val appleClientSecretGenerator: AppleClientSecretGenerator,
+    private val appleProperties: AppleProperties,
+) {
+    private val restClient = RestClient.create()
+
+    fun getTokens(authorizationCode: String): AppleTokenResponse {
+        val clientSecret = appleClientSecretGenerator.generateClientSecret()
+
+        val formData = LinkedMultiValueMap<String, String>().apply {
+            add("client_id", appleProperties.clientId)
+            add("client_secret", clientSecret)
+            add("code", authorizationCode)
+            add("grant_type", "authorization_code")
+            add("redirect_uri", appleProperties.redirectUri)
+        }
+
+        return restClient.post()
+            .uri("https://appleid.apple.com/auth/token")
+            .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+            .body(formData)
+            .retrieve()
+            .body(AppleTokenResponse::class.java)
+            ?: throw RuntimeException("Failed to retrieve tokens from Apple")
+    }
+
+    data class AppleTokenResponse(
+        val access_token: String,
+        val token_type: String,
+        val expires_in: Int,
+        val refresh_token: String?,
+        val id_token: String
+    )
+}

--- a/application/src/main/kotlin/core/application/security/properties/AppleProperties.kt
+++ b/application/src/main/kotlin/core/application/security/properties/AppleProperties.kt
@@ -1,0 +1,13 @@
+package core.application.security.properties
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+import org.springframework.core.io.Resource
+
+@ConfigurationProperties(prefix = "apple")
+data class AppleProperties(
+    val teamId: String,
+    val clientId: String,
+    val keyId: String, // id_token 의 apple RSA public Key
+    val privateKeyPath: Resource,
+    val redirectUri: String,
+)

--- a/application/src/main/resources/application-dev.yml
+++ b/application/src/main/resources/application-dev.yml
@@ -11,3 +11,9 @@ spring:
 logging:
   level:
     org.springframework.orm.jpa: INFO
+apple:
+  client-id: ${DEV_APPLE_CLIENT_ID}
+  key-id: ${DEV_APPLE_KEY_ID}
+  team-id: ${DEV_APPLE_TEAM_ID}
+  private-key-path: ${DEV_APPLE_PRIVATE_KEY_PATH}
+  redirect-uri: ${DEV_APPLE_REDIRECT_URL}

--- a/application/src/main/resources/application-local.yml
+++ b/application/src/main/resources/application-local.yml
@@ -7,6 +7,12 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: update
+      ddl-auto: validate
 server:
   port: 8080
+apple:
+  client-id: ${LOCAL_APPLE_CLIENT_ID}
+  key-id: ${LOCAL_APPLE_KEY_ID}
+  team-id: ${LOCAL_APPLE_TEAM_ID}
+  private-key-path: ${LOCAL_APPLE_PRIVATE_KEY_PATH}
+  redirect-uri: ${LOCAL_APPLE_REDIRECT_URL}

--- a/application/src/main/resources/application-prod.yml
+++ b/application/src/main/resources/application-prod.yml
@@ -11,3 +11,9 @@ spring:
 logging:
   level:
     org.springframework.orm.jpa: INFO
+apple:
+  client-id: ${PROD_APPLE_CLIENT_ID}
+  key-id: ${PROD_APPLE_KEY_ID}
+  team-id: ${PROD_APPLE_TEAM_ID}
+  private-key-path: ${PROD_APPLE_PRIVATE_KEY_PATH}
+  redirect-uri: ${PROD_APPLE_REDIRECT_URL}

--- a/application/src/main/resources/application.yml
+++ b/application/src/main/resources/application.yml
@@ -46,12 +46,26 @@ spring:
             scope:
               - account_email
               - profile_nickname
+          apple:
+            client-id: ${apple.client-id}
+            client-secret: ${apple.client-secret}
+            authorization-grant-type: authorization_code
+            redirect-uri: ${APPLE_REDIRECT_URL}
+            scope:
+              - name
+              - email
         provider:
           kakao:
             authorization-uri: https://kauth.kakao.com/oauth/authorize
             token-uri: https://kauth.kakao.com/oauth/token
             user-info-uri: https://kapi.kakao.com/v2/user/me
             user-name-attribute: id
+          apple:
+            authorization-uri: https://appleid.apple.com/auth/authorize
+            token-uri: https://appleid.apple.com/auth/token
+            jwk-set-uri: https://appleid.apple.com/auth/keys
+            user-name-attribute: sub
+
 
 management:
   endpoints:

--- a/application/src/test/kotlin/core/application/member/application/service/auth/AppleAuthServiceTest.kt
+++ b/application/src/test/kotlin/core/application/member/application/service/auth/AppleAuthServiceTest.kt
@@ -1,0 +1,134 @@
+package core.application.member.application.service.auth
+
+import core.application.member.application.service.oauth.MemberOAuthService
+import core.application.security.oauth.apple.AppleTokenExchangeService
+import core.application.security.oauth.token.JwtTokenProvider
+import core.domain.member.aggregate.Member
+import core.domain.member.aggregate.MemberOAuth
+import core.domain.member.enums.OAuthProvider
+import core.domain.member.port.outbound.MemberOAuthPersistencePort
+import core.domain.member.port.outbound.MemberPersistencePort
+import core.domain.member.vo.MemberId
+import core.domain.member.vo.MemberOAuthId
+import core.domain.refreshToken.port.outbound.RefreshTokenPersistencePort
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.times
+import org.mockito.Mockito.verify
+import org.mockito.Mockito.`when`
+import core.application.member.application.exception.MemberNotFoundException
+
+import org.mockito.Mockito
+import org.springframework.core.env.Environment
+
+class AppleAuthServiceTest {
+
+    private val appleTokenExchangeService: AppleTokenExchangeService = mock(AppleTokenExchangeService::class.java)
+    private val memberOAuthPersistencePort: MemberOAuthPersistencePort = mock(MemberOAuthPersistencePort::class.java)
+    private val memberPersistencePort: MemberPersistencePort = mock(MemberPersistencePort::class.java)
+    private val memberOAuthService: MemberOAuthService = mock(MemberOAuthService::class.java)
+    private val jwtTokenProvider: JwtTokenProvider = mock(JwtTokenProvider::class.java)
+    private val refreshTokenPersistencePort: RefreshTokenPersistencePort = mock(RefreshTokenPersistencePort::class.java)
+    private val environment: Environment = mock(Environment::class.java)
+
+    private val appleIdTokenValidator: core.application.security.oauth.apple.AppleIdTokenValidator = mock(core.application.security.oauth.apple.AppleIdTokenValidator::class.java)
+
+    private val appleAuthService = AppleAuthService(
+        appleTokenExchangeService,
+        memberOAuthPersistencePort,
+        memberPersistencePort,
+        memberOAuthService,
+        jwtTokenProvider,
+        refreshTokenPersistencePort,
+        environment,
+        appleIdTokenValidator
+    )
+
+    @Test
+    fun `login should throw MemberNotFoundException if member not exists`() {
+        // Arrange
+        val authCode = "valid-code"
+        val idToken = "id-token"
+        val tokenResponse = AppleTokenExchangeService.AppleTokenResponse(
+            access_token = "access",
+            token_type = "Bearer",
+            expires_in = 3600,
+            refresh_token = "refresh",
+            id_token = idToken
+        )
+
+        `when`(appleTokenExchangeService.getTokens(authCode)).thenReturn(tokenResponse)
+
+        val claims = Mockito.mock(io.jsonwebtoken.Claims::class.java)
+        `when`(claims.subject).thenReturn("user-123")
+        `when`(appleIdTokenValidator.verify(idToken)).thenReturn(claims)
+
+        `when`(memberOAuthPersistencePort.findByProviderAndExternalId(OAuthProvider.APPLE, "user-123")).thenReturn(null)
+
+        // Act & Assert
+        assertThrows(MemberNotFoundException::class.java) {
+            appleAuthService.login(authCode)
+        }
+
+        verify(memberPersistencePort, times(0)).save(anyObject())
+    }
+
+    @Test
+    fun `login should login existing member`() {
+        // Arrange
+        val authCode = "valid-code"
+        val idToken = "id-token"
+         val tokenResponse = AppleTokenExchangeService.AppleTokenResponse(
+            access_token = "access",
+            token_type = "Bearer",
+            expires_in = 3600,
+            refresh_token = "refresh",
+            id_token = idToken
+        )
+
+        `when`(appleTokenExchangeService.getTokens(authCode)).thenReturn(tokenResponse)
+
+        val claims = Mockito.mock(io.jsonwebtoken.Claims::class.java)
+        `when`(claims.subject).thenReturn("user-123")
+        `when`(appleIdTokenValidator.verify(idToken)).thenReturn(claims) // No email needed
+
+        val existingMemberId = MemberId(1L)
+        val memberOAuth = MemberOAuth(
+            id = MemberOAuthId(10L),
+            externalId = "user-123",
+            provider = OAuthProvider.APPLE,
+            memberId = existingMemberId
+        )
+        `when`(memberOAuthPersistencePort.findByProviderAndExternalId(OAuthProvider.APPLE, "user-123")).thenReturn(memberOAuth)
+
+        val existingMember = Member(
+            id = existingMemberId,
+            email = "test@apple.com",
+            signupEmail = "test@apple.com",
+            name = "Apple User",
+            status = core.domain.member.enums.MemberStatus.ACTIVE,
+            part = core.domain.member.enums.MemberPart.SERVER
+        )
+        `when`(memberPersistencePort.findById(1L)).thenReturn(existingMember)
+
+        `when`(jwtTokenProvider.generateAccessToken("1")).thenReturn("app-access")
+        `when`(jwtTokenProvider.generateRefreshToken("1")).thenReturn("app-refresh")
+
+        // Act
+        val result = appleAuthService.login(authCode)
+
+        // Assert
+        verify(memberPersistencePort, times(0)).save(anyObject())
+        verify(memberOAuthService, times(0)).addMemberOAuthProvider(anyObject(), anyObject())
+        assertEquals("app-access", result.accessToken)
+    }
+
+    private fun <T> anyObject(): T {
+        Mockito.any<T>()
+        return uninitialized()
+    }
+    @Suppress("UNCHECKED_CAST")
+    private fun <T> uninitialized(): T = null as T
+}

--- a/domain/src/main/kotlin/core/domain/member/enums/OAuthProvider.kt
+++ b/domain/src/main/kotlin/core/domain/member/enums/OAuthProvider.kt
@@ -10,6 +10,7 @@ package core.domain.member.enums
  */
 enum class OAuthProvider {
     KAKAO,
+    APPLE,
     ;
 
     fun isProviderOf(provider: String): Boolean = this.name == provider

--- a/domain/src/main/kotlin/core/domain/member/port/outbound/MemberOAuthPersistencePort.kt
+++ b/domain/src/main/kotlin/core/domain/member/port/outbound/MemberOAuthPersistencePort.kt
@@ -2,10 +2,15 @@ package core.domain.member.port.outbound
 
 import core.domain.member.aggregate.Member
 import core.domain.member.aggregate.MemberOAuth
+import core.domain.member.enums.OAuthProvider
 
 interface MemberOAuthPersistencePort {
     fun save(
         memberOAuth: MemberOAuth,
         member: Member,
     )
+    fun findByProviderAndExternalId(
+        provider: OAuthProvider,
+        externalId: String,
+    ): MemberOAuth?
 }

--- a/domain/src/main/kotlin/core/domain/security/oauth/dto/AppleAuthAttributes.kt
+++ b/domain/src/main/kotlin/core/domain/security/oauth/dto/AppleAuthAttributes.kt
@@ -1,0 +1,19 @@
+package core.domain.security.oauth.dto
+
+import core.domain.member.enums.OAuthProvider
+
+class AppleAuthAttributes(
+    private val attributes: Map<String, Any>,
+) : OAuthAttributes {
+    override fun getExternalId(): String = attributes["sub"] as String
+
+    override fun getProvider(): OAuthProvider = OAuthProvider.APPLE
+
+    override fun getEmail(): String = attributes["email"] as String
+
+    override fun getName(): String = "Apple User" // Apple ID Token usually doesn't have name unless requested specifically in first login scope
+
+    companion object {
+        fun of(attributes: Map<String, Any>): AppleAuthAttributes = AppleAuthAttributes(attributes)
+    }
+}

--- a/domain/src/main/kotlin/core/domain/security/oauth/dto/OAuthAttributes.kt
+++ b/domain/src/main/kotlin/core/domain/security/oauth/dto/OAuthAttributes.kt
@@ -18,6 +18,7 @@ interface OAuthAttributes {
         ): OAuthAttributes? =
             when {
                 OAuthProvider.KAKAO.isProviderOf(providerId) -> KakaoAuthAttributes.of(attributes)
+                OAuthProvider.APPLE.isProviderOf(providerId) -> AppleAuthAttributes.of(attributes)
                 else -> null
             }
     }

--- a/entity/src/main/kotlin/core/entity/member/MemberOAuthEntity.kt
+++ b/entity/src/main/kotlin/core/entity/member/MemberOAuthEntity.kt
@@ -2,6 +2,9 @@ package core.entity.member
 
 import core.domain.member.aggregate.Member
 import core.domain.member.aggregate.MemberOAuth
+import core.domain.member.enums.OAuthProvider
+import core.domain.member.vo.MemberId
+import core.domain.member.vo.MemberOAuthId
 import jakarta.persistence.Column
 import jakarta.persistence.ConstraintMode
 import jakarta.persistence.Entity
@@ -29,6 +32,14 @@ class MemberOAuthEntity(
     @JoinColumn(name = "member_id", nullable = false, foreignKey = ForeignKey(ConstraintMode.NO_CONSTRAINT))
     val member: MemberEntity,
 ) {
+    fun toDomain(): MemberOAuth =
+        MemberOAuth(
+            id = MemberOAuthId(id),
+            externalId = externalId,
+            provider = OAuthProvider.valueOf(provider),
+            memberId = MemberId(member.id),
+        )
+
     companion object {
         fun of(
             memberOAuth: MemberOAuth,

--- a/persistence/src/main/kotlin/core/persistence/member/repository/oauth/MemberOAuthJpaRepository.kt
+++ b/persistence/src/main/kotlin/core/persistence/member/repository/oauth/MemberOAuthJpaRepository.kt
@@ -3,4 +3,9 @@ package core.persistence.member.repository.oauth
 import core.entity.member.MemberOAuthEntity
 import org.springframework.data.jpa.repository.JpaRepository
 
-interface MemberOAuthJpaRepository : JpaRepository<MemberOAuthEntity, Long>
+interface MemberOAuthJpaRepository : JpaRepository<MemberOAuthEntity, Long> {
+    fun findByProviderAndExternalId(
+        provider: String,
+        externalId: String,
+    ): MemberOAuthEntity?
+}

--- a/persistence/src/main/kotlin/core/persistence/member/repository/oauth/MemberOAuthRepository.kt
+++ b/persistence/src/main/kotlin/core/persistence/member/repository/oauth/MemberOAuthRepository.kt
@@ -2,6 +2,7 @@ package core.persistence.member.repository.oauth
 
 import core.domain.member.aggregate.Member
 import core.domain.member.aggregate.MemberOAuth
+import core.domain.member.enums.OAuthProvider
 import core.domain.member.port.outbound.MemberOAuthPersistencePort
 import core.entity.member.MemberOAuthEntity
 import org.springframework.stereotype.Repository
@@ -15,5 +16,12 @@ class MemberOAuthRepository(
         member: Member,
     ) {
         memberOAuthJpaRepository.save(MemberOAuthEntity.of(memberOAuth, member))
+    }
+
+    override fun findByProviderAndExternalId(
+        provider: OAuthProvider,
+        externalId: String,
+    ): MemberOAuth? {
+        return memberOAuthJpaRepository.findByProviderAndExternalId(provider.name, externalId)?.toDomain()
     }
 }


### PR DESCRIPTION
feat: Apple OAuth 로그인 기능 구현

# Summary

Apple OAuth 로그인 기능을 구현했습니다.

보안 정책 및 개인 키 관리 이슈로 인해, Kakao OAuth와 달리 클라이언트 → 서버 → Apple 구조로 인증 플로우를 설계했습니다.

관련 작업으로 closed #197

## Tasks

Apple OAuth 로그인 기능 구현

Apple 개인 키(.p8) 및 client_secret(JWT)을 서버에서만 생성·관리하도록 설계

OAuth 관련 설정을 환경 변수 기반으로 분리하여 환경별(dev/prod) 주입 가능하도록 구성

## ETC

로컬 환경에서는 Apple OAuth 테스트가 불가능합니다.

Apple 정책상 localhost, ngrok/grok 등의 임시 도메인은 Redirect URL 및 Domain validation 단계에서 허용되지 않습니다.

grok(http://localhost:8080 프록시)을 사용해 Apple Developer Console에 Redirect URL을 추가하려 했으나,
Domain not eligible 에러로 저장이 불가했습니다.

이에 따라 Apple OAuth 검증은 Developer 서버에 배포 후 진행합니다.

apple:
  client-id: ${LOCAL_APPLE_CLIENT_ID}
  key-id: ${LOCAL_APPLE_KEY_ID}
  team-id: ${LOCAL_APPLE_TEAM_ID}
  private-key-path: ${LOCAL_APPLE_PRIVATE_KEY_PATH}
  redirect-uri: ${LOCAL_APPLE_REDIRECT_URL}


위 Apple OAuth 관련 파라미터들은

Dev 환경: git-secret을 통해 주입하도록 CD flow를 변경했습니다.

운영 환경: 서버 환경 변수로 직접 설정 예정이며,
@wlsgussla123 님으로부터 운영용 .p8 키 전달받는 즉시 배포 진행하겠습니다.

Screenshot
<img width="1029" height="525" alt="image" src="https://github.com/user-attachments/assets/1adc20fe-7655-498f-a959-f24164122959" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * Apple 로그인 지원: 사용자가 Apple 계정을 통해 애플리케이션에 로그인할 수 있는 기능이 추가되었습니다.

* **테스트**
  * Apple 인증 플로우에 대한 테스트 케이스 추가

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->