### PR TITLE
add response field (memberId, cohortId)

### DIFF
--- a/application/src/main/kotlin/core/application/member/presentation/controller/MemberApi.kt
+++ b/application/src/main/kotlin/core/application/member/presentation/controller/MemberApi.kt
@@ -76,12 +76,16 @@ interface MemberApi {
                                 "data": {
                                     "members": [
                                         {
+                                            "memberId": 1,
+                                            "cohortId": 17,
                                             "name": "홍길동",
                                             "teamName": "1팀",
                                             "status": "PENDING",
                                             "part": "UNASSIGNED"
                                         },
                                         {
+                                            "memberId": 2,
+                                            "cohortId": 17,
                                             "name": "김철수",
                                             "teamName": "2팀",
                                             "status": "ACTIVE",

--- a/application/src/main/kotlin/core/application/member/presentation/controller/MemberController.kt
+++ b/application/src/main/kotlin/core/application/member/presentation/controller/MemberController.kt
@@ -57,6 +57,8 @@ class MemberController(
             MemberOverviewResponse.of(
                 memberQueryService.getMembersOverview().map { member ->
                     MemberOverviewResponse.MemberSummary(
+                        memberId = member.memberId,
+                        cohortId = member.cohortId,
                         name = member.name,
                         teamName = member.teamNumber?.let { "${it}팀" } ?: "미배정",
                         status = member.status,

--- a/application/src/main/kotlin/core/application/member/presentation/response/MemberOverviewResponse.kt
+++ b/application/src/main/kotlin/core/application/member/presentation/response/MemberOverviewResponse.kt
@@ -7,6 +7,10 @@ data class MemberOverviewResponse(
     val members: List<MemberSummary>,
 ) {
     data class MemberSummary(
+        @field:Schema(description = "멤버 ID", example = "1")
+        val memberId: Long,
+        @field:Schema(description = "기수 ID", example = "17")
+        val cohortId: Long?,
         @field:Schema(description = "멤버 이름", example = "홍길동")
         val name: String,
         @field:Schema(description = "팀 이름", example = "1팀")

--- a/domain/src/main/kotlin/core/domain/member/port/outbound/query/MemberOverviewQueryModel.kt
+++ b/domain/src/main/kotlin/core/domain/member/port/outbound/query/MemberOverviewQueryModel.kt
@@ -1,6 +1,8 @@
 package core.domain.member.port.outbound.query
 
 data class MemberOverviewQueryModel(
+    val memberId: Long,
+    val cohortId: Long?,
     val name: String,
     val teamNumber: Int?,
     val status: String,

--- a/persistence/src/main/kotlin/core/persistence/member/repository/MemberRepository.kt
+++ b/persistence/src/main/kotlin/core/persistence/member/repository/MemberRepository.kt
@@ -153,10 +153,12 @@ class MemberRepository(
 
         return dsl
             .select(
+                MEMBERS.MEMBER_ID,
                 MEMBERS.NAME,
                 MEMBERS.STATUS,
                 MEMBERS.PART,
                 maxCohortValue,
+                MEMBER_COHORTS.COHORT_ID,
                 maxTeamNumber,
             )
             .from(MEMBERS)
@@ -174,6 +176,7 @@ class MemberRepository(
                 MEMBERS.NAME,
                 MEMBERS.STATUS,
                 MEMBERS.PART,
+                MEMBER_COHORTS.COHORT_ID,
             )
             .orderBy(
                 maxCohortValue.desc().nullsLast(),
@@ -182,6 +185,8 @@ class MemberRepository(
             )
             .fetch { record ->
                 MemberOverviewQueryModel(
+                    memberId = requireNotNull(record[MEMBERS.MEMBER_ID]),
+                    cohortId = record[MEMBER_COHORTS.COHORT_ID],
                     name = record[MEMBERS.NAME] ?: "",
                     teamNumber = record[maxTeamNumber],
                     status = record[MEMBERS.STATUS] ?: "",


### PR DESCRIPTION
## Summary

- closed #390 
add response field (memberId, cohortId)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 변경 사항

* **새로운 기능**
  * 회원 목록 조회 API 응답에 각 회원의 회원 ID와 코호트 ID 정보가 포함되도록 개선되었습니다.

* **문서화**
  * API 응답 스키마가 새로 추가된 필드를 반영하도록 업데이트되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->