### PR TITLE
Refactor : 출석 화면 기수 다중 조회로 인한 fetchOne 오류 수정

### DIFF
--- a/application/src/main/kotlin/core/application/attendance/application/exception/AttendanceExceptionCode.kt
+++ b/application/src/main/kotlin/core/application/attendance/application/exception/AttendanceExceptionCode.kt
@@ -10,6 +10,7 @@ enum class AttendanceExceptionCode(
 ) : ExceptionCode {
     INVALID_ATTENDANCE_ID(HttpStatus.BAD_REQUEST, "ATTENDANCE-400-01", "유효하지 않은 출석 아이디입니다"),
     ATTENDANCE_NOT_FOUND(HttpStatus.NOT_FOUND, "ATTENDANCE-404-01", "출석을 찾을 수 없습니다"),
+    MEMBER_ATTENDANCE_AMBIGUOUS(HttpStatus.CONFLICT, "ATTENDANCE-409-01", "멤버 출석 정보를 특정할 수 없습니다"),
     ;
 
     override fun getStatus(): HttpStatus = this.status

--- a/application/src/main/kotlin/core/application/attendance/application/exception/MemberAttendanceAmbiguousException.kt
+++ b/application/src/main/kotlin/core/application/attendance/application/exception/MemberAttendanceAmbiguousException.kt
@@ -1,0 +1,8 @@
+package core.application.attendance.application.exception
+
+import core.application.common.exception.BusinessException
+import core.application.common.exception.ExceptionCode
+
+class MemberAttendanceAmbiguousException(
+    code: ExceptionCode = AttendanceExceptionCode.MEMBER_ATTENDANCE_AMBIGUOUS,
+) : BusinessException(code)

--- a/application/src/main/kotlin/core/application/attendance/application/service/AttendanceQueryService.kt
+++ b/application/src/main/kotlin/core/application/attendance/application/service/AttendanceQueryService.kt
@@ -1,6 +1,7 @@
 package core.application.attendance.application.service
 
 import core.application.attendance.application.exception.AttendanceNotFoundException
+import core.application.attendance.application.exception.MemberAttendanceAmbiguousException
 import core.application.attendance.presentation.mapper.AttendanceMapper
 import core.application.attendance.presentation.response.DetailAttendancesBySessionResponse
 import core.application.attendance.presentation.response.DetailMemberAttendancesResponse
@@ -118,10 +119,16 @@ class AttendanceQueryService(
     }
 
     fun getDetailMemberAttendances(query: GetDetailMemberAttendancesQuery): DetailMemberAttendancesResponse {
-        val memberAttendanceQueryResult =
+        val memberAttendanceQueryResults =
             attendancePersistencePort
                 .findDetailMemberAttendance(query)
-                ?: throw AttendanceNotFoundException()
+
+        val memberAttendanceQueryResult =
+            when {
+                memberAttendanceQueryResults.isEmpty() -> throw AttendanceNotFoundException()
+                memberAttendanceQueryResults.size > 1 -> throw MemberAttendanceAmbiguousException()
+                else -> memberAttendanceQueryResults.first()
+            }
 
         val sessionAttendanceQueryResult =
             attendancePersistencePort

--- a/domain/src/main/kotlin/core/domain/attendance/port/outbound/AttendancePersistencePort.kt
+++ b/domain/src/main/kotlin/core/domain/attendance/port/outbound/AttendancePersistencePort.kt
@@ -34,7 +34,7 @@ interface AttendancePersistencePort {
 
     fun findDetailAttendanceBySession(query: GetDetailAttendanceBySessionQuery): SessionDetailAttendanceQueryModel?
 
-    fun findDetailMemberAttendance(query: GetDetailMemberAttendancesQuery): MemberDetailAttendanceQueryModel?
+    fun findDetailMemberAttendance(query: GetDetailMemberAttendancesQuery): List<MemberDetailAttendanceQueryModel>
 
     fun findMemberSessionAttendances(query: GetDetailMemberAttendancesQuery): List<MemberSessionAttendanceQueryModel>
 

--- a/persistence/src/main/kotlin/core/persistence/attendance/repository/AttendanceRepository.kt
+++ b/persistence/src/main/kotlin/core/persistence/attendance/repository/AttendanceRepository.kt
@@ -33,6 +33,7 @@ import org.jooq.impl.DSL.select
 import org.jooq.impl.DSL.selectOne
 import org.jooq.impl.DSL.sum
 import org.jooq.impl.DSL.`when`
+import org.jooq.impl.SQLDataType
 import org.springframework.stereotype.Repository
 import java.time.ZoneId
 
@@ -254,7 +255,7 @@ class AttendanceRepository(
 
     override fun findDetailMemberAttendance(
         query: GetDetailMemberAttendancesQuery,
-    ): MemberDetailAttendanceQueryModel? {
+    ): List<MemberDetailAttendanceQueryModel> {
         val isAdminField = isAdminField()
 
         return dsl
@@ -310,7 +311,7 @@ class AttendanceRepository(
                 TEAMS.NUMBER,
                 MEMBERS.PART,
                 COHORTS.VALUE,
-            ).fetchOne {
+            ).fetch {
                 MemberDetailAttendanceQueryModel(
                     memberId = it[MEMBERS.MEMBER_ID]!!,
                     memberName = it[MEMBERS.NAME]!!,
@@ -540,7 +541,28 @@ class AttendanceRepository(
         listOf(
             ATTENDANCES.MEMBER_ID.eq(query.memberId.value),
             ATTENDANCES.DELETED_AT.isNull,
+            SESSIONS.COHORT_ID.eq(latestAttendedCohortId(query.memberId.value)),
         )
+
+    /**
+     * 해당 멤버가 출석 기록을 가진 기수 중 가장 최신(기수 값이 가장 큰) 기수의 cohortId.
+     * 멤버가 여러 기수에 걸쳐 출석한 경우 기수별로 행이 분리되어 통계가 다건이 되는 것을 막기 위해
+     * 최신 기수 하나로 한정한다.
+     */
+    private fun latestAttendedCohortId(memberId: Long) =
+        select(SESSIONS.COHORT_ID)
+            .from(ATTENDANCES)
+            .join(SESSIONS)
+            .on(ATTENDANCES.SESSION_ID.eq(SESSIONS.SESSION_ID))
+            .join(COHORTS)
+            .on(SESSIONS.COHORT_ID.eq(COHORTS.COHORT_ID))
+            .where(
+                ATTENDANCES.MEMBER_ID.eq(memberId),
+                ATTENDANCES.DELETED_AT.isNull,
+            ).orderBy(
+                DSL.cast(COHORTS.VALUE, SQLDataType.INTEGER).desc(),
+                SESSIONS.COHORT_ID.desc(),
+            ).limit(1)
 
     private fun myAttendanceConditions(query: GetMyAttendanceBySessionQuery): List<Condition> =
         listOf(


### PR DESCRIPTION
## Summary

>- #512 close

<!-- 해당 PR에 대한 요약을 작성해주세요. -->

## Tasks

- 출석 화면 접속 시 500에러 발생 수정
- 다중 기수 조회 시 커스텀 예외 추가
- 최신 기수 하나만 가져오도록 수정

## ETC

<!-- 추가적인 정보나 참고 사항을 작성해주세요. -->

## Screenshot

<!-- (없을 경우 삭제) 작업한 내용에 대한 스크린샷을 첨부해주세요._ -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Bug Fixes**
  * 회원 출석 정보 조회 시 여러 기록이 존재하는 경우를 감지하여 명확한 오류 메시지 제공
  * 출석 기록 없음과 모호한 다중 기록을 구분하여 더 정확한 에러 응답 처리

* **New Features**
  * 회원 출석 정보 조회 오류 케이스에 대한 새로운 충돌 상태(409) 예외 처리 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->