### PR TITLE
Fix : 출석 지각, 결석 시간 적용

### DIFF
--- a/application/src/main/kotlin/core/application/afterParty/application/service/AfterPartyCommandService.kt
+++ b/application/src/main/kotlin/core/application/afterParty/application/service/AfterPartyCommandService.kt
@@ -2,9 +2,8 @@ package core.application.afterParty.application.service
 
 import core.application.afterParty.application.exception.AfterPartyNotFoundException
 import core.application.afterParty.application.exception.InviteTagNameNotFoundException
-import core.application.member.application.service.authority.MemberAuthorityService
-import core.application.afterParty.presentation.response.AfterPartyInviteeCompensationResponse
 import core.application.member.application.exception.MemberNotFoundException
+import core.application.member.application.service.authority.MemberAuthorityService
 import core.domain.afterParty.aggregate.AfterParty
 import core.domain.afterParty.aggregate.AfterPartyInviteTag
 import core.domain.afterParty.aggregate.AfterPartyInvitee
@@ -12,16 +11,16 @@ import core.domain.afterParty.enums.AfterPartyInviteTagEnum
 import core.domain.afterParty.port.inbound.AfterPartyCommandUseCase
 import core.domain.afterParty.port.inbound.AfterPartyInviteTagQueryUseCase
 import core.domain.afterParty.port.inbound.AfterPartyInviteeCommandUseCase
-import core.domain.afterParty.port.outbound.AfterPartyInviteePersistencePort
 import core.domain.afterParty.port.outbound.AfterPartyInviteTagPersistencePort
+import core.domain.afterParty.port.outbound.AfterPartyInviteePersistencePort
 import core.domain.afterParty.port.outbound.AfterPartyPersistencePort
 import core.domain.authorization.vo.RoleType
 import core.domain.cohort.port.outbound.CohortPersistencePort
 import core.domain.cohort.vo.CohortId
 import core.domain.member.aggregate.Member
 import core.domain.member.aggregate.MemberCohort
-import core.domain.member.port.inbound.MemberQueryUseCase
 import core.domain.member.enums.MemberStatus
+import core.domain.member.port.inbound.MemberQueryUseCase
 import core.domain.member.vo.MemberId
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional

--- a/application/src/main/kotlin/core/application/member/application/service/MemberQueryService.kt
+++ b/application/src/main/kotlin/core/application/member/application/service/MemberQueryService.kt
@@ -10,11 +10,11 @@ import core.domain.authorization.vo.RoleId
 import core.domain.cohort.port.inbound.CohortQueryUseCase
 import core.domain.cohort.vo.CohortId
 import core.domain.member.aggregate.Member
-import core.domain.member.port.outbound.query.MemberOverviewQueryModel
 import core.domain.member.port.inbound.MemberQueryByRoleUseCase
 import core.domain.member.port.inbound.MemberQueryUseCase
 import core.domain.member.port.outbound.MemberPersistencePort
 import core.domain.member.port.outbound.query.MemberNameRoleQueryModel
+import core.domain.member.port.outbound.query.MemberOverviewQueryModel
 import core.domain.member.vo.MemberId
 import core.domain.team.vo.TeamId
 import org.springframework.beans.factory.annotation.Value
@@ -68,8 +68,7 @@ class MemberQueryService(
         memberPersistencePort
             .findAllByCohort(value)
 
-    fun getMembersByCohortId(cohortId: CohortId): List<MemberId> =
-        memberPersistencePort.findAllByCohortId(cohortId)
+    fun getMembersByCohortId(cohortId: CohortId): List<MemberId> = memberPersistencePort.findAllByCohortId(cohortId)
 
     /**
      * 멤버의 식별자를 기반으로 해당 멤버의 팀 번호를 조회함.
@@ -83,9 +82,7 @@ class MemberQueryService(
         memberPersistencePort.findMemberTeamByMemberId(memberId)
             ?: defaultTeamId
 
-    fun checkWhiteList(
-        email: String,
-    ): Member? = memberPersistencePort.findBySignupEmail(email)
+    fun checkWhiteList(email: String): Member? = memberPersistencePort.findBySignupEmail(email)
 
     fun getMembersOverview(latest: Boolean?): List<MemberOverviewQueryModel> =
         memberPersistencePort.findAllOrderedByHighestCohortAndStatus(

--- a/application/src/main/kotlin/core/application/member/presentation/controller/MemberApi.kt
+++ b/application/src/main/kotlin/core/application/member/presentation/controller/MemberApi.kt
@@ -11,10 +11,10 @@ import core.application.security.annotation.CurrentMemberId
 import core.domain.cohort.vo.CohortId
 import core.domain.member.vo.MemberId
 import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.Parameter
 import io.swagger.v3.oas.annotations.media.Content
 import io.swagger.v3.oas.annotations.media.ExampleObject
 import io.swagger.v3.oas.annotations.media.Schema
-import io.swagger.v3.oas.annotations.Parameter
 import io.swagger.v3.oas.annotations.parameters.RequestBody
 import io.swagger.v3.oas.annotations.responses.ApiResponse
 import io.swagger.v3.oas.annotations.tags.Tag

--- a/application/src/main/kotlin/core/application/session/application/service/SessionQueryService.kt
+++ b/application/src/main/kotlin/core/application/session/application/service/SessionQueryService.kt
@@ -52,11 +52,10 @@ class SessionQueryService(
         sessionPersistencePort.findSessionById(sessionId.value)
             ?: throw SessionNotFoundException()
 
-    fun getAttendanceTime(sessionId: SessionId): Instant =
+    fun getAttendancePolicy(sessionId: SessionId): AttendancePolicy =
         sessionPersistencePort
             .findSessionById(sessionId.value)
             ?.attendancePolicy
-            ?.attendanceStart
             ?: throw SessionNotFoundException()
 
     fun getSessionWeeks(): List<SessionWeekQueryModel> {

--- a/application/src/main/kotlin/core/application/session/presentation/controller/SessionQueryController.kt
+++ b/application/src/main/kotlin/core/application/session/presentation/controller/SessionQueryController.kt
@@ -65,7 +65,7 @@ class SessionQueryController(
     ): CustomResponse<AttendanceTimeResponse> {
         val response =
             sessionQueryService
-                .getAttendanceTime(sessionId)
+                .getAttendancePolicy(sessionId)
                 .let { SessionMapper.toAttendanceTimeResponse(it) }
 
         return CustomResponse.ok(response)

--- a/application/src/main/kotlin/core/application/session/presentation/mapper/SessionMapper.kt
+++ b/application/src/main/kotlin/core/application/session/presentation/mapper/SessionMapper.kt
@@ -16,8 +16,8 @@ import core.domain.session.port.inbound.command.SessionAttendancePolicyCommand
 import core.domain.session.port.inbound.command.SessionCreateCommand
 import core.domain.session.port.inbound.command.SessionUpdateCommand
 import core.domain.session.port.inbound.query.SessionWeekQueryModel
+import core.domain.session.vo.AttendancePolicy
 import core.domain.session.vo.SessionId
-import java.time.Instant
 import java.time.LocalDateTime
 
 object SessionMapper {
@@ -73,10 +73,12 @@ object SessionMapper {
             )
         }
 
-    fun toAttendanceTimeResponse(attendanceStartTime: Instant) =
+    fun toAttendanceTimeResponse(attendancePolicy: AttendancePolicy) =
         AttendanceTimeResponse(
             attendanceStartTime =
-                instantToLocalDateTime(attendanceStartTime),
+                instantToLocalDateTime(attendancePolicy.attendanceStart),
+            attendanceLateTime = instantToLocalDateTime(attendancePolicy.lateStart),
+            attendanceAbsentTime = instantToLocalDateTime(attendancePolicy.absentStart),
         )
 
     fun toSessionCreateCommand(request: SessionCreateRequest) =

--- a/application/src/main/kotlin/core/application/session/presentation/response/AttendanceTimeResponse.kt
+++ b/application/src/main/kotlin/core/application/session/presentation/response/AttendanceTimeResponse.kt
@@ -4,4 +4,6 @@ import java.time.LocalDateTime
 
 data class AttendanceTimeResponse(
     val attendanceStartTime: LocalDateTime,
+    val attendanceLateTime: LocalDateTime,
+    val attendanceAbsentTime: LocalDateTime,
 )

--- a/domain/src/main/kotlin/core/domain/member/port/outbound/MemberPersistencePort.kt
+++ b/domain/src/main/kotlin/core/domain/member/port/outbound/MemberPersistencePort.kt
@@ -3,8 +3,8 @@ package core.domain.member.port.outbound
 import core.domain.authorization.vo.RoleId
 import core.domain.cohort.vo.CohortId
 import core.domain.member.aggregate.Member
-import core.domain.member.port.outbound.query.MemberOverviewQueryModel
 import core.domain.member.port.outbound.query.MemberNameRoleQueryModel
+import core.domain.member.port.outbound.query.MemberOverviewQueryModel
 import core.domain.member.vo.MemberId
 
 interface MemberPersistencePort {

--- a/domain/src/main/kotlin/core/domain/session/aggregate/Session.kt
+++ b/domain/src/main/kotlin/core/domain/session/aggregate/Session.kt
@@ -9,7 +9,6 @@ import core.domain.session.vo.AttendancePolicy
 import core.domain.session.vo.SessionId
 import java.time.Instant
 import java.time.ZoneId
-import java.time.temporal.ChronoUnit
 import kotlin.random.Random
 
 /**
@@ -65,10 +64,8 @@ class Session(
     private fun determineAttendanceStatus(now: Instant): AttendanceResult =
         when {
             now.isBefore(attendancePolicy.attendanceStart) -> AttendanceResult.TooEarly
-            now.isBefore(attendancePolicy.attendanceStart.plus(16, ChronoUnit.MINUTES)) ->
-                AttendanceResult.Success(AttendanceStatus.PRESENT)
-            now.isBefore(attendancePolicy.attendanceStart.plus(31, ChronoUnit.MINUTES)) ->
-                AttendanceResult.Success(AttendanceStatus.LATE)
+            now.isBefore(attendancePolicy.lateStart) -> AttendanceResult.Success(AttendanceStatus.PRESENT)
+            now.isBefore(attendancePolicy.absentStart) -> AttendanceResult.Success(AttendanceStatus.LATE)
             else -> AttendanceResult.Success(AttendanceStatus.ABSENT)
         }
 

--- a/domain/src/main/kotlin/core/domain/session/event/SessionCreateEvent.kt
+++ b/domain/src/main/kotlin/core/domain/session/event/SessionCreateEvent.kt
@@ -1,7 +1,7 @@
 package core.domain.session.event
 
-import core.domain.session.vo.SessionId
 import core.domain.cohort.vo.CohortId
+import core.domain.session.vo.SessionId
 
 data class SessionCreateEvent(
     val sessionId: SessionId,

--- a/persistence/src/main/kotlin/core/persistence/member/repository/MemberRepository.kt
+++ b/persistence/src/main/kotlin/core/persistence/member/repository/MemberRepository.kt
@@ -6,8 +6,8 @@ import core.domain.member.aggregate.Member
 import core.domain.member.enums.MemberPart
 import core.domain.member.enums.MemberStatus
 import core.domain.member.port.outbound.MemberPersistencePort
-import core.domain.member.port.outbound.query.MemberOverviewQueryModel
 import core.domain.member.port.outbound.query.MemberNameRoleQueryModel
+import core.domain.member.port.outbound.query.MemberOverviewQueryModel
 import core.domain.member.vo.MemberId
 import core.entity.member.MemberEntity
 import org.jooq.DSLContext
@@ -18,13 +18,13 @@ import org.jooq.dsl.tables.references.MEMBER_ROLES
 import org.jooq.dsl.tables.references.MEMBER_TEAMS
 import org.jooq.dsl.tables.references.ROLES
 import org.jooq.dsl.tables.references.TEAMS
-import org.jooq.impl.DSL.field
 import org.jooq.impl.DSL.exists
+import org.jooq.impl.DSL.field
 import org.jooq.impl.DSL.max
 import org.jooq.impl.DSL.name
 import org.jooq.impl.DSL.selectOne
-import org.jooq.impl.DSL.`when`
 import org.jooq.impl.DSL.table
+import org.jooq.impl.DSL.`when`
 import org.springframework.stereotype.Repository
 import java.time.LocalDateTime
 import java.time.ZoneId


### PR DESCRIPTION
## Summary

>- #429 close

<!-- 해당 PR에 대한 요약을 작성해주세요. -->

## Tasks

- 지각, 결석 시간 적용 로직 수정(실제 입력한 값 사용하도록)
- 출석 시간 조회 시 출석, 지각, 결석 시간 내려주도록 변경

## ETC

<!-- 추가적인 정보나 참고 사항을 작성해주세요. -->

## Screenshot

<!-- (없을 경우 삭제) 작업한 내용에 대한 스크린샷을 첨부해주세요._ -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **개선 사항**
  * 세션 출석 정책 조회 API가 확장되어 출석 시작 시간, 지각 시간, 결석 시간을 모두 제공합니다.
  * 출석 상태 판정 로직이 정책 기반 임계값으로 개선되어 더 정확한 출석 상태 판정이 가능합니다.

* **기타**
  * 코드 정렬 및 포맷팅 최적화가 진행되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->