### PR TITLE
refactor : 회식, 공지 멤버 조회 속도 개선(N+1, DB 배치 조회)

### DIFF
--- a/application/src/main/kotlin/core/application/afterParty/application/service/invitee/AfterPartyInviteeQueryService.kt
+++ b/application/src/main/kotlin/core/application/afterParty/application/service/invitee/AfterPartyInviteeQueryService.kt
@@ -13,8 +13,10 @@ import core.domain.member.aggregate.Member
 import core.domain.member.vo.MemberId
 import core.domain.team.vo.TeamNumber
 import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
 
 @Service
+@Transactional(readOnly = true)
 class AfterPartyInviteeQueryService(
     val afterPartyInviteePersistencePort: AfterPartyInviteePersistencePort,
     val memberQueryService: MemberQueryService,
@@ -49,16 +51,25 @@ class AfterPartyInviteeQueryService(
                 rsvpMemberIds,
                 currentCohortValue,
             )
+        val rsvpStatusByMemberId: Map<MemberId, Boolean?> = invitees.associate { it.memberId to it.rsvpStatus }
 
-        return inviteeMember.map { member ->
-            AfterPartyRsvpMemberResponse(
-                memberId = member.id!!,
-                name = member.name,
-                part = member.part,
-                teamNumber = rsvpMemberTeamNumberMap[member.id!!] ?: TeamNumber(0),
-                isAdmin = retrievedMemberAdminMap[member.id!!] ?: false,
-                rsvpStatus = invitees.find { it.memberId == member.id!! }?.rsvpStatus,
+        return inviteeMember
+            .map { member ->
+                AfterPartyRsvpMemberResponse(
+                    memberId = member.id!!,
+                    name = member.name,
+                    part = member.part,
+                    teamNumber = rsvpMemberTeamNumberMap[member.id!!] ?: TeamNumber.defaultValue(),
+                    isAdmin = retrievedMemberAdminMap[member.id!!] ?: false,
+                    rsvpStatus = rsvpStatusByMemberId[member.id!!],
+                )
+            }.sortedWith(
+                compareByDescending<AfterPartyRsvpMemberResponse> { it.rsvpStatus == true }
+                    .thenBy { it.teamNumber.value == 0 }
+                    .thenByDescending { it.rsvpStatus == false }
+                    .thenByDescending { it.isAdmin }
+                    .thenBy { it.teamNumber.value }
+                    .thenBy { it.name },
             )
-        }
     }
 }

--- a/application/src/main/kotlin/core/application/afterParty/application/service/invitee/AfterPartyInviteeQueryService.kt
+++ b/application/src/main/kotlin/core/application/afterParty/application/service/invitee/AfterPartyInviteeQueryService.kt
@@ -8,6 +8,7 @@ import core.domain.afterParty.aggregate.AfterPartyInvitee
 import core.domain.afterParty.port.inbound.AfterPartyInviteeQueryUseCase
 import core.domain.afterParty.port.outbound.AfterPartyInviteePersistencePort
 import core.domain.afterParty.vo.AfterPartyId
+import core.domain.cohort.port.inbound.CohortQueryUseCase
 import core.domain.member.aggregate.Member
 import core.domain.member.vo.MemberId
 import core.domain.team.vo.TeamNumber
@@ -18,6 +19,7 @@ class AfterPartyInviteeQueryService(
     val afterPartyInviteePersistencePort: AfterPartyInviteePersistencePort,
     val memberQueryService: MemberQueryService,
     val memberAccessService: MemberAccessService,
+    val cohortQueryUseCase: CohortQueryUseCase,
 ) : AfterPartyInviteeQueryUseCase {
     override fun getInviteesByAfterPartyId(afterPartyId: AfterPartyId): List<AfterPartyInvitee> =
         afterPartyInviteePersistencePort.findByAfterPartyId(afterPartyId)
@@ -32,18 +34,31 @@ class AfterPartyInviteeQueryService(
         )
             ?: throw AfterPartyMemberNotFoundException()
 
-    fun getRsvpMembers(afterPartyId: AfterPartyId): List<AfterPartyRsvpMemberResponse> =
-        getInviteesByAfterPartyId(afterPartyId).map { invitee ->
-            val rsvpMember: Member = memberQueryService.getMemberById(invitee.memberId)
-            val rsvpMemberTeamNumber: TeamNumber = memberQueryService.getMemberTeamNumber(invitee.memberId)
-            val isAdmin: Boolean = memberAccessService.isAdmin(invitee.memberId)
+    fun getRsvpMembers(afterPartyId: AfterPartyId): List<AfterPartyRsvpMemberResponse> {
+        val currentCohortValue: String = cohortQueryUseCase.getLatestCohortValue()
+
+        val invitees: List<AfterPartyInvitee> = getInviteesByAfterPartyId(afterPartyId = afterPartyId)
+        val inviteeMember: List<Member> = memberQueryService.getMembersByIds(invitees.map { it.memberId })
+        val rsvpMemberIds: List<MemberId> = inviteeMember.map { it.id!! }
+        val rsvpMemberTeamNumberMap: Map<MemberId, TeamNumber> =
+            memberQueryService.getMemberTeamNumberByMemberIds(
+                rsvpMemberIds,
+            )
+        val retrievedMemberAdminMap: Map<MemberId, Boolean> =
+            memberAccessService.getIsAdminByMemberIds(
+                rsvpMemberIds,
+                currentCohortValue,
+            )
+
+        return inviteeMember.map { member ->
             AfterPartyRsvpMemberResponse(
-                memberId = rsvpMember.id ?: throw AfterPartyMemberNotFoundException(),
-                name = rsvpMember.name,
-                part = rsvpMember.part,
-                teamNumber = rsvpMemberTeamNumber,
-                isAdmin = isAdmin,
-                rsvpStatus = invitee.rsvpStatus,
+                memberId = member.id!!,
+                name = member.name,
+                part = member.part,
+                teamNumber = rsvpMemberTeamNumberMap[member.id!!] ?: TeamNumber(0),
+                isAdmin = retrievedMemberAdminMap[member.id!!] ?: false,
+                rsvpStatus = invitees.find { it.memberId == member.id!! }?.rsvpStatus,
             )
         }
+    }
 }

--- a/application/src/main/kotlin/core/application/announcement/application/service/AnnouncementQueryService.kt
+++ b/application/src/main/kotlin/core/application/announcement/application/service/AnnouncementQueryService.kt
@@ -26,6 +26,7 @@ import core.domain.announcement.port.outbound.AnnouncementPersistencePort
 import core.domain.announcement.port.outbound.query.AnnouncementListItemQueryModel
 import core.domain.announcement.vo.AnnouncementId
 import core.domain.announcement.vo.AssignmentId
+import core.domain.cohort.port.inbound.CohortQueryUseCase
 import core.domain.member.aggregate.Member
 import core.domain.member.port.inbound.MemberQueryUseCase
 import core.domain.member.vo.MemberId
@@ -43,6 +44,7 @@ class AnnouncementQueryService(
     val assignmentQueryUseCase: AssignmentQueryUseCase,
     val memberQueryUseCase: MemberQueryUseCase,
     val memberAccessService: MemberAccessService,
+    val cohortQueryUseCase: CohortQueryUseCase,
 ) : AnnouncementQueryUseCase {
     fun getAllAnnouncements(): AnnouncementListResponse {
         val announcementListItemQueryModels: List<AnnouncementListItemQueryModel> =
@@ -122,30 +124,35 @@ class AnnouncementQueryService(
 
     fun getAnnouncementReadMemberList(announcementId: AnnouncementId): AnnouncementViewMemberListResponse {
         val announcementReads: List<AnnouncementRead> = announcementReadQueryUseCase.getByAnnouncementId(announcementId)
+        val announcementReadMemberIds: List<MemberId> = announcementReads.map { it.memberId }
+        val currentCohort: String = cohortQueryUseCase.getLatestCohortValue()
 
-        val readMemberIds: List<MemberId> =
-            announcementReads.filter { it.isRead() }.map { it.memberId }
-        val readMembers: List<Member> = memberQueryUseCase.getMembersByIds(readMemberIds)
-        val readMemberItems: List<AnnouncementViewMemberListItemResponse> =
-            readMembers.map { readMember ->
-                val teamNumber: TeamNumber = memberQueryUseCase.getMemberTeamNumber(readMember.id!!)
-                val isAdmin: Boolean = memberAccessService.isAdmin(readMember.id!!)
-                AnnouncementViewMemberListItemResponse.of(readMember, teamNumber, isAdmin)
-            }
+        val retrievedMembers: List<Member> = memberQueryUseCase.getMembersByIds(announcementReadMemberIds)
+        val retrievedMemberTeamNumberMap: Map<MemberId, TeamNumber> =
+            memberQueryUseCase.getMemberTeamNumberByMemberIds(
+                announcementReadMemberIds,
+            )
+        val retrievedMemberAdminMap: Map<MemberId, Boolean> =
+            memberAccessService.getIsAdminByMemberIds(
+                memberIds = announcementReadMemberIds,
+                cohortValue = currentCohort,
+            )
 
-        val unreadMemberIds: List<MemberId> =
-            announcementReads.filter { !it.isRead() }.map { it.memberId }
-        val unreadMembers: List<Member> = memberQueryUseCase.getMembersByIds(unreadMemberIds)
-        val unreadMemberItems: List<AnnouncementViewMemberListItemResponse> =
-            unreadMembers.map { unreadMember ->
-                val teamNumber: TeamNumber = memberQueryUseCase.getMemberTeamNumber(unreadMember.id!!)
-                val isAdmin: Boolean = memberAccessService.isAdmin(unreadMember.id!!)
-                AnnouncementViewMemberListItemResponse.of(unreadMember, teamNumber, isAdmin)
-            }
+        val memberItems: List<AnnouncementViewMemberListItemResponse> =
+            retrievedMembers.map { member ->
+                val teamNumber: TeamNumber = retrievedMemberTeamNumberMap[member.id!!] ?: TeamNumber(0)
+                val isAdmin: Boolean = retrievedMemberAdminMap[member.id!!] ?: false
+                AnnouncementViewMemberListItemResponse.of(member, teamNumber, isAdmin)
+            }.sortedWith(compareBy({ it.teamNumber.value }, { it.name }))
+        val readMemberIds: Set<MemberId> =
+            announcementReads.filter { it.isRead() }.map { it.memberId }.toSet()
+
+        val unreadMemberIds: Set<MemberId> =
+            announcementReads.filter { !it.isRead() }.map { it.memberId }.toSet()
 
         return AnnouncementViewMemberListResponse.of(
-            readMembers = readMemberItems,
-            unreadMembers = unreadMemberItems,
+            readMembers = memberItems.filter { it.memberId in readMemberIds },
+            unreadMembers = memberItems.filter { it.memberId in unreadMemberIds },
         )
     }
 
@@ -161,12 +168,28 @@ class AnnouncementQueryService(
             assignmentSubmissionQueryUseCase.getByAssignmentId(
                 assignment.id ?: throw AssignmentNotFoundException(),
             )
+        val assignmentSubmissionMemberIds: List<MemberId> = assignmentSubmissions.map { it.memberId }
+        val assignmentSubmissionMembers: List<Member> =
+            memberQueryUseCase.getMembersByIds(
+                assignmentSubmissionMemberIds,
+            )
+        val assignmentSubmissionMemberTeamNumberMap: Map<MemberId, TeamNumber> =
+            memberQueryUseCase.getMemberTeamNumberByMemberIds(
+                assignmentSubmissionMemberIds,
+            )
+        val assignmentSubmissionMemberAdminMap: Map<MemberId, Boolean> =
+            memberAccessService.getIsAdminByMemberIds(
+                memberIds = assignmentSubmissionMemberIds,
+                cohortValue = cohortQueryUseCase.getLatestCohortValue(),
+            )
 
         val assignmentStatusMemberListItemResponses: List<AssignmentStatusMemberListItemResponse> =
             assignmentSubmissions.map { assignmentSubmission ->
-                val member: Member = memberQueryUseCase.getMemberById(assignmentSubmission.memberId)
-                val teamNumber: TeamNumber = memberQueryUseCase.getMemberTeamNumber(member.id!!)
-                val isAdmin: Boolean = memberAccessService.isAdmin(member.id!!)
+                val member: Member =
+                    assignmentSubmissionMembers.find { it.id == assignmentSubmission.memberId }
+                        ?: throw AnnouncementNotFoundException()
+                val teamNumber: TeamNumber = assignmentSubmissionMemberTeamNumberMap[member.id!!] ?: TeamNumber(0)
+                val isAdmin: Boolean = assignmentSubmissionMemberAdminMap[member.id!!] ?: false
                 AssignmentStatusMemberListItemResponse.of(
                     memberId = member.id!!,
                     name = member.name,

--- a/application/src/main/kotlin/core/application/announcement/application/service/AnnouncementQueryService.kt
+++ b/application/src/main/kotlin/core/application/announcement/application/service/AnnouncementQueryService.kt
@@ -11,6 +11,7 @@ import core.application.announcement.presentation.response.AnnouncementViewMembe
 import core.application.announcement.presentation.response.AssignmentStatusMemberListItemResponse
 import core.application.announcement.presentation.response.AssignmentStatusMemberListResponse
 import core.application.common.converter.TimeMapper.instantToLocalDateTime
+import core.application.member.application.exception.MemberNotFoundException
 import core.application.member.application.service.access.MemberAccessService
 import core.domain.announcement.aggregate.Announcement
 import core.domain.announcement.aggregate.AnnouncementRead
@@ -139,11 +140,17 @@ class AnnouncementQueryService(
             )
 
         val memberItems: List<AnnouncementViewMemberListItemResponse> =
-            retrievedMembers.map { member ->
-                val teamNumber: TeamNumber = retrievedMemberTeamNumberMap[member.id!!] ?: TeamNumber(0)
-                val isAdmin: Boolean = retrievedMemberAdminMap[member.id!!] ?: false
-                AnnouncementViewMemberListItemResponse.of(member, teamNumber, isAdmin)
-            }.sortedWith(compareBy({ it.teamNumber.value }, { it.name }))
+            retrievedMembers
+                .map { member ->
+                    val teamNumber: TeamNumber = retrievedMemberTeamNumberMap[member.id!!] ?: TeamNumber.defaultValue()
+                    val isAdmin: Boolean = retrievedMemberAdminMap[member.id!!] ?: false
+                    AnnouncementViewMemberListItemResponse.of(member, teamNumber, isAdmin)
+                }.sortedWith(
+                    compareBy<AnnouncementViewMemberListItemResponse> { it.teamNumber.value == 0 }
+                        .thenByDescending { it.isAdmin }
+                        .thenBy { it.teamNumber.value }
+                        .thenBy { it.name },
+                )
         val readMemberIds: Set<MemberId> =
             announcementReads.filter { it.isRead() }.map { it.memberId }.toSet()
 
@@ -168,6 +175,8 @@ class AnnouncementQueryService(
             assignmentSubmissionQueryUseCase.getByAssignmentId(
                 assignment.id ?: throw AssignmentNotFoundException(),
             )
+
+        val latestCohortValue = cohortQueryUseCase.getLatestCohortValue()
         val assignmentSubmissionMemberIds: List<MemberId> = assignmentSubmissions.map { it.memberId }
         val assignmentSubmissionMembers: List<Member> =
             memberQueryUseCase.getMembersByIds(
@@ -180,26 +189,34 @@ class AnnouncementQueryService(
         val assignmentSubmissionMemberAdminMap: Map<MemberId, Boolean> =
             memberAccessService.getIsAdminByMemberIds(
                 memberIds = assignmentSubmissionMemberIds,
-                cohortValue = cohortQueryUseCase.getLatestCohortValue(),
+                cohortValue = latestCohortValue,
             )
 
         val assignmentStatusMemberListItemResponses: List<AssignmentStatusMemberListItemResponse> =
-            assignmentSubmissions.map { assignmentSubmission ->
-                val member: Member =
-                    assignmentSubmissionMembers.find { it.id == assignmentSubmission.memberId }
-                        ?: throw AnnouncementNotFoundException()
-                val teamNumber: TeamNumber = assignmentSubmissionMemberTeamNumberMap[member.id!!] ?: TeamNumber(0)
-                val isAdmin: Boolean = assignmentSubmissionMemberAdminMap[member.id!!] ?: false
-                AssignmentStatusMemberListItemResponse.of(
-                    memberId = member.id!!,
-                    name = member.name,
-                    teamNumber = teamNumber,
-                    isAdmin = isAdmin,
-                    part = member.part,
-                    submitStatus = assignmentSubmission.submitStatus,
-                    score = assignmentSubmission.score,
+            assignmentSubmissions
+                .map { assignmentSubmission ->
+                    val member: Member =
+                        assignmentSubmissionMembers.find { it.id == assignmentSubmission.memberId }
+                            ?: throw MemberNotFoundException()
+                    val teamNumber: TeamNumber =
+                        assignmentSubmissionMemberTeamNumberMap[member.id!!] ?: TeamNumber.defaultValue()
+                    val isAdmin: Boolean = assignmentSubmissionMemberAdminMap[member.id!!] ?: false
+                    AssignmentStatusMemberListItemResponse.of(
+                        memberId = member.id!!,
+                        name = member.name,
+                        teamNumber = teamNumber,
+                        isAdmin = isAdmin,
+                        part = member.part,
+                        submitStatus = assignmentSubmission.submitStatus,
+                        score = assignmentSubmission.score,
+                    )
+                }.sortedWith(
+                    compareBy<AssignmentStatusMemberListItemResponse> { it.teamNumber.value == 0 }
+                        .thenBy { it.submitStatus.sortedValue() }
+                        .thenByDescending { it.isAdmin }
+                        .thenBy { it.teamNumber.value }
+                        .thenBy { it.name },
                 )
-            }
 
         return AssignmentStatusMemberListResponse.from(assignmentStatusMemberListItemResponses)
     }

--- a/application/src/main/kotlin/core/application/attendance/application/service/AttendanceQueryService.kt
+++ b/application/src/main/kotlin/core/application/attendance/application/service/AttendanceQueryService.kt
@@ -33,7 +33,7 @@ class AttendanceQueryService(
     fun getAttendancesBySession(query: GetAttendancesBySessionWeekQuery): SessionAttendancesResponse {
         val myTeamNumber: TeamNumber =
             query.onlyMyTeam
-                ?.let { memberQueryService.getMemberTeamNumber(query.memberId) } ?: TeamNumber(0)
+                ?.let { memberQueryService.getMemberTeamNumber(query.memberId) } ?: TeamNumber.defaultValue()
 
         val queryResult =
             attendancePersistencePort
@@ -59,7 +59,7 @@ class AttendanceQueryService(
     fun getMemberAttendances(query: GetMemberAttendancesQuery): MemberAttendancesResponse {
         val myTeamNumber =
             query.onlyMyTeam
-                ?.let { memberQueryService.getMemberTeamNumber(query.memberId) } ?: TeamNumber(0)
+                ?.let { memberQueryService.getMemberTeamNumber(query.memberId) } ?: TeamNumber.defaultValue()
 
         val queryResult =
             attendancePersistencePort

--- a/application/src/main/kotlin/core/application/member/application/service/MemberQueryService.kt
+++ b/application/src/main/kotlin/core/application/member/application/service/MemberQueryService.kt
@@ -89,6 +89,11 @@ class MemberQueryService(
                 ?: defaultTeamId,
         )
 
+    override fun getMemberTeamNumberByMemberIds(memberIds: List<MemberId>): Map<MemberId, TeamNumber> =
+        memberPersistencePort.findMemberTeamNumberByMemberIds(memberIds)
+            .mapKeys { MemberId(it.key) }
+            .mapValues { TeamNumber(it.value) }
+
     override fun getMemberTeamId(memberId: MemberId): TeamId =
         TeamId(
             memberPersistencePort.findMemberTeamIdByMemberId(memberId)

--- a/application/src/main/kotlin/core/application/member/application/service/access/MemberAccessService.kt
+++ b/application/src/main/kotlin/core/application/member/application/service/access/MemberAccessService.kt
@@ -43,6 +43,31 @@ class MemberAccessService(
         } ?: RoleType.Guest
     }
 
+    fun getIsAdminByMemberIds(
+        memberIds: List<MemberId>,
+        cohortValue: String = cohortQueryUseCase.getLatestCohortValue(),
+    ): Map<MemberId, Boolean> {
+        if (memberIds.isEmpty()) return emptyMap()
+
+        val normalizedCohort = normalizeCohortValue(cohortValue)
+        val roleNamesByMemberId: Map<Long, List<String>> =
+            memberRolePersistencePort.findRoleNamesByMemberIds(memberIds.map { it.value })
+
+        return memberIds.associateWith { memberId ->
+            val currentRoles =
+                currentCohortRoleResolver.filterCurrentRoles(
+                    roleNames = roleNamesByMemberId[memberId.value] ?: emptyList(),
+                    latestCohortValue = normalizedCohort,
+                )
+            val roleType =
+                ROLE_PRIORITY.firstOrNull { roleType ->
+                    currentRoles.any { roleName -> RoleType.from(roleName) == roleType }
+                } ?: RoleType.Guest
+
+            roleType == RoleType.Organizer
+        }
+    }
+
     fun getEffectivePermissions(memberId: MemberId): List<String> = roleQueryUseCase.getPermissionsByMemberId(memberId)
 
     private fun normalizeCohortValue(cohortValue: String): String = cohortValue.trim().removeSuffix("기")

--- a/application/src/main/kotlin/core/application/member/application/service/access/MemberAccessService.kt
+++ b/application/src/main/kotlin/core/application/member/application/service/access/MemberAccessService.kt
@@ -45,7 +45,7 @@ class MemberAccessService(
 
     fun getIsAdminByMemberIds(
         memberIds: List<MemberId>,
-        cohortValue: String = cohortQueryUseCase.getLatestCohortValue(),
+        cohortValue: String,
     ): Map<MemberId, Boolean> {
         if (memberIds.isEmpty()) return emptyMap()
 

--- a/domain/src/main/kotlin/core/domain/announcement/enums/SubmitStatus.kt
+++ b/domain/src/main/kotlin/core/domain/announcement/enums/SubmitStatus.kt
@@ -12,4 +12,12 @@ enum class SubmitStatus(
     companion object {
         fun fromValue(value: Int): SubmitStatus = entries.first { it.value == value }
     }
+
+    fun sortedValue(): Int =
+        when (this) {
+            SUBMITTED -> 0
+            PENDING -> 1
+            LATE_SUBMITTED -> 2
+            NOT_SUBMITTED -> 3
+        }
 }

--- a/domain/src/main/kotlin/core/domain/member/port/inbound/MemberQueryUseCase.kt
+++ b/domain/src/main/kotlin/core/domain/member/port/inbound/MemberQueryUseCase.kt
@@ -24,6 +24,8 @@ interface MemberQueryUseCase {
 
     fun getMemberTeamNumber(memberId: MemberId): TeamNumber
 
+    fun getMemberTeamNumberByMemberIds(memberIds: List<MemberId>): Map<MemberId, TeamNumber>
+
     fun getMemberById(memberId: MemberId): Member
 
     fun getMemberTeamId(memberId: MemberId): TeamId

--- a/domain/src/main/kotlin/core/domain/member/port/outbound/MemberPersistencePort.kt
+++ b/domain/src/main/kotlin/core/domain/member/port/outbound/MemberPersistencePort.kt
@@ -48,6 +48,8 @@ interface MemberPersistencePort {
 
     fun findMemberTeamNumberByMemberId(memberId: MemberId): Int?
 
+    fun findMemberTeamNumberByMemberIds(memberIds: List<MemberId>): Map<Long, Int>
+
     fun findMemberTeamIdByMemberId(memberId: MemberId): Long?
 
     fun findAll(): List<Member>

--- a/domain/src/main/kotlin/core/domain/team/vo/TeamNumber.kt
+++ b/domain/src/main/kotlin/core/domain/team/vo/TeamNumber.kt
@@ -4,6 +4,9 @@ package core.domain.team.vo
 value class TeamNumber(
     val value: Int,
 ) {
+    companion object {
+        fun defaultValue(): TeamNumber = TeamNumber(0)
+    }
     constructor(v: Int?) : this(v ?: 0)
 
     override fun toString(): String = value.toString()

--- a/persistence/src/main/kotlin/core/persistence/member/repository/MemberRepository.kt
+++ b/persistence/src/main/kotlin/core/persistence/member/repository/MemberRepository.kt
@@ -41,6 +41,7 @@ import org.jooq.dsl.tables.references.REFRESH_TOKENS
 import org.jooq.dsl.tables.references.ROLES
 import org.jooq.dsl.tables.references.SENT_ANNOUNCEMENT_NOTIFICATIONS
 import org.jooq.dsl.tables.references.TEAMS
+import org.jooq.impl.DSL
 import org.jooq.impl.DSL.exists
 import org.jooq.impl.DSL.field
 import org.jooq.impl.DSL.inline
@@ -299,6 +300,39 @@ class MemberRepository(
                     part = record[MEMBERS.PART],
                 )
             }
+    }
+
+    override fun findMemberTeamNumberByMemberIds(memberIds: List<MemberId>): Map<Long, Int> {
+        if (memberIds.isEmpty()) return emptyMap()
+
+        // 멤버별 가장 최신(max) member_team_id를 서브쿼리로 구함
+        val maxMemberTeamId =
+            DSL.select(
+                MEMBER_TEAMS.MEMBER_ID,
+                DSL.max(MEMBER_TEAMS.MEMBER_TEAM_ID).`as`("max_id"),
+            )
+                .from(MEMBER_TEAMS)
+                .where(MEMBER_TEAMS.MEMBER_ID.`in`(memberIds.map { it.value }))
+                .groupBy(MEMBER_TEAMS.MEMBER_ID)
+                .asTable("latest_mt")
+
+        return dsl
+            .select(MEMBER_TEAMS.MEMBER_ID, TEAMS.NUMBER)
+            .from(MEMBER_TEAMS)
+            .join(TEAMS).on(MEMBER_TEAMS.TEAM_ID.eq(TEAMS.TEAM_ID))
+            .join(maxMemberTeamId)
+            .on(
+                MEMBER_TEAMS.MEMBER_TEAM_ID.eq(
+                    maxMemberTeamId.field("max_id", Long::class.java),
+                ),
+            )
+            .fetch()
+            .mapNotNull { record ->
+                val memberId = record[MEMBER_TEAMS.MEMBER_ID] ?: return@mapNotNull null
+                val teamNumber = record[TEAMS.NUMBER] ?: return@mapNotNull null
+                memberId to teamNumber
+            }
+            .toMap()
     }
 
     override fun findMemberTeamNumberByMemberId(memberId: MemberId): Int? =


### PR DESCRIPTION
## Summary

>- #482 close

<!-- 해당 PR에 대한 요약을 작성해주세요. -->

## Tasks

- N+1, DB 단건 조회 개선
  - 회식 멤버 조회
  - 공지 읽은 멤버 조회

## ETC

<!-- 추가적인 정보나 참고 사항을 작성해주세요. -->

## Screenshot

<!-- (없을 경우 삭제) 작업한 내용에 대한 스크린샷을 첨부해주세요._ -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 개선 사항

* **성능 최적화**
  * 멤버/팀/관리자 정보 조회를 일괄 처리로 전환해 DB 호출 횟수 감소 및 초대·공지·과제 관련 목록 조회 속도 향상
* **동작 변경**
  * RSVP/멤버 목록 정렬 기준 개선(읽음상태·팀번호·관리자·이름 순)
  * 팀 번호와 관리자 정보의 기본값 처리 방식 통일 및 최신 코호트 기준 관리자 판정 반영
* **품질 개선**
  * 제출 상태 정렬 우선순위 지정 로직 추가

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/depromeet/dpm-core-server/pull/483)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->