### PR TITLE
feat : kakao native login function support

### DIFF
--- a/application/src/main/kotlin/core/application/member/application/service/auth/KakaoAuthService.kt
+++ b/application/src/main/kotlin/core/application/member/application/service/auth/KakaoAuthService.kt
@@ -3,7 +3,7 @@ package core.application.member.application.service.auth
 import core.application.member.application.exception.MemberDeletedException
 import core.application.member.application.service.role.MemberRoleService
 import core.application.member.application.service.team.MemberTeamService
-import core.application.security.oauth.kakao.KakaoTokenExchangeService
+import core.application.security.oauth.kakao.KakaoUserInfoClient
 import core.application.security.oauth.redirect.OAuthRedirectUriValidator
 import core.application.security.oauth.token.JwtTokenProvider
 import core.domain.member.aggregate.Member
@@ -18,7 +18,7 @@ import org.springframework.transaction.annotation.Transactional
 
 @Service
 class KakaoAuthService(
-    private val kakaoTokenExchangeService: KakaoTokenExchangeService,
+    private val kakaoUserInfoClient: KakaoUserInfoClient,
     private val redirectUriValidator: OAuthRedirectUriValidator,
     private val memberOAuthPersistencePort: MemberOAuthPersistencePort,
     private val memberPersistencePort: MemberPersistencePort,
@@ -36,7 +36,7 @@ class KakaoAuthService(
         val attributes =
             OAuthAttributes.of(
                 KAKAO_PROVIDER_ID,
-                kakaoTokenExchangeService.getUserAttributes(
+                kakaoUserInfoClient.getUserAttributes(
                     authorizationCode = authorizationCode,
                     redirectUri = validatedRedirectUri,
                 ),

--- a/application/src/main/kotlin/core/application/member/application/service/auth/KakaoLoginTokenSaveService.kt
+++ b/application/src/main/kotlin/core/application/member/application/service/auth/KakaoLoginTokenSaveService.kt
@@ -6,6 +6,7 @@ import core.application.security.oauth.token.JwtTokenProvider
 import core.domain.member.vo.MemberId
 import core.domain.refreshToken.aggregate.RefreshToken
 import core.domain.refreshToken.port.outbound.RefreshTokenPersistencePort
+import io.github.oshai.kotlinlogging.KotlinLogging
 import jakarta.servlet.http.HttpServletResponse
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -16,13 +17,22 @@ class KakaoLoginTokenSaveService(
     private val jwtTokenInjector: JwtTokenInjector,
     private val refreshTokenPersistencePort: RefreshTokenPersistencePort,
 ) {
+    private val logger = KotlinLogging.logger { }
+
     @Transactional
     fun save(
         accessToken: String,
         refreshToken: String,
         response: HttpServletResponse,
     ) {
-        if (!jwtTokenProvider.validateToken(accessToken) || !jwtTokenProvider.validateToken(refreshToken)) {
+        val accessTokenValid = jwtTokenProvider.validateToken(accessToken)
+        val refreshTokenValid = jwtTokenProvider.validateToken(refreshToken)
+
+        if (!accessTokenValid || !refreshTokenValid) {
+            logger.warn {
+                "Rejected Kakao token save request: invalid token pair " +
+                    "(accessTokenValid=$accessTokenValid, refreshTokenValid=$refreshTokenValid)"
+            }
             throw TokenInvalidException()
         }
 
@@ -30,6 +40,10 @@ class KakaoLoginTokenSaveService(
         val refreshTokenMemberId = jwtTokenProvider.getMemberId(refreshToken)
 
         if (accessTokenMemberId != refreshTokenMemberId) {
+            logger.warn {
+                "Rejected Kakao token save request: token subjects differ " +
+                    "(accessTokenMemberId=$accessTokenMemberId, refreshTokenMemberId=$refreshTokenMemberId)"
+            }
             throw TokenInvalidException()
         }
 

--- a/application/src/main/kotlin/core/application/member/application/service/auth/KakaoNativeLoginService.kt
+++ b/application/src/main/kotlin/core/application/member/application/service/auth/KakaoNativeLoginService.kt
@@ -1,0 +1,84 @@
+package core.application.member.application.service.auth
+
+import core.application.member.application.exception.MemberDeletedException
+import core.application.member.presentation.response.KakaoNativeLoginResponse
+import core.application.security.oauth.exception.OAuthAuthenticationFailedException
+import core.application.security.oauth.exception.OAuthExceptionCode
+import core.application.security.oauth.kakao.KakaoUserInfoClient
+import core.application.security.oauth.token.JwtTokenProvider
+import core.domain.member.enums.MemberStatus
+import core.domain.member.port.inbound.HandleMemberLoginUseCase
+import core.domain.member.port.outbound.MemberOAuthPersistencePort
+import core.domain.member.port.outbound.MemberPersistencePort
+import core.domain.security.oauth.dto.OAuthAttributes
+import io.github.oshai.kotlinlogging.KotlinLogging
+import org.springframework.stereotype.Service
+
+@Service
+class KakaoNativeLoginService(
+    private val kakaoUserInfoClient: KakaoUserInfoClient,
+    private val memberOAuthPersistencePort: MemberOAuthPersistencePort,
+    private val memberPersistencePort: MemberPersistencePort,
+    private val handleMemberLoginUseCase: HandleMemberLoginUseCase,
+    private val jwtTokenProvider: JwtTokenProvider,
+) {
+    private val logger = KotlinLogging.logger { }
+
+    fun login(kakaoAccessToken: String): KakaoNativeLoginResponse {
+        val attributes = resolveAttributes(kakaoAccessToken)
+        val memberOAuth =
+            memberOAuthPersistencePort.findByProviderAndExternalId(
+                provider = attributes.getProvider(),
+                externalId = attributes.getExternalId(),
+            )
+
+        if (memberOAuth == null) {
+            return KakaoNativeLoginResponse.signupRequired(
+                provider = attributes.getProvider().name,
+                externalId = attributes.getExternalId(),
+                email = attributes.getEmail(),
+                name = attributes.getName(),
+            )
+        }
+
+        memberPersistencePort.findById(memberOAuth.memberId)?.let { member ->
+            if (member.deletedAt != null || member.status == MemberStatus.WITHDRAWN) {
+                throw MemberDeletedException()
+            }
+        }
+
+        val loginResult = handleMemberLoginUseCase.handleLoginSuccess(attributes)
+        val refreshToken =
+            loginResult.refreshToken
+                ?: throw IllegalStateException("Refresh token was not issued for Kakao native login")
+        val memberId = refreshToken.memberId.value
+        val accessToken = jwtTokenProvider.generateAccessToken(memberId.toString())
+        val memberStatus = memberPersistencePort.findById(refreshToken.memberId)?.status
+
+        logger.info { "Kakao native login succeeded for memberId=$memberId" }
+
+        return KakaoNativeLoginResponse.loginSuccess(
+            accessToken = accessToken,
+            refreshToken = refreshToken.token,
+            memberId = memberId,
+            memberStatus = memberStatus,
+        )
+    }
+
+    private fun resolveAttributes(kakaoAccessToken: String): OAuthAttributes =
+        try {
+            OAuthAttributes.of(
+                KAKAO_PROVIDER_ID,
+                kakaoUserInfoClient.getUserAttributesByAccessToken(kakaoAccessToken),
+            ) ?: throw OAuthAuthenticationFailedException()
+        } catch (_: OAuthAuthenticationFailedException) {
+            throw OAuthAuthenticationFailedException(OAuthExceptionCode.KAKAO_ACCESS_TOKEN_INVALID)
+        } catch (e: Exception) {
+            logger.warn(e) { "Failed to load Kakao user info with native access token" }
+            throw OAuthAuthenticationFailedException(OAuthExceptionCode.KAKAO_ACCESS_TOKEN_INVALID)
+        }
+
+    companion object {
+        private const val KAKAO_PROVIDER_ID = "KAKAO"
+    }
+}

--- a/application/src/main/kotlin/core/application/member/presentation/controller/MemberKakaoNativeLoginController.kt
+++ b/application/src/main/kotlin/core/application/member/presentation/controller/MemberKakaoNativeLoginController.kt
@@ -1,0 +1,63 @@
+package core.application.member.presentation.controller
+
+import core.application.common.exception.CustomResponse
+import core.application.member.application.service.auth.KakaoNativeLoginService
+import core.application.member.presentation.response.KakaoNativeLoginResponse
+import core.application.security.oauth.exception.OAuthAuthenticationFailedException
+import core.application.security.oauth.exception.OAuthExceptionCode
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.responses.ApiResponses
+import io.swagger.v3.oas.annotations.tags.Tag
+import org.springframework.http.HttpHeaders
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestHeader
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@Tag(name = "Member-Login", description = "Member Login API")
+@RestController
+@RequestMapping(value = ["/v1/auth/kakao", "/api/v1/auth/kakao"])
+class MemberKakaoNativeLoginController(
+    private val kakaoNativeLoginService: KakaoNativeLoginService,
+) {
+    @PostMapping("/native")
+    @Operation(
+        summary = "Kakao Native Login",
+        description = "Authenticates a user with a Kakao native access token and returns backend-issued JWT tokens or a signup-required status.",
+    )
+    @ApiResponses(
+        value = [
+            ApiResponse(responseCode = "200", description = "Native login processed successfully"),
+            ApiResponse(responseCode = "400", description = "Authorization header is missing or malformed"),
+            ApiResponse(responseCode = "401", description = "Invalid Kakao access token"),
+            ApiResponse(responseCode = "500", description = "Internal server error"),
+        ],
+    )
+    fun login(
+        @RequestHeader(HttpHeaders.AUTHORIZATION, required = false)
+        authorizationHeader: String?,
+    ): CustomResponse<KakaoNativeLoginResponse> {
+        val kakaoAccessToken = extractBearerToken(authorizationHeader)
+        return CustomResponse.ok(kakaoNativeLoginService.login(kakaoAccessToken))
+    }
+
+    private fun extractBearerToken(authorizationHeader: String?): String {
+        if (authorizationHeader.isNullOrBlank()) {
+            throw OAuthAuthenticationFailedException(OAuthExceptionCode.KAKAO_ACCESS_TOKEN_REQUIRED)
+        }
+        if (!authorizationHeader.startsWith(BEARER_PREFIX)) {
+            throw OAuthAuthenticationFailedException(OAuthExceptionCode.KAKAO_ACCESS_TOKEN_REQUIRED)
+        }
+
+        return authorizationHeader
+            .removePrefix(BEARER_PREFIX)
+            .trim()
+            .takeIf { it.isNotBlank() }
+            ?: throw OAuthAuthenticationFailedException(OAuthExceptionCode.KAKAO_ACCESS_TOKEN_REQUIRED)
+    }
+
+    companion object {
+        private const val BEARER_PREFIX = "Bearer "
+    }
+}

--- a/application/src/main/kotlin/core/application/member/presentation/controller/MemberKakaoTokenController.kt
+++ b/application/src/main/kotlin/core/application/member/presentation/controller/MemberKakaoTokenController.kt
@@ -21,7 +21,7 @@ class MemberKakaoTokenController(
     @PostMapping("/login/auth/kakao/tokens")
     @Operation(
         summary = "Kakao Login Token Save",
-        description = "Receives Kakao login tokens in the request body and stores them as backend cookies.",
+        description = "Receives backend-issued JWT accessToken/refreshToken in the request body and stores them as backend cookies. This endpoint does not accept Kakao OAuth provider tokens.",
     )
     @ApiResponses(
         value = [

--- a/application/src/main/kotlin/core/application/member/presentation/response/KakaoNativeLoginResponse.kt
+++ b/application/src/main/kotlin/core/application/member/presentation/response/KakaoNativeLoginResponse.kt
@@ -1,0 +1,57 @@
+package core.application.member.presentation.response
+
+import core.domain.member.enums.MemberStatus
+
+data class KakaoNativeLoginResponse(
+    val loginStatus: KakaoNativeLoginStatus,
+    val accessToken: String? = null,
+    val refreshToken: String? = null,
+    val memberId: Long? = null,
+    val memberStatus: MemberStatus? = null,
+    val signupContext: SignupContext? = null,
+) {
+    data class SignupContext(
+        val provider: String,
+        val externalId: String,
+        val email: String,
+        val name: String,
+    )
+
+    companion object {
+        fun loginSuccess(
+            accessToken: String,
+            refreshToken: String,
+            memberId: Long,
+            memberStatus: MemberStatus?,
+        ): KakaoNativeLoginResponse =
+            KakaoNativeLoginResponse(
+                loginStatus = KakaoNativeLoginStatus.LOGIN_SUCCESS,
+                accessToken = accessToken,
+                refreshToken = refreshToken,
+                memberId = memberId,
+                memberStatus = memberStatus,
+            )
+
+        fun signupRequired(
+            provider: String,
+            externalId: String,
+            email: String,
+            name: String,
+        ): KakaoNativeLoginResponse =
+            KakaoNativeLoginResponse(
+                loginStatus = KakaoNativeLoginStatus.SIGNUP_REQUIRED,
+                signupContext =
+                    SignupContext(
+                        provider = provider,
+                        externalId = externalId,
+                        email = email,
+                        name = name,
+                    ),
+            )
+    }
+}
+
+enum class KakaoNativeLoginStatus {
+    LOGIN_SUCCESS,
+    SIGNUP_REQUIRED,
+}

--- a/application/src/main/kotlin/core/application/security/configuration/SecurityConfig.kt
+++ b/application/src/main/kotlin/core/application/security/configuration/SecurityConfig.kt
@@ -148,6 +148,7 @@ class SecurityConfig(
                 "/login/kakao",
                 "/login/apple",
                 "/login/auth/apple",
+                "/api/v1/auth/kakao/native",
                 // General login paths (must come after specific paths)
                 "/login/**",
                 "/login",

--- a/application/src/main/kotlin/core/application/security/oauth/exception/OAuthAuthenticationFailedException.kt
+++ b/application/src/main/kotlin/core/application/security/oauth/exception/OAuthAuthenticationFailedException.kt
@@ -1,0 +1,7 @@
+package core.application.security.oauth.exception
+
+import core.application.common.exception.BusinessException
+
+class OAuthAuthenticationFailedException(
+    code: OAuthExceptionCode = OAuthExceptionCode.AUTHENTICATION_FAILED,
+) : BusinessException(code)

--- a/application/src/main/kotlin/core/application/security/oauth/exception/OAuthExceptionCode.kt
+++ b/application/src/main/kotlin/core/application/security/oauth/exception/OAuthExceptionCode.kt
@@ -10,6 +10,8 @@ enum class OAuthExceptionCode(
 ) : ExceptionCode {
     AUTHENTICATION_FAILED(HttpStatus.BAD_REQUEST, "OAUTH-400-1", "소셜 로그인에 실패했습니다"),
     UNSUPPORTED_OAUTH_PROVIDER(HttpStatus.BAD_REQUEST, "OAUTH-400-2", "지원하지 않는 OAuth 제공자입니다"),
+    KAKAO_ACCESS_TOKEN_INVALID(HttpStatus.UNAUTHORIZED, "OAUTH-401-1", "유효하지 않은 Kakao 액세스 토큰입니다"),
+    KAKAO_ACCESS_TOKEN_REQUIRED(HttpStatus.BAD_REQUEST, "OAUTH-400-3", "Authorization 헤더에 Kakao 액세스 토큰이 필요합니다"),
     ;
 
     override fun getStatus(): HttpStatus = status

--- a/application/src/main/kotlin/core/application/security/oauth/kakao/KakaoTokenExchangeService.kt
+++ b/application/src/main/kotlin/core/application/security/oauth/kakao/KakaoTokenExchangeService.kt
@@ -10,10 +10,10 @@ import org.springframework.web.client.RestClient
 @Service
 class KakaoTokenExchangeService(
     private val clientRegistrationRepository: ClientRegistrationRepository,
-) {
+) : KakaoUserInfoClient {
     private val restClient = RestClient.create()
 
-    fun getUserAttributes(
+    override fun getUserAttributes(
         authorizationCode: String,
         redirectUri: String?,
     ): Map<String, Any> {
@@ -29,8 +29,16 @@ class KakaoTokenExchangeService(
                 tokenUri = registration.providerDetails.tokenUri,
             )
 
+        return getUserAttributesByAccessToken(tokenResponse.accessToken)
+    }
+
+    override fun getUserAttributesByAccessToken(accessToken: String): Map<String, Any> {
+        val registration =
+            clientRegistrationRepository.findByRegistrationId(KAKAO_REGISTRATION_ID)
+                ?: throw IllegalStateException("Kakao OAuth registration is missing")
+
         return getUserInfo(
-            accessToken = tokenResponse.accessToken,
+            accessToken = accessToken,
             userInfoUri = registration.providerDetails.userInfoEndpoint.uri,
         )
     }

--- a/application/src/main/kotlin/core/application/security/oauth/kakao/KakaoUserInfoClient.kt
+++ b/application/src/main/kotlin/core/application/security/oauth/kakao/KakaoUserInfoClient.kt
@@ -1,0 +1,10 @@
+package core.application.security.oauth.kakao
+
+interface KakaoUserInfoClient {
+    fun getUserAttributes(
+        authorizationCode: String,
+        redirectUri: String?,
+    ): Map<String, Any>
+
+    fun getUserAttributesByAccessToken(accessToken: String): Map<String, Any>
+}

--- a/application/src/main/kotlin/core/application/security/oauth/token/JwtAuthenticationFilter.kt
+++ b/application/src/main/kotlin/core/application/security/oauth/token/JwtAuthenticationFilter.kt
@@ -16,6 +16,11 @@ class JwtAuthenticationFilter(
     companion object {
         private const val HEADER_AUTHORIZATION = "Authorization"
         private const val TOKEN_PREFIX = "Bearer "
+        private val EXCLUDED_PATHS =
+            setOf(
+                "/v1/auth/kakao/native",
+                "/api/v1/auth/kakao/native",
+            )
     }
 
     override fun doFilterInternal(
@@ -44,6 +49,8 @@ class JwtAuthenticationFilter(
 
         filterChain.doFilter(request, response)
     }
+
+    override fun shouldNotFilter(request: HttpServletRequest): Boolean = request.requestURI in EXCLUDED_PATHS
 
     private fun getAccessToken(authorizationHeader: String?): String? {
         if (authorizationHeader.isNullOrEmpty() || !authorizationHeader.startsWith(TOKEN_PREFIX)) {


### PR DESCRIPTION
# Research: Kakao Web Login and App Login Flow

**Date**: 2026-05-21 23:35:00 KST
**Researcher**: codex
**Issue**: Web 브라우저 로그인과 앱 네이티브 로그인을 동시에 지원할 때의 서버 플로우 정리 및 현재 구현 검증

---

## 결론

현재 구현 방향은 전반적으로 적합하다.

- 웹 로그인과 앱 로그인은 **서로 다른 인증 재료**를 사용해야 한다.
- 웹은 **Kakao authorization code** 기반으로 처리하는 것이 맞다.
- 앱은 **Kakao access token** 기반으로 처리하는 것이 맞다.
- 앱 로그인에서 `provider + externalId` 기준으로 기존 회원을 판단하고, 미연동 계정이면 `SIGNUP_REQUIRED`를 반환하는 현재 로직은 요구사항과 일치한다.

다만 아래 3가지는 반드시 문서화하거나 후속 정리가 필요하다.

1. `/login/auth/kakao/tokens`는 **Kakao 토큰 저장 API가 아니다**.  
   이 API는 **백엔드가 이미 발급한 JWT accessToken/refreshToken을 쿠키로 저장하는 API**다.
2. 웹 로그인은 현재 **두 가지 스타일**이 공존한다.  
   브라우저 redirect 스타일과 frontend-managed authorization code exchange 스타일을 클라이언트별로 명확히 구분해야 한다.
3. 앱 로그인에서 `SIGNUP_REQUIRED` 이후에 사용할 **온보딩/회원 연동 완료 API는 아직 별도로 정리되어 있지 않다**.

---

## 용어 구분

### 1. Kakao provider token

카카오가 발급하는 토큰이다.

- 예: Kakao SDK native login 결과의 `accessToken`
- 용도: 카카오 사용자 정보 조회
- 서버는 이 토큰으로 `https://kapi.kakao.com/v2/user/me`를 호출할 수 있다

### 2. Backend JWT token

우리 서버가 발급하는 토큰이다.

- `accessToken`
- `refreshToken`
- 용도: 우리 서비스 인증/인가

이 둘을 섞으면 안 된다.

---

## 권장 아키텍처

### 웹 로그인

웹은 **authorization code 기반**으로 로그인한다.

이유:

- 브라우저 환경에서는 OAuth redirect/code flow가 표준적이다
- Kakao access token을 프런트가 직접 오래 들고 있을 필요가 없다
- 서버가 code를 exchange하고 바로 우리 JWT를 발급할 수 있다

### 앱 로그인

앱은 **Kakao SDK native login + Kakao access token 전달** 방식으로 로그인한다.

이유:

- 네이티브 앱은 Kakao SDK를 통해 provider login을 처리하는 것이 자연스럽다
- 앱은 쿠키보다 토큰 바디 응답을 다루기 쉽다
- 브라우저 redirect에 의존하지 않아도 된다

---

## 현재 지원 플로우

## 1. 웹 로그인: browser redirect 스타일

### 엔드포인트

- `GET /login/kakao`
- Spring callback: `/login/oauth2/code/kakao`
- token reissue: `GET /v1/reissue`

### 플로우

1. 브라우저가 `GET /login/kakao` 호출
2. 서버가 `OAUTH2_REDIRECT_URI` 쿠키에 브라우저 복귀 위치를 저장
3. 서버가 `/oauth2/authorization/kakao`로 redirect
4. Kakao 로그인 완료 후 callback이 `/login/oauth2/code/kakao`로 돌아옴
5. `CustomAuthenticationSuccessHandler`가 `HandleMemberLoginUseCase.handleLoginSuccess()` 실행
6. 서버는 **refreshToken 쿠키만** 저장
7. 서버는 원래 프런트 URL로 `?authenticated=true`를 붙여 redirect
8. 프런트는 이후 `GET /v1/reissue`를 호출해서 accessToken을 재발급받아야 한다

### 현재 구현 검증

적합하다. 다만 중요한 전제가 있다.

- 이 플로우는 callback 시점에 `accessToken` 쿠키를 심지 않는다
- 따라서 프런트는 `authenticated=true`만 보고 끝내면 안 되고, 반드시 `reissue`를 이어서 호출해야 한다

즉, 이 플로우는 **refreshToken cookie 기반 세션 복구형 웹 로그인**으로 이해해야 한다.

---

## 2. 웹 로그인: frontend-managed authorization code exchange 스타일

### 엔드포인트

- `GET /login/oauth/authorization/kakao`
- `POST /login/auth/kakao`

### 플로우

1. 프런트가 `GET /login/oauth/authorization/kakao?redirectUri={frontend callback}` 호출
2. 서버가 Kakao authorization URL을 생성해서 반환
3. 프런트가 그 URL로 브라우저/팝업 이동
4. Kakao가 프런트가 가진 callback URL로 authorization code 전달
5. 프런트가 `POST /login/auth/kakao`에 `authorizationCode`와 `redirectUri`를 전달
6. 서버가 Kakao token exchange 수행
7. 서버가 Kakao user info 조회
8. 서버가 회원 조회/생성/연동 처리
9. 서버가 backend `accessToken`/`refreshToken` 발급
10. 서버가 응답 body로 토큰을 반환하고, 동시에 쿠키도 저장

### 현재 구현 검증

이 플로우도 적합하다.

특히 SPA나 popup 기반 웹 로그인에서는 이쪽이 더 명시적이다.

현재 코드 기준으로는 미연동 Kakao 계정이 들어오면:

- 기존 member를 email 기준으로 찾거나
- 없으면 `PENDING` member를 생성하고
- `memberOAuth`를 연결한 뒤
- backend JWT를 발급한다

즉, **웹 로그인은 신규 OAuth 유저를 서버가 수용하는 정책**이고, 앱 로그인은 **신규 OAuth 유저를 `SIGNUP_REQUIRED`로 돌려보내는 정책**이다.

이 플로우의 장점:

- redirect 후 추가 reissue step이 필요 없다
- 프런트가 code exchange 타이밍을 통제할 수 있다
- 응답 body와 cookie를 동시에 받을 수 있다

---

## 3. 앱 로그인: Kakao Native Login

### 엔드포인트

- `POST /v1/auth/kakao/native`
- `POST /api/v1/auth/kakao/native`

### 요청 형식

```http
POST /v1/auth/kakao/native
Authorization: Bearer {kakao_access_token}
```

### 플로우

1. 앱이 Kakao SDK로 native login 수행
2. 앱이 Kakao `accessToken` 획득
3. 앱이 `Authorization: Bearer {kakao_access_token}`로 서버 호출
4. 서버가 Kakao user info API 호출
5. 서버가 `provider=KAKAO + externalId=kakao user id` 기준으로 `memberOAuth` 조회
6. 분기

#### 6-A. 기존 연동 회원인 경우

7. 서버가 `HandleMemberLoginUseCase`를 통해 로그인 처리
8. 서버가 backend `refreshToken`을 발급/저장
9. 서버가 backend `accessToken`을 새로 발급
10. 서버가 아래 응답을 반환

```json
{
  "status": "OK",
  "message": "요청에 성공했습니다",
  "code": "G000",
  "data": {
    "loginStatus": "LOGIN_SUCCESS",
    "accessToken": "...",
    "refreshToken": "...",
    "memberId": 42,
    "memberStatus": "ACTIVE"
  }
}
```

#### 6-B. 미연동 회원인 경우

7. 서버는 내부 멤버를 자동 생성하지 않음
8. 서버는 아래 응답을 반환

```json
{
  "status": "OK",
  "message": "요청에 성공했습니다",
  "code": "G000",
  "data": {
    "loginStatus": "SIGNUP_REQUIRED",
    "signupContext": {
      "provider": "KAKAO",
      "externalId": "123456",
      "email": "user@example.com",
      "name": "카카오닉네임"
    }
  }
}
```

### 현재 구현 검증

요구사항과 일치한다.

좋은 점:

- 앱이 쿠키에 의존하지 않는다
- 앱 로그인과 웹 로그인의 contract가 명확히 분리된다
- `provider + externalId` 기준으로만 “기존 회원”을 판단하므로 계정 병합 기준이 명확하다
- 미연동 계정을 자동 생성하지 않아서 원치 않는 silent signup을 막는다

주의할 점:

- `SIGNUP_REQUIRED` 이후 진행할 앱 전용 온보딩/연동 완료 API는 별도 설계가 필요하다
- 현재는 “기존 email이 같더라도 OAuth link가 없으면 기존 회원으로 보지 않는다”

이 마지막 동작은 보안상 더 안전하다.  
반대로 이메일 기준 자동 병합을 원하면 별도 검증 절차가 필요하다.

---

## `/login/auth/kakao/tokens`의 위치

### 현재 역할

`POST /login/auth/kakao/tokens`는 **Kakao 토큰 저장 API가 아니다**.

이 엔드포인트는 다음 용도다.

- 프런트가 **이미 backend JWT pair**를 갖고 있을 때
- 그 JWT를 서버 cookie로 동기화하고 싶을 때

즉, 입력값은 아래 둘이어야 한다.

- backend `accessToken`
- backend `refreshToken`

Kakao provider access token을 보내면 실패하는 것이 정상이다.

### 현재 구현 검증

로직 자체는 맞다.  
다만 이름이 혼동을 유발한다.

권장:

- 단기: API 설명에 “backend-issued JWT only”를 명시
- 중기: 이름 변경 또는 deprecated 처리 검토

---

## 현재 로직 적합성 평가

## 적합한 점

### 1. 웹과 앱의 인증 재료를 분리했다

- 웹: authorization code
- 앱: Kakao access token

이 분리는 올바르다.

다만 **신규 회원 처리 정책은 플랫폼별로 다르다**.

- 웹: 서버가 `PENDING` member를 생성/연결할 수 있음
- 앱: 서버가 자동 생성하지 않고 `SIGNUP_REQUIRED` 반환

이 차이는 의도라면 괜찮지만, 제품 정책 문서에도 반드시 명시되어야 한다.

### 2. 앱 로그인은 쿠키 의존성이 없다

모바일 클라이언트에 더 적합하다.

### 3. 앱 로그인에서 미연동 계정을 자동 생성하지 않는다

요구사항과 맞고, 보안적으로도 더 명확하다.

### 4. JWT 필터 예외 처리가 들어갔다

`Authorization: Bearer {kakao_access_token}`를 우리 JWT 필터가 오해하지 않도록 한 점은 필수였다.

---

## 주의가 필요한 점

### 1. 웹 로그인 방식이 두 가지다

현재 웹에서는 아래 둘이 동시에 존재한다.

- redirect 기반 웹 로그인
- frontend-managed code exchange 웹 로그인

둘 다 가능하지만, 같은 클라이언트가 두 방식을 혼용하면 디버깅이 어려워진다.

권장:

- 브라우저 웹앱은 한 가지 방식만 표준으로 채택
- 개인적으로는 SPA라면 `GET /login/oauth/authorization/kakao` + `POST /login/auth/kakao` 조합이 더 명확하다

### 2. redirect 기반 웹 로그인은 refresh cookie만 심는다

현재 `CustomAuthenticationSuccessHandler`는 refreshToken만 저장한다.

이게 의도라면:

- 프런트는 redirect 후 반드시 `/v1/reissue`를 호출해야 한다

이 전제가 프런트 문서에도 있어야 한다.

### 3. 앱 로그인은 아직 “로그인 시작점”만 완성됐다

`SIGNUP_REQUIRED`를 반환하는 것은 맞지만, 그 다음 단계가 필요하다.

예:

- Kakao 계정을 기존 member에 연결하는 API
- 신규 member 생성/온보딩 완료 API
- 운영 승인 대기(`PENDING`) 상태에서 앱이 보여줄 화면 정의

즉, native login endpoint는 적절하지만 **signup completion flow까지 포함해 완결된 상태는 아직 아니다**.

---

## 권장 운영 가이드

### 웹

권장 표준:

1. `GET /login/oauth/authorization/kakao`
2. Kakao authorize
3. frontend callback에서 code 수신
4. `POST /login/auth/kakao`

이렇게 하면 backend JWT를 body와 cookie 모두에서 일관되게 다룰 수 있다.

### 앱

권장 표준:

1. Kakao SDK native login
2. `POST /v1/auth/kakao/native`
3. `LOGIN_SUCCESS`면 앱 secure storage에 backend token 저장
4. `SIGNUP_REQUIRED`면 앱 온보딩/계정연결 플로우 진입

### 레거시/보조

`/login/auth/kakao/tokens`는 아래 경우에만 사용:

- 어떤 이유로든 프런트가 backend JWT pair는 이미 받았지만
- cookie 동기화가 추가로 필요한 경우

앱의 첫 로그인 진입점으로 쓰면 안 된다.

---

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * Kakao 네이티브 로그인 엔드포인트 추가
  * 로그인 성공/회원가입 필요 상태 응답 구조 추가

* **리팩토링**
  * 사용자 속성 조회 로직 재구성
  * JWT 필터 제외 경로 업데이트
  * OAuth 예외 코드 확대

* **버그 수정**
  * 토큰 검증 시 로깅 추가

* **문서화**
  * OAuth 토큰 저장 API 설명 수정

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/depromeet/dpm-core-server/pull/498?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->