### PR TITLE
refactor : integration accesstoken to refreshtoken retry

### DIFF
--- a/application/src/main/kotlin/core/application/member/application/service/auth/KakaoLoginTokenSaveService.kt
+++ b/application/src/main/kotlin/core/application/member/application/service/auth/KakaoLoginTokenSaveService.kt
@@ -21,31 +21,17 @@ class KakaoLoginTokenSaveService(
 
     @Transactional
     fun save(
-        accessToken: String,
         refreshToken: String,
         response: HttpServletResponse,
     ) {
-        val accessTokenValid = jwtTokenProvider.validateToken(accessToken)
-        val refreshTokenValid = jwtTokenProvider.validateToken(refreshToken)
-
-        if (!accessTokenValid || !refreshTokenValid) {
+        if (!jwtTokenProvider.validateToken(refreshToken)) {
             logger.warn {
-                "Rejected Kakao token save request: invalid token pair " +
-                    "(accessTokenValid=$accessTokenValid, refreshTokenValid=$refreshTokenValid)"
+                "Rejected Kakao token save request: invalid refresh token"
             }
             throw TokenInvalidException()
         }
 
-        val accessTokenMemberId = jwtTokenProvider.getMemberId(accessToken)
         val refreshTokenMemberId = jwtTokenProvider.getMemberId(refreshToken)
-
-        if (accessTokenMemberId != refreshTokenMemberId) {
-            logger.warn {
-                "Rejected Kakao token save request: token subjects differ " +
-                    "(accessTokenMemberId=$accessTokenMemberId, refreshTokenMemberId=$refreshTokenMemberId)"
-            }
-            throw TokenInvalidException()
-        }
 
         val refreshTokenEntity =
             refreshTokenPersistencePort.findByMemberId(refreshTokenMemberId)
@@ -53,6 +39,7 @@ class KakaoLoginTokenSaveService(
                 ?: RefreshToken.create(MemberId(refreshTokenMemberId), refreshToken)
 
         refreshTokenPersistencePort.save(refreshTokenEntity)
+        val accessToken = jwtTokenProvider.generateAccessToken(refreshTokenMemberId.toString())
         jwtTokenInjector.injectAccessToken(accessToken, response)
         jwtTokenInjector.injectRefreshToken(refreshToken, response)
     }

--- a/application/src/main/kotlin/core/application/member/presentation/controller/MemberKakaoTokenController.kt
+++ b/application/src/main/kotlin/core/application/member/presentation/controller/MemberKakaoTokenController.kt
@@ -3,12 +3,17 @@ package core.application.member.presentation.controller
 import core.application.common.exception.CustomResponse
 import core.application.member.application.service.auth.KakaoLoginTokenSaveService
 import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.media.Content
+import io.swagger.v3.oas.annotations.media.ExampleObject
+import io.swagger.v3.oas.annotations.media.Schema
 import io.swagger.v3.oas.annotations.responses.ApiResponse
 import io.swagger.v3.oas.annotations.responses.ApiResponses
+import io.swagger.v3.oas.annotations.parameters.RequestBody as SwaggerRequestBody
 import io.swagger.v3.oas.annotations.tags.Tag
 import jakarta.servlet.http.HttpServletResponse
 import jakarta.validation.Valid
 import jakarta.validation.constraints.NotBlank
+import org.springframework.http.MediaType.APPLICATION_JSON_VALUE
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RestController
@@ -22,9 +27,28 @@ class MemberKakaoTokenController(
     @Operation(
         summary = "Kakao Login Token Save",
         description =
-            "Receives backend-issued JWT accessToken/refreshToken in" +
-                " the request body and stores them as backend cookies." +
-                "This endpoint does not accept Kakao OAuth provider tokens.",
+            "Receives the backend-issued refreshToken in the request body and stores the backend cookies." +
+                "The access token cookie is regenerated on the server, so the request no longer needs to send it.",
+        requestBody =
+            SwaggerRequestBody(
+                required = true,
+                content = [
+                    Content(
+                        mediaType = APPLICATION_JSON_VALUE,
+                        schema = Schema(implementation = KakaoLoginTokenSaveRequest::class),
+                        examples = [
+                            ExampleObject(
+                                name = "Kakao login token save request",
+                                value = """
+                                    {
+                                        "refreshToken": "eyJhbGciOiJIUzI1NiJ9..."
+                                    }
+                                """,
+                            ),
+                        ],
+                    ),
+                ],
+            ),
     )
     @ApiResponses(
         value = [
@@ -37,13 +61,11 @@ class MemberKakaoTokenController(
         @RequestBody @Valid request: KakaoLoginTokenSaveRequest,
         response: HttpServletResponse,
     ): CustomResponse<Void> {
-        kakaoLoginTokenSaveService.save(request.accessToken, request.refreshToken, response)
+        kakaoLoginTokenSaveService.save(request.refreshToken, response)
         return CustomResponse.ok()
     }
 
     data class KakaoLoginTokenSaveRequest(
-        @field:NotBlank(message = "accessToken은 필수입니다")
-        val accessToken: String,
         @field:NotBlank(message = "refreshToken은 필수입니다")
         val refreshToken: String,
     )

--- a/application/src/main/kotlin/core/application/refreshToken/application/service/RefreshTokenService.kt
+++ b/application/src/main/kotlin/core/application/refreshToken/application/service/RefreshTokenService.kt
@@ -4,11 +4,8 @@ import core.application.refreshToken.application.exception.TokenInvalidException
 import core.application.refreshToken.application.exception.TokenNotFoundException
 import core.application.security.oauth.token.JwtTokenInjector
 import core.application.security.oauth.token.JwtTokenProvider
-import core.application.security.oauth.token.JwtTokenResolver
 import core.domain.refreshToken.aggregate.RefreshToken
 import core.domain.refreshToken.port.outbound.RefreshTokenPersistencePort
-import io.github.oshai.kotlinlogging.KotlinLogging
-import jakarta.servlet.http.HttpServletRequest
 import jakarta.servlet.http.HttpServletResponse
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -16,49 +13,24 @@ import org.springframework.transaction.annotation.Transactional
 @Service
 class RefreshTokenService(
     private val refreshTokenPersistencePort: RefreshTokenPersistencePort,
-    private val tokenResolver: JwtTokenResolver,
     private val tokenInjector: JwtTokenInjector,
     private val tokenProvider: JwtTokenProvider,
 ) {
-    private val logger = KotlinLogging.logger { }
-
-    /**
-     * HTTP Header에서 Refresh Token을 추출하여, 해당 토큰을 기반으로 Access Token을 재발급하고,
-     * RTR(Refresh Token Rotation) 전략에 따라 Refresh Token도 재발급함.
-     *
-     * @throws TokenInvalidException
-     * @throws TokenNotFoundException
-     *
-     * @author LeeHanEum
-     * @author its-sky
-     * @since 2025.07.17
-     */
     @Transactional
     fun reissueBasedOnRefreshToken(
-        request: HttpServletRequest,
+        refreshToken: String,
         response: HttpServletResponse,
     ): String {
-        val tokenCandidates =
-            tokenResolver.resolveRefreshTokenCandidatesFromRequest(request)
-
-        if (tokenCandidates.isEmpty()) {
+        if (!tokenProvider.validateToken(refreshToken)) {
             throw TokenInvalidException()
         }
 
-        for (token in tokenCandidates.distinct()) {
-            if (!tokenProvider.validateToken(token)) {
-                continue
-            }
+        val savedRefreshToken =
+            refreshTokenPersistencePort.findByToken(refreshToken)
+                ?: throw TokenNotFoundException()
 
-            val refreshToken =
-                refreshTokenPersistencePort.findByToken(token)
-                    ?: continue
-
-            tokenInjector.injectRefreshToken(rotate(refreshToken), response)
-            return tokenProvider.generateAccessToken(refreshToken.memberId.toString())
-        }
-
-        throw TokenNotFoundException()
+        tokenInjector.injectRefreshToken(rotate(savedRefreshToken), response)
+        return tokenProvider.generateAccessToken(savedRefreshToken.memberId.toString())
     }
 
     private fun rotate(refreshToken: RefreshToken): RefreshToken {

--- a/application/src/main/kotlin/core/application/refreshToken/presentation/controller/ReissueApi.kt
+++ b/application/src/main/kotlin/core/application/refreshToken/presentation/controller/ReissueApi.kt
@@ -7,13 +7,37 @@ import io.swagger.v3.oas.annotations.media.Content
 import io.swagger.v3.oas.annotations.media.ExampleObject
 import io.swagger.v3.oas.annotations.media.Schema
 import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.parameters.RequestBody
 import io.swagger.v3.oas.annotations.tags.Tag
-import jakarta.servlet.http.HttpServletRequest
 import jakarta.servlet.http.HttpServletResponse
 import org.springframework.http.MediaType.APPLICATION_JSON_VALUE
 
 @Tag(name = "Reissue", description = "토큰 재발급 API")
 interface ReissueApi {
+    @Operation(
+        summary = "액세스 토큰 발급 API",
+        description = "요청 본문의 refreshToken을 기반으로 액세스 토큰을 재발급합니다.",
+        requestBody =
+            RequestBody(
+                required = true,
+                content = [
+                    Content(
+                        mediaType = APPLICATION_JSON_VALUE,
+                        schema = Schema(implementation = RefreshTokenReissueRequest::class),
+                        examples = [
+                            ExampleObject(
+                                name = "액세스 토큰 발급 요청 예시",
+                                value = """
+                                    {
+                                        "refreshToken": "eyJhbGciOiJIUzI1NiJ9..."
+                                    }
+                                """,
+                            ),
+                        ],
+                    ),
+                ],
+            ),
+    )
     @ApiResponse(
         responseCode = "200",
         description = "토큰 재발급 성공",
@@ -40,9 +64,12 @@ interface ReissueApi {
             ),
         ],
     )
-    @Operation(summary = "액세스 토큰 발급 API", description = "쿠키의 리프레시 토큰을 추출하여 액세스 토큰을 발급합니다.")
     fun reissue(
-        request: HttpServletRequest,
+        request: RefreshTokenReissueRequest,
         response: HttpServletResponse,
     ): CustomResponse<TokenResponse>
 }
+
+data class RefreshTokenReissueRequest(
+    val refreshToken: String,
+)

--- a/application/src/main/kotlin/core/application/refreshToken/presentation/controller/ReissueController.kt
+++ b/application/src/main/kotlin/core/application/refreshToken/presentation/controller/ReissueController.kt
@@ -4,9 +4,9 @@ import core.application.common.exception.CustomResponse
 import core.application.refreshToken.application.service.RefreshTokenService
 import core.application.refreshToken.presentation.response.TokenResponse
 import core.application.security.properties.TokenProperties
-import jakarta.servlet.http.HttpServletRequest
 import jakarta.servlet.http.HttpServletResponse
-import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RestController
 
 @RestController
@@ -14,12 +14,12 @@ class ReissueController(
     private val refreshTokenService: RefreshTokenService,
     private val tokenProperties: TokenProperties,
 ) : ReissueApi {
-    @GetMapping("/v1/reissue")
+    @PostMapping("/v1/reissue")
     override fun reissue(
-        request: HttpServletRequest,
+        @RequestBody request: RefreshTokenReissueRequest,
         response: HttpServletResponse,
     ): CustomResponse<TokenResponse> {
-        val tokenResult = refreshTokenService.reissueBasedOnRefreshToken(request, response)
+        val tokenResult = refreshTokenService.reissueBasedOnRefreshToken(request.refreshToken, response)
         return CustomResponse.ok(TokenResponse.of(tokenResult, tokenProperties))
     }
 }


### PR DESCRIPTION
## Summary

>- 관련 있는 Issue를 태그해주세요.

<!-- 해당 PR에 대한 요약을 작성해주세요. -->

## Tasks

- 해당 PR에 포함된 작업을 작성해주세요.
- 해당 PR에 포함된 작업을 작성해주세요.

## ETC

<!-- 추가적인 정보나 참고 사항을 작성해주세요. -->

## Screenshot

<!-- (없을 경우 삭제) 작업한 내용에 대한 스크린샷을 첨부해주세요._ -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **API Changes**
  * 토큰 재발급 엔드포인트의 HTTP 메서드가 GET에서 POST로 변경되었습니다.
  * 토큰 재발급 요청 방식이 쿠키 기반에서 요청 본문(JSON) 기반으로 변경되었습니다.
  * 카카오 로그인 토큰 저장 요청 시 리프레시 토큰만 필요하도록 간소화되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->