### PR TITLE
feat : 지정한 멤버에게 과제 제출 요청 푸시 알림 발송 구현

### DIFF
--- a/application/src/main/kotlin/core/application/announcement/application/event/AnnouncementNotificationListener.kt
+++ b/application/src/main/kotlin/core/application/announcement/application/event/AnnouncementNotificationListener.kt
@@ -6,6 +6,7 @@ import core.application.member.application.service.MemberQueryService
 import core.domain.announcement.enums.AnnouncementType
 import core.domain.announcement.event.AnnouncementCreatedEvent
 import core.domain.announcement.event.AnnouncementRemindEvent
+import core.domain.announcement.event.AnnouncementRemindToMembersEvent
 import core.domain.announcement.vo.AnnouncementId
 import core.domain.member.vo.MemberId
 import core.domain.notification.enums.NotificationMessageType
@@ -43,7 +44,7 @@ class AnnouncementNotificationListener(
 
     @Async
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
-    fun createdEventHandle(announcementRemindEvent: AnnouncementRemindEvent) {
+    fun remindEventHandle(announcementRemindEvent: AnnouncementRemindEvent) {
         val messageType: NotificationMessageType =
             when (announcementRemindEvent.announcement.announcementType) {
                 AnnouncementType.GENERAL -> NotificationMessageType.ANNOUNCEMENT_REMIND
@@ -69,6 +70,17 @@ class AnnouncementNotificationListener(
             messageType = messageType,
             variables = mapOf("title" to announcementRemindEvent.announcement.title),
             data = mapOf("announcementId" to announcementRemindEvent.announcement.id!!.value),
+        )
+    }
+
+    @Async
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    fun remindToMembersEventHandle(announcementRemindToMembersEvent: AnnouncementRemindToMembersEvent) {
+        notificationCommandUseCase.sendPushNotificationToMembers(
+            memberIds = announcementRemindToMembersEvent.memberIds,
+            messageType = NotificationMessageType.ASSIGNMENT_SUBMIT_REQUEST_TO_MEMBERS,
+            variables = mapOf("title" to announcementRemindToMembersEvent.announcement.title),
+            data = mapOf("announcementId" to announcementRemindToMembersEvent.announcement.id!!.value),
         )
     }
 }

--- a/application/src/main/kotlin/core/application/announcement/application/service/AnnouncementCommandService.kt
+++ b/application/src/main/kotlin/core/application/announcement/application/service/AnnouncementCommandService.kt
@@ -3,6 +3,7 @@ package core.application.announcement.application.service
 import core.application.announcement.application.exception.AnnouncementNotFoundException
 import core.application.announcement.application.exception.AnnouncementTypeCannotBeChangedException
 import core.application.announcement.application.exception.AssignmentSubmitTypeNotNullException
+import core.application.announcement.application.exception.NotAnAssignmentException
 import core.domain.announcement.aggregate.Announcement
 import core.domain.announcement.aggregate.AnnouncementAssignment
 import core.domain.announcement.aggregate.AnnouncementRead
@@ -265,6 +266,8 @@ class AnnouncementCommandService(
         memberIds: List<MemberId>,
     ) {
         val targetAnnouncement: Announcement = announcementQueryUseCase.getAnnouncementById(announcementId)
+        if (targetAnnouncement.announcementType != AnnouncementType.ASSIGNMENT) throw NotAnAssignmentException()
+
         eventPublisher.publishEvent(
             AnnouncementRemindToMembersEvent.of(
                 announcement = targetAnnouncement,

--- a/application/src/main/kotlin/core/application/announcement/application/service/AnnouncementCommandService.kt
+++ b/application/src/main/kotlin/core/application/announcement/application/service/AnnouncementCommandService.kt
@@ -13,6 +13,7 @@ import core.domain.announcement.enums.SubmitStatus
 import core.domain.announcement.enums.SubmitType
 import core.domain.announcement.event.AnnouncementCreatedEvent
 import core.domain.announcement.event.AnnouncementRemindEvent
+import core.domain.announcement.event.AnnouncementRemindToMembersEvent
 import core.domain.announcement.port.inbound.AnnouncementAssignmentCommandUseCase
 import core.domain.announcement.port.inbound.AnnouncementCommandUseCase
 import core.domain.announcement.port.inbound.AnnouncementQueryUseCase
@@ -255,6 +256,19 @@ class AnnouncementCommandService(
             AnnouncementRemindEvent.of(
                 announcement = targetAnnouncement,
                 cohortId = cohortQueryUseCase.getLatestCohortId(),
+            ),
+        )
+    }
+
+    override fun remindNotificationToMembers(
+        announcementId: AnnouncementId,
+        memberIds: List<MemberId>,
+    ) {
+        val targetAnnouncement: Announcement = announcementQueryUseCase.getAnnouncementById(announcementId)
+        eventPublisher.publishEvent(
+            AnnouncementRemindToMembersEvent.of(
+                announcement = targetAnnouncement,
+                memberIds = memberIds,
             ),
         )
     }

--- a/application/src/main/kotlin/core/application/announcement/presentation/controller/AnnouncementCommandApi.kt
+++ b/application/src/main/kotlin/core/application/announcement/presentation/controller/AnnouncementCommandApi.kt
@@ -1,6 +1,7 @@
 package core.application.announcement.presentation.controller
 
 import core.application.announcement.presentation.request.CreateAnnouncementRequest
+import core.application.announcement.presentation.request.RemindNotificationToMembersRequest
 import core.application.announcement.presentation.request.UpdateAnnouncementRequest
 import core.application.announcement.presentation.request.UpdateSubmitStatusRequest
 import core.application.common.exception.CustomResponse
@@ -87,4 +88,17 @@ interface AnnouncementCommandApi {
         description = "공지나 과제의 리마인드 알림을 발송하는 API입니다",
     )
     fun remindNotification(announcementId: AnnouncementId): CustomResponse<Void>
+
+    @ApiResponse(
+        responseCode = "200",
+        description = "지정된 디퍼들에게 공지/과제 리마인드 알림 성공",
+    )
+    @Operation(
+        summary = "지정된 디퍼들에게 공지/과제 리마인드 알림 API",
+        description = "지정된 디퍼들에게 공지나 과제의 리마인드 알림을 발송하는 API입니다",
+    )
+    fun remindNotificationToMembers(
+        announcementId: AnnouncementId,
+        remindNotificationToMembersRequest: RemindNotificationToMembersRequest,
+    ): CustomResponse<Void>
 }

--- a/application/src/main/kotlin/core/application/announcement/presentation/controller/AnnouncementCommandController.kt
+++ b/application/src/main/kotlin/core/application/announcement/presentation/controller/AnnouncementCommandController.kt
@@ -2,6 +2,7 @@ package core.application.announcement.presentation.controller
 
 import core.application.announcement.application.service.AnnouncementCommandService
 import core.application.announcement.presentation.request.CreateAnnouncementRequest
+import core.application.announcement.presentation.request.RemindNotificationToMembersRequest
 import core.application.announcement.presentation.request.UpdateAnnouncementRequest
 import core.application.announcement.presentation.request.UpdateSubmitStatusRequest
 import core.application.common.converter.TimeMapper.localDateTimeToInstant
@@ -114,6 +115,18 @@ class AnnouncementCommandController(
         @PathVariable announcementId: AnnouncementId,
     ): CustomResponse<Void> {
         announcementCommandService.remindNotification(announcementId)
+        return CustomResponse.ok()
+    }
+
+    @PostMapping("/{announcementId}/remind-notification-to-members")
+    override fun remindNotificationToMembers(
+        @PathVariable announcementId: AnnouncementId,
+        @RequestBody remindNotificationToMembersRequest: RemindNotificationToMembersRequest,
+    ): CustomResponse<Void> {
+        announcementCommandService.remindNotificationToMembers(
+            announcementId = announcementId,
+            memberIds = remindNotificationToMembersRequest.memberIds,
+        )
         return CustomResponse.ok()
     }
 }

--- a/application/src/main/kotlin/core/application/announcement/presentation/request/RemindNotificationToMembersRequest.kt
+++ b/application/src/main/kotlin/core/application/announcement/presentation/request/RemindNotificationToMembersRequest.kt
@@ -1,0 +1,7 @@
+package core.application.announcement.presentation.request
+
+import core.domain.member.vo.MemberId
+
+data class RemindNotificationToMembersRequest(
+    val memberIds: List<MemberId>,
+)

--- a/domain/src/main/kotlin/core/domain/announcement/event/AnnouncementRemindToMembersEvent.kt
+++ b/domain/src/main/kotlin/core/domain/announcement/event/AnnouncementRemindToMembersEvent.kt
@@ -1,0 +1,20 @@
+package core.domain.announcement.event
+
+import core.domain.announcement.aggregate.Announcement
+import core.domain.member.vo.MemberId
+
+data class AnnouncementRemindToMembersEvent(
+    val announcement: Announcement,
+    val memberIds: List<MemberId>,
+) {
+    companion object {
+        fun of(
+            announcement: Announcement,
+            memberIds: List<MemberId>,
+        ): AnnouncementRemindToMembersEvent =
+            AnnouncementRemindToMembersEvent(
+                announcement = announcement,
+                memberIds = memberIds,
+            )
+    }
+}

--- a/domain/src/main/kotlin/core/domain/announcement/port/inbound/AnnouncementCommandUseCase.kt
+++ b/domain/src/main/kotlin/core/domain/announcement/port/inbound/AnnouncementCommandUseCase.kt
@@ -55,4 +55,9 @@ interface AnnouncementCommandUseCase {
     )
 
     fun remindNotification(announcementId: AnnouncementId)
+
+    fun remindNotificationToMembers(
+        announcementId: AnnouncementId,
+        memberIds: List<MemberId>,
+    )
 }

--- a/domain/src/main/kotlin/core/domain/notification/enums/NotificationMessageType.kt
+++ b/domain/src/main/kotlin/core/domain/notification/enums/NotificationMessageType.kt
@@ -45,6 +45,11 @@ enum class NotificationMessageType(
         bodyTemplate = "{title}",
         description = "과제 미제출자 제출요청 알림",
     ),
+    ASSIGNMENT_SUBMIT_REQUEST_TO_MEMBERS(
+        title = "과제를 제출해주세요!",
+        bodyTemplate = "{title}",
+        description = "선택한 멤버 과제 제출요청 알림",
+    ),
     ASSIGNMENT_DUE_24H(
         title = "과제 제출까지 하루 남았어요.",
         bodyTemplate = "잊으신 건 아니죠? 내일 이 시간은 과제 제출 마감이에요. 미리 확인해 보세요!",


### PR DESCRIPTION
## Summary

>- #454 close

<!-- 해당 PR에 대한 요약을 작성해주세요. -->

## Tasks

- 지정한 멤버에게 과제 제출 요청 푸시 알림 구현

## ETC

<!-- 추가적인 정보나 참고 사항을 작성해주세요. -->

## Screenshot

<!-- (없을 경우 삭제) 작업한 내용에 대한 스크린샷을 첨부해주세요._ -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 공지사항 상기 알림을 특정 멤버에게 직접 발송 가능
  * 선택한 멤버에게 알림을 보낼 수 있는 신규 API 엔드포인트 추가
  * 멤버 대상 과제 제출 요청 알림(ASSIGNMENT_SUBMIT_REQUEST_TO_MEMBERS) 유형 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->