### PR TITLE
fix: restore login and apple profile flows from 9e baseline

### DIFF
--- a/application/src/main/kotlin/core/application/member/application/exception/InvalidMemberPartException.kt
+++ b/application/src/main/kotlin/core/application/member/application/exception/InvalidMemberPartException.kt
@@ -1,0 +1,8 @@
+package core.application.member.application.exception
+
+import core.application.common.exception.BusinessException
+
+class InvalidMemberPartException :
+    BusinessException(
+        MemberExceptionCode.INVALID_MEMBER_PART,
+    )

--- a/application/src/main/kotlin/core/application/member/application/exception/MemberExceptionCode.kt
+++ b/application/src/main/kotlin/core/application/member/application/exception/MemberExceptionCode.kt
@@ -21,6 +21,7 @@ enum class MemberExceptionCode(
     INVALID_EMAIL_PASSWORD(HttpStatus.UNAUTHORIZED, "MEMBER-401-01", "이메일 또는 비밀번호가 올바르지 않습니다"),
     MEMBER_NOT_ALLOWED(HttpStatus.FORBIDDEN, "MEMBER-403-01", "로그인이 제한된 회원입니다"),
     APPLE_LOGIN_MEMBER_REQUIRED(HttpStatus.FORBIDDEN, "MEMBER-403-02", "Apple 로그인 회원만 사용할 수 있습니다"),
+    INVALID_MEMBER_PART(HttpStatus.BAD_REQUEST, "MEMBER-400-05", "유효하지 않은 멤버 파트입니다"),
     MEMBER_DELETED(HttpStatus.UNAUTHORIZED, "MEMBER-401-02", "탈퇴한 회원입니다"),
     ;
 

--- a/application/src/main/kotlin/core/application/member/application/service/MemberCommandService.kt
+++ b/application/src/main/kotlin/core/application/member/application/service/MemberCommandService.kt
@@ -1,6 +1,7 @@
 package core.application.member.application.service
 
 import core.application.member.application.exception.AppleLoginMemberRequiredException
+import core.application.member.application.exception.InvalidMemberPartException
 import core.application.member.application.exception.MemberNotFoundException
 import core.application.member.application.exception.MemberStatusAlreadyUpdatedException
 import core.application.member.application.service.cohort.MemberCohortService
@@ -120,7 +121,13 @@ class MemberCommandService(
         }
 
         member.updateName(request.name.trim())
-        member.updatePart(MemberPart.valueOf(request.part.trim().uppercase()))
+        val normalizedPart = request.part.trim().uppercase()
+        if (normalizedPart != "UNASSIGNED") {
+            val memberPart =
+                runCatching { MemberPart.valueOf(normalizedPart) }
+                    .getOrElse { throw InvalidMemberPartException() }
+            member.updatePart(memberPart)
+        }
 
         val savedMember = memberPersistencePort.save(member)
         return AppleMemberProfileUpdateResponse(

--- a/application/src/main/kotlin/core/application/member/application/service/auth/KakaoLoginTokenSaveService.kt
+++ b/application/src/main/kotlin/core/application/member/application/service/auth/KakaoLoginTokenSaveService.kt
@@ -21,31 +21,17 @@ class KakaoLoginTokenSaveService(
 
     @Transactional
     fun save(
-        accessToken: String,
         refreshToken: String,
         response: HttpServletResponse,
     ) {
-        val accessTokenValid = jwtTokenProvider.validateToken(accessToken)
-        val refreshTokenValid = jwtTokenProvider.validateToken(refreshToken)
-
-        if (!accessTokenValid || !refreshTokenValid) {
+        if (!jwtTokenProvider.validateToken(refreshToken)) {
             logger.warn {
-                "Rejected Kakao token save request: invalid token pair " +
-                    "(accessTokenValid=$accessTokenValid, refreshTokenValid=$refreshTokenValid)"
+                "Rejected Kakao token save request: invalid refresh token"
             }
             throw TokenInvalidException()
         }
 
-        val accessTokenMemberId = jwtTokenProvider.getMemberId(accessToken)
         val refreshTokenMemberId = jwtTokenProvider.getMemberId(refreshToken)
-
-        if (accessTokenMemberId != refreshTokenMemberId) {
-            logger.warn {
-                "Rejected Kakao token save request: token subjects differ " +
-                    "(accessTokenMemberId=$accessTokenMemberId, refreshTokenMemberId=$refreshTokenMemberId)"
-            }
-            throw TokenInvalidException()
-        }
 
         val refreshTokenEntity =
             refreshTokenPersistencePort.findByMemberId(refreshTokenMemberId)
@@ -53,6 +39,7 @@ class KakaoLoginTokenSaveService(
                 ?: RefreshToken.create(MemberId(refreshTokenMemberId), refreshToken)
 
         refreshTokenPersistencePort.save(refreshTokenEntity)
+        val accessToken = jwtTokenProvider.generateAccessToken(refreshTokenMemberId.toString())
         jwtTokenInjector.injectAccessToken(accessToken, response)
         jwtTokenInjector.injectRefreshToken(refreshToken, response)
     }

--- a/application/src/main/kotlin/core/application/member/presentation/controller/MemberKakaoTokenController.kt
+++ b/application/src/main/kotlin/core/application/member/presentation/controller/MemberKakaoTokenController.kt
@@ -22,9 +22,8 @@ class MemberKakaoTokenController(
     @Operation(
         summary = "Kakao Login Token Save",
         description =
-            "Receives backend-issued JWT accessToken/refreshToken in" +
-                " the request body and stores them as backend cookies." +
-                "This endpoint does not accept Kakao OAuth provider tokens.",
+            "Receives the backend-issued refreshToken in the request body and stores backend cookies. " +
+                "The access token cookie is regenerated on the server, so the request no longer needs to send it.",
     )
     @ApiResponses(
         value = [
@@ -37,13 +36,11 @@ class MemberKakaoTokenController(
         @RequestBody @Valid request: KakaoLoginTokenSaveRequest,
         response: HttpServletResponse,
     ): CustomResponse<Void> {
-        kakaoLoginTokenSaveService.save(request.accessToken, request.refreshToken, response)
+        kakaoLoginTokenSaveService.save(request.refreshToken, response)
         return CustomResponse.ok()
     }
 
     data class KakaoLoginTokenSaveRequest(
-        @field:NotBlank(message = "accessToken은 필수입니다")
-        val accessToken: String,
         @field:NotBlank(message = "refreshToken은 필수입니다")
         val refreshToken: String,
     )

--- a/application/src/main/kotlin/core/application/refreshToken/application/service/RefreshTokenService.kt
+++ b/application/src/main/kotlin/core/application/refreshToken/application/service/RefreshTokenService.kt
@@ -4,10 +4,8 @@ import core.application.refreshToken.application.exception.TokenInvalidException
 import core.application.refreshToken.application.exception.TokenNotFoundException
 import core.application.security.oauth.token.JwtTokenInjector
 import core.application.security.oauth.token.JwtTokenProvider
-import core.application.security.oauth.token.JwtTokenResolver
 import core.domain.refreshToken.aggregate.RefreshToken
 import core.domain.refreshToken.port.outbound.RefreshTokenPersistencePort
-import jakarta.servlet.http.HttpServletRequest
 import jakarta.servlet.http.HttpServletResponse
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -15,36 +13,24 @@ import org.springframework.transaction.annotation.Transactional
 @Service
 class RefreshTokenService(
     private val refreshTokenPersistencePort: RefreshTokenPersistencePort,
-    private val tokenResolver: JwtTokenResolver,
     private val tokenInjector: JwtTokenInjector,
     private val tokenProvider: JwtTokenProvider,
 ) {
     @Transactional
     fun reissueBasedOnRefreshToken(
-        request: HttpServletRequest,
+        refreshToken: String,
         response: HttpServletResponse,
     ): String {
-        val tokenCandidates =
-            tokenResolver.resolveRefreshTokenCandidatesFromRequest(request)
-
-        if (tokenCandidates.isEmpty()) {
+        if (!tokenProvider.validateToken(refreshToken)) {
             throw TokenInvalidException()
         }
 
-        for (token in tokenCandidates.distinct()) {
-            if (!tokenProvider.validateToken(token)) {
-                continue
-            }
+        val savedRefreshToken =
+            refreshTokenPersistencePort.findByToken(refreshToken)
+                ?: throw TokenNotFoundException()
 
-            val refreshToken =
-                refreshTokenPersistencePort.findByToken(token)
-                    ?: continue
-
-            tokenInjector.injectRefreshToken(rotate(refreshToken), response)
-            return tokenProvider.generateAccessToken(refreshToken.memberId.toString())
-        }
-
-        throw TokenNotFoundException()
+        tokenInjector.injectRefreshToken(rotate(savedRefreshToken), response)
+        return tokenProvider.generateAccessToken(savedRefreshToken.memberId.toString())
     }
 
     private fun rotate(refreshToken: RefreshToken): RefreshToken {

--- a/application/src/main/kotlin/core/application/refreshToken/presentation/controller/ReissueApi.kt
+++ b/application/src/main/kotlin/core/application/refreshToken/presentation/controller/ReissueApi.kt
@@ -7,13 +7,37 @@ import io.swagger.v3.oas.annotations.media.Content
 import io.swagger.v3.oas.annotations.media.ExampleObject
 import io.swagger.v3.oas.annotations.media.Schema
 import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.parameters.RequestBody
 import io.swagger.v3.oas.annotations.tags.Tag
-import jakarta.servlet.http.HttpServletRequest
 import jakarta.servlet.http.HttpServletResponse
 import org.springframework.http.MediaType.APPLICATION_JSON_VALUE
 
 @Tag(name = "Reissue", description = "토큰 재발급 API")
 interface ReissueApi {
+    @Operation(
+        summary = "액세스 토큰 발급 API",
+        description = "요청 본문의 refreshToken을 기반으로 액세스 토큰을 재발급합니다.",
+        requestBody =
+            RequestBody(
+                required = true,
+                content = [
+                    Content(
+                        mediaType = APPLICATION_JSON_VALUE,
+                        schema = Schema(implementation = RefreshTokenReissueRequest::class),
+                        examples = [
+                            ExampleObject(
+                                name = "액세스 토큰 발급 요청 예시",
+                                value = """
+                                    {
+                                        "refreshToken": "eyJhbGciOiJIUzI1NiJ9..."
+                                    }
+                                """,
+                            ),
+                        ],
+                    ),
+                ],
+            ),
+    )
     @ApiResponse(
         responseCode = "200",
         description = "토큰 재발급 성공",
@@ -40,9 +64,12 @@ interface ReissueApi {
             ),
         ],
     )
-    @Operation(summary = "액세스 토큰 발급 API", description = "쿠키의 리프레시 토큰을 추출하여 액세스 토큰을 발급합니다.")
     fun reissue(
-        request: HttpServletRequest,
+        request: RefreshTokenReissueRequest,
         response: HttpServletResponse,
     ): CustomResponse<TokenResponse>
 }
+
+data class RefreshTokenReissueRequest(
+    val refreshToken: String,
+)

--- a/application/src/main/kotlin/core/application/refreshToken/presentation/controller/ReissueController.kt
+++ b/application/src/main/kotlin/core/application/refreshToken/presentation/controller/ReissueController.kt
@@ -4,9 +4,9 @@ import core.application.common.exception.CustomResponse
 import core.application.refreshToken.application.service.RefreshTokenService
 import core.application.refreshToken.presentation.response.TokenResponse
 import core.application.security.properties.TokenProperties
-import jakarta.servlet.http.HttpServletRequest
 import jakarta.servlet.http.HttpServletResponse
-import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RestController
 
 @RestController
@@ -14,12 +14,12 @@ class ReissueController(
     private val refreshTokenService: RefreshTokenService,
     private val tokenProperties: TokenProperties,
 ) : ReissueApi {
-    @GetMapping("/v1/reissue")
+    @PostMapping("/v1/reissue")
     override fun reissue(
-        request: HttpServletRequest,
+        @RequestBody request: RefreshTokenReissueRequest,
         response: HttpServletResponse,
     ): CustomResponse<TokenResponse> {
-        val tokenResult = refreshTokenService.reissueBasedOnRefreshToken(request, response)
+        val tokenResult = refreshTokenService.reissueBasedOnRefreshToken(request.refreshToken, response)
         return CustomResponse.ok(TokenResponse.of(tokenResult, tokenProperties))
     }
 }

--- a/application/src/main/kotlin/core/application/security/oauth/token/JwtAuthenticationFilter.kt
+++ b/application/src/main/kotlin/core/application/security/oauth/token/JwtAuthenticationFilter.kt
@@ -12,6 +12,7 @@ import org.springframework.web.filter.OncePerRequestFilter
 @Component
 class JwtAuthenticationFilter(
     private val jwtTokenProvider: JwtTokenProvider,
+    private val jwtTokenResolver: JwtTokenResolver,
 ) : OncePerRequestFilter() {
     companion object {
         private const val HEADER_AUTHORIZATION = "Authorization"
@@ -30,22 +31,27 @@ class JwtAuthenticationFilter(
         filterChain: FilterChain,
     ) {
         val authorizationHeader = request.getHeader(HEADER_AUTHORIZATION)
-        val token = getAccessToken(authorizationHeader) ?: getAccessTokenFromCookie(request)
+        val tokenCandidates =
+            buildList {
+                getAccessToken(authorizationHeader)?.let(::add)
+                getAccessTokenFromCookie(request)?.let(::add)
+                jwtTokenResolver.resolveRefreshTokenCandidatesFromRequest(request)
+                    .forEach(::add)
+            }.distinct()
 
-        if (authorizationHeader != null &&
+        val authenticatedToken =
+            tokenCandidates.firstOrNull { jwtTokenProvider.validateToken(it) }
+
+        if (authenticatedToken != null) {
+            val authentication = jwtTokenProvider.getAuthentication(authenticatedToken)
+            SecurityContextHolder.getContext().authentication = authentication
+        } else if (authorizationHeader != null &&
             authorizationHeader.isNotEmpty() &&
-            !authorizationHeader.startsWith(TOKEN_PREFIX) &&
-            token == null
+            !authorizationHeader.startsWith(TOKEN_PREFIX)
         ) {
             throw InvalidAccessTokenException(JwtExceptionCode.AUTHORIZATION_HEADER_INVALID)
-        }
-
-        if (token != null) {
-            if (!jwtTokenProvider.validateToken(token)) {
-                throw InvalidAccessTokenException(JwtExceptionCode.TOKEN_INVALID)
-            }
-            val authentication = jwtTokenProvider.getAuthentication(token)
-            SecurityContextHolder.getContext().authentication = authentication
+        } else if (tokenCandidates.isNotEmpty()) {
+            throw InvalidAccessTokenException(JwtExceptionCode.TOKEN_INVALID)
         }
 
         filterChain.doFilter(request, response)

--- a/application/src/main/resources/application-dev.yml
+++ b/application/src/main/resources/application-dev.yml
@@ -3,9 +3,9 @@ spring:
     activate:
       on-profile: dev
   datasource:
-    url: jdbc:mysql://${DEV_DB_HOST:localhost}:${DEV_DB_PORT:3306}/${DEV_DB_SCHEMA:dpm_core}?serverTimezone=Asia/Seoul&characterEncoding=UTF-8
-    username: ${DEV_DB_USERNAME}
-    password: ${DEV_DB_PASSWORD}
+    url: jdbc:mysql://${DEV_DB_HOST:${DB_HOST:localhost}}:${DEV_DB_PORT:${DB_PORT:3306}}/${DEV_DB_SCHEMA:${DB_SCHEMA:dpm_core}}?serverTimezone=Asia/Seoul&characterEncoding=UTF-8
+    username: ${DEV_DB_USERNAME:${DB_USERNAME:root}}
+    password: ${DEV_DB_PASSWORD:${DB_PASSWORD:}}
     driver-class-name: com.mysql.cj.jdbc.Driver
   security:
     oauth2:
@@ -31,8 +31,8 @@ logging:
   level:
     org.springframework.orm.jpa: INFO
 apple:
-  client-id: ${DEV_APPLE_CLIENT_ID}
-  key-id: ${DEV_APPLE_KEY_ID}
-  team-id: ${DEV_APPLE_TEAM_ID}
-  private-key: ${DEV_APPLE_PRIVATE_KEY}
-  redirect-uri: ${DEV_APPLE_REDIRECT_URI}
+  client-id: ${DEV_APPLE_CLIENT_ID:${APPLE_CLIENT_ID:}}
+  key-id: ${DEV_APPLE_KEY_ID:${APPLE_KEY_ID:}}
+  team-id: ${DEV_APPLE_TEAM_ID:${APPLE_TEAM_ID:}}
+  private-key: ${DEV_APPLE_PRIVATE_KEY:${APPLE_PRIVATE_KEY:}}
+  redirect-uri: ${DEV_APPLE_REDIRECT_URI:${APPLE_REDIRECT_URI:}}


### PR DESCRIPTION
## Summary

>- 관련 있는 Issue를 태그해주세요.

<!-- 해당 PR에 대한 요약을 작성해주세요. -->

## Tasks

- 해당 PR에 포함된 작업을 작성해주세요.
- 해당 PR에 포함된 작업을 작성해주세요.

## ETC

<!-- 추가적인 정보나 참고 사항을 작성해주세요. -->

## Screenshot

<!-- (없을 경우 삭제) 작업한 내용에 대한 스크린샷을 첨부해주세요._ -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 토큰 재발급 API가 요청 본문 기반으로 바뀌어, refresh 토큰만 보내면 액세스 토큰을 다시 받을 수 있습니다.
  * 로그인 토큰 저장 흐름도 refresh 토큰 중심으로 간소화되었습니다.

* **Bug Fixes**
  * 회원 프로필의 파트 값이 유효하지 않을 때 더 명확한 오류가 반환되도록 개선했습니다.
  * 인증 토큰 검증이 여러 입력 경로를 더 안정적으로 처리하도록 개선했습니다.

* **Chores**
  * 개발 환경 설정의 기본값 처리 범위를 확장해, 환경변수 누락 시에도 더 유연하게 동작합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->